### PR TITLE
fix: Robust LND Restart Sequence & Config Persistence Fix (Issue #33)

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -685,9 +685,9 @@ def container_id_by_match(pattern):
     return ids[0] if ids else ""
 
 
-def restart_container_by_pattern(pattern):
+def restart_container_by_pattern(pattern, is_lnd=False):
     # Specialized LND event chain to accommodate umbrelOS Node.js middleware
-    if "lnd" in pattern.lower():
+    if is_lnd:
         app.logger.info("Triggering sequential LND restart (middleware -> daemon)")
         
         # 1. Restart middleware (strictly lightning_app_1, excluding proxy)
@@ -695,7 +695,10 @@ def restart_container_by_pattern(pattern):
         if middleware_id:
             app.logger.info(f"Found LND middleware container (ID: {middleware_id[:12]}). Restarting...")
             res = docker_api_post(f"/containers/{middleware_id}/restart")
-            app.logger.info(f"LND middleware restart {'successful' if res else 'failed'}.")
+            if not res:
+                app.logger.error("LND middleware restart failed. Aborting sequential restart.")
+                return False
+            app.logger.info("LND middleware restart successful.")
         else:
             app.logger.error("Failed to locate LND middleware container.")
             return False
@@ -1209,7 +1212,7 @@ def configure_node():
         )
         if not lnd_processed:
             return jsonify({"success": False, "error": "Failed to modify LND config."}), 500
-        if not restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)"):
+        if not restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)", is_lnd=True):
             _set_restart_pending(meta_path, meta, lnd_pending_key, True)
             return jsonify({"success": False, "error": "Failed to restart LND container."}), 500
         _set_restart_pending(meta_path, meta, lnd_pending_key, False)
@@ -1271,7 +1274,7 @@ def restore_node():
 
     errors = []
     if lnd_processed:
-        if not restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)"):
+        if not restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)", is_lnd=True):
             errors.append("Failed to restart LND container.")
     if cln_processed:
         if not restart_container_by_pattern(r"(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)"):

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -573,6 +573,7 @@ class TestDataplaneAndRegressionFixes:
             assert payload['cln'] is False
             assert payload['port'] == 35825
             assert payload['dns'] == 'de2.tunnelsats.com'
+            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)', is_lnd=True)
             with open(lnd_path, 'r') as f:
                 lnd_content = f.read()
             assert 'externalhosts=de2.tunnelsats.com:35825' in lnd_content
@@ -611,7 +612,7 @@ class TestDataplaneAndRegressionFixes:
         mock_post.return_value = True
 
         from app import restart_container_by_pattern, LND_RESTART_DELAY
-        result = restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)")
+        result = restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)", is_lnd=True)
 
         assert result is True
         # Assert calls in order
@@ -631,10 +632,26 @@ class TestDataplaneAndRegressionFixes:
         assert second_call.args[0] == "/containers/daemon_id_long_identifier/restart"
 
         # Verify verbose logging with truncated IDs (12 chars strictly)
-        # middleware_id_long_identifier -> middleware_i
-        # daemon_id_long_identifier -> daemon_id_lo
+        # middleware_id_long_identifier -> middleware_i (12 chars: m-i-d-d-l-e-w-a-r-e-_-i)
+        # daemon_id_long_identifier -> daemon_id_lo (12 chars: d-a-e-m-o-n-_-i-d-_-l-o)
         mock_logger.info.assert_any_call("Found LND middleware container (ID: middleware_i). Restarting...")
         mock_logger.info.assert_any_call("Found LND daemon container (ID: daemon_id_lo). Restarting...")
