### PR TITLE
fix: restore globe visibility by allowing CSP 'unsafe-inline' styles

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -32,7 +32,7 @@ def add_security_headers(response):
     csp = (
         "default-src 'self'; "
         "script-src 'self' 'unsafe-eval'; "
-        "style-src 'self'; "
+        "style-src 'self' 'unsafe-inline'; "
         "font-src 'self'; "
         "img-src 'self' data: https://*.tunnelsats.com; "
         "connect-src 'self' https://*.tunnelsats.com; "


### PR DESCRIPTION
## Problem
The rotating globe is invisible or extremely faint on Umbrel/HTTP deployments.

## Root Cause
The strict `style-src 'self'` CSP directive blocks the **Globe.gl** library from dynamically injecting required layout and visibility styles. While we achieved zero-inline for our own code, this third-party 3D library requires inline style manipulation for the WebGL container.

## Solution
Added `'unsafe-inline'` back to the `style-src` directive in `server/app.py`. This restores full visibility to the rotating globe while maintaining the rest of the hardened security headers.

## Verification
- Captured console logs showing CSP style violations in Globe.gl.
- Verified that allowing `'unsafe-inline'` resolves the errors and restores vibrancy to the globe.

Closes #46.