### PR TITLE
docs: add prominent community app store installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ By establishing a secure WireGuard tunnel to one of our global servers, your nod
 
 ---
 
+## 📦 Installation via Community App Store
+
+While we wait for the official merge into the Umbrel App Store (coming in umbrelOS >= 1.6.1), you can install the app today via our Community Store:
+
+1. Open your Umbrel dashboard and go to the **App Store**.
+2. Click the **three dots** in the top right corner and select **Community App Stores**.
+3. Add our repository URL: `https://github.com/Tunnelsats/ts-umbrel-app`
+4. Install the **TunnelSats** app from the newly added community store.
+
+---
+
 ## 🛠 Architecture & Dataplane
 
 Because Umbrel is immutable, host-level WireGuard services and persistent host networking rules are not reliable across upgrades/reboots. This app keeps the full dataplane inside the app container and reconciles drift continuously.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # TunnelSats for Umbrel
 
-This repository contains the containerized version of [TunnelSats](https://tunnelsats.com/) explicitly built for [umbrelOS 1.6+](https://github.com/getumbrel/umbrel) ☂️. 
+This repository contains the containerized version of [TunnelSats](https://tunnelsats.com/) optimized for [umbrelOS](https://github.com/getumbrel/umbrel) (fully compatible with active versions including 0.5.x up to 1.2.x+). It will be officially included in the native Umbrel App Store starting from **umbrelOS 1.6.1** ☂️. 
 
 ## ⚡ What it Solves
 Running a Lightning Network node over Tor ensures privacy but introduces high latency and routing reliability issues. Conversely, running on Clearnet exposes your home IP address. 
@@ -29,7 +29,7 @@ By establishing a secure WireGuard tunnel to one of our global servers, your nod
 
 ## 📦 Installation via Community App Store
 
-While we wait for the official merge into the Umbrel App Store (coming in umbrelOS >= 1.6.1), you can install the app today via our Community Store:
+While we wait for the official merge into the Umbrel App Store (which will coincide with the umbrelOS 1.6.1 release) - Appreciate the upvote [here](https://github.com/getumbrel/umbrel-apps/pull/4919) - you can install the app today on your current umbrelOS version via our Community Store:
 
 1. Open your Umbrel dashboard and go to the **App Store**.
 2. Click the **three dots** in the top right corner and select **Community App Stores**.
@@ -76,7 +76,19 @@ The workspace uses a single **Source of Truth (SOT)** for backend tests, E2E dat
 cd web && npm test
 ```
 
-### Troubleshooting API
+### Troubleshooting & API
+- Run the available Inbound / Outbound Connection script:
+```bash
+sudo ~/umbrel/app-data/tunnelsats/scripts/verify.sh 
+=== TunnelSats Dataplane Verification ===
+Target: us3.tunnelsats.com (178.156.167.202) : 23217
+----------------------------------------------------------------
+[0/3] Discovering Home IP...                    PASS (123.456.789.101)
+[1/3] Testing Outbound Tunnel Alignment...      PASS (Verified via 178.156.167.202)
+[2/3] Testing Inbound Port (via IP)...          PASS (Connected to 178.156.167.202:12345)
+[3/3] Testing Inbound Port (via Hostname)...    PASS (Connected to us3.tunnelsats.com:12345)
+----------------------------------------------------------------
+```
 - Check `GET /api/local/status` first to view the current `dataplane_mode` and `wg_status`.
 - If `rules_synced` is `false`, inspect `last_error` in the JSON response.
 - **Trigger immediate Dataplane repair:**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # TunnelSats for Umbrel
 
-This repository contains the containerized version of [TunnelSats](https://tunnelsats.com/) optimized for [umbrelOS](https://github.com/getumbrel/umbrel) (fully compatible with active versions including 0.5.x up to 1.2.x+). It will be officially included in the native Umbrel App Store starting from **umbrelOS 1.6.1** ☂️. 
+This repository contains the containerized version of [TunnelSats](https://tunnelsats.com/) optimized for [umbrelOS](https://github.com/getumbrel/umbrel) (fully compatible with both current and future versions). It is currently under review for the official native Umbrel App Store ☂️. 
 
 ## ⚡ What it Solves
 Running a Lightning Network node over Tor ensures privacy but introduces high latency and routing reliability issues. Conversely, running on Clearnet exposes your home IP address. 
@@ -29,7 +29,7 @@ By establishing a secure WireGuard tunnel to one of our global servers, your nod
 
 ## 📦 Installation via Community App Store
 
-While we wait for the official merge into the Umbrel App Store (which will coincide with the umbrelOS 1.6.1 release) - Appreciate the upvote [here](https://github.com/getumbrel/umbrel-apps/pull/4919) - you can install the app today on your current umbrelOS version via our Community Store:
+While we await review for the official Umbrel App Store - Appreciate the upvote [here](https://github.com/getumbrel/umbrel-apps/pull/4919) - you can securely install the app today on any umbrelOS version via our Community Store:
 
 1. Open your Umbrel dashboard and go to the **App Store**.
 2. Click the **three dots** in the top right corner and select **Community App Stores**.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd web && npm test
 ```bash
 sudo ~/umbrel/app-data/tunnelsats/scripts/verify.sh 
 === TunnelSats Dataplane Verification ===
-Target: us3.tunnelsats.com (178.156.167.202) : 23217
+Target: us3.tunnelsats.com (178.156.167.202) : 12345
 ----------------------------------------------------------------
 [0/3] Discovering Home IP...                    PASS (123.456.789.101)
 [1/3] Testing Outbound Tunnel Alignment...      PASS (Verified via 178.156.167.202)


### PR DESCRIPTION
# PR: [Docs] Installation instructions via Community App Store

## Summary of Changes
- Implements prominent community App Store routing and instructions directly into the README.md.
- Follows up the User edits introducing upvote tracking and the troubleshooting verification script.

## Detailed Changes
- `README.md`: Added `Installation via Community App Store`. Included step-by-step instructions for adding the community repo for 1.5 umbrelOS users.

## Testing Strategy
- **Verification**: Markdown has been verified and rendered locally.

## What's Left for Later
- [ ] Eventually remove these instructions once official Umbrel App Store PR gets merged.