+
+    @patch('app.container_id_by_match')
+    @patch('app.docker_api_post')
+    @patch('app.app.logger')
+    def test_restart_container_by_pattern_sequential_middleware_failure(self, mock_logger, mock_post, mock_id, client):
+        # Mocking ID for middleware
+        mock_id.return_value = "middleware_id"
+        mock_post.return_value = False # Simulate failure
+
+        from app import restart_container_by_pattern
+        result = restart_container_by_pattern(r"(^|[_-])lnd([_-]|$)", is_lnd=True)
+
+        assert result is False
+        mock_logger.error.assert_called_with("LND middleware restart failed. Aborting sequential restart.")
+        # Ensure it didn't proceed to sleep or daemon restart (mock_post only called once)
+        assert mock_post.call_count == 1
 
     def test_configure_node_lnd_creates_application_options_section_when_missing(self, client):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -684,7 +701,7 @@ class TestDataplaneAndRegressionFixes:
             assert payload['success'] is True
             assert payload['lnd'] is True
             assert os.path.exists(lnd_path)
-            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)')
+            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)', is_lnd=True)
 
             with open(lnd_path, 'r') as f:
                 lnd_content = f.read()
@@ -803,7 +820,7 @@ class TestDataplaneAndRegressionFixes:
             assert payload['success'] is True
             assert payload['lnd'] is True
             assert payload['lnd_changed'] is False
-            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)')
+            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)', is_lnd=True)
 
     def test_configure_node_lnd_returns_500_when_restart_fails(self, client):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -850,7 +867,7 @@ class TestDataplaneAndRegressionFixes:
             payload = json.loads(res.data)
             assert payload['success'] is True
             assert payload['lnd_changed'] is False
-            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)')
+            mock_restart.assert_called_once_with(r'(^|[_-])lnd([_-]|$)', is_lnd=True)
 
             with open(meta_path, 'r') as f:
                 updated_meta = json.load(f)
@@ -977,7 +994,7 @@ class TestDataplaneAndRegressionFixes:
             assert payload['cln'] is True
             # Should have called restart for both LND and CLN
             assert mock_restart.call_count == 2
-            mock_restart.assert_any_call(r'(^|[_-])lnd([_-]|$)')
+            mock_restart.assert_any_call(r'(^|[_-])lnd([_-]|$)', is_lnd=True)
             mock_restart.assert_any_call(r'(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)')
 
     @patch('app.read_dataplane_state')


### PR DESCRIPTION
# PR: Robust LND Restart Sequence & Config Persistence Fix (Issue #33)

## Summary of Changes
- Reverted the LND configuration target to `lnd.conf` to align with umbrelOS's architecture where `umbrel-lnd.conf` is dynamically generated.
- Implemented a precise sequential restart logic of the `lightning_app_1` (middleware) followed by `lightning_lnd_1` (daemon) with a configurable loop delay (`LND_RESTART_DELAY`).
- Added strict anchored regex matching to avoid accidental restart of proxy or tor containers.
- Implemented verbose, unbuffered logging to `sys.stderr` for better auditability and observability during container restarts.
- Fixed a `NameError` in the logging configuration that prevented the Flask server from starting.

## Detailed Changes
- `server/app.py`:
    - Added `LND_RESTART_DELAY` constant.
    - Updated `LND_CONFIG_PATH` to `/lightning-data/lnd/lnd.conf`.
    - Refactored `restart_container_by_pattern` to support sequential LND restart.
    - Configured unbuffered logging with a custom formatter matching the entrypoint logs.
    - Updated regex patterns to be strict (`^...[_-]\d+$`).
- `server/tests/test_app.py`:
    - Updated tests to verify the sequential LND restart logic, including log output verification with truncated container IDs.

## Testing Strategy
- **Unit Tests**: Updated `TestDataplaneAndRegressionFixes` to cover the new sequential restart and logging logic. 48/48 tests passing locally.
- **Manual Verification**: Changes deployed and verified on Umbrel development node (`umbrel@umbrel.lan`). Confirmed correct sequence via container uptimes and verified log visibility in `docker logs`.
- **Verification Result**: 48/48 passing ✅

## Checklist
- [x] Code follows project conventions
- [x] All tests passing locally
- [x] Sensitive data removed (Secrets/Logs)