### PR TITLE
feat(ci): PR D - Docker Multi-arch Release Pipeline

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,25 +18,25 @@ jobs:
     
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
 
       - name: Login to Docker Hub
         # Only login if it's not a PR in order to avoid pushing from forks
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           images: tunnelsats/ts-umbrel-app
           tags: |
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
         with:
           context: .
           # Only push on master or tag, do test builds on PR
@@ -55,5 +55,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Description
This PR addresses PR D (Phase 4), establishing the CI/CD release automation pipeline.
It auto-builds and publishes `linux/amd64` and `linux/arm64` Docker images to Docker Hub whenever code merges to `master` or a new `v*` tag is pushed.

## Features
- `.github/workflows/docker-release.yml` Github Action added.
- Multi-arch support enforced via QEMU and Buildx actions.
- Automatic latest / semver tagging from GitHub releases/branches via `docker/metadata-action`.

## Verification
- ✅ Locally dry-ran a `linux/amd64,linux/arm64` build using QEMU. The build succeeds perfectly without any architecture-specific dependency crashes.
