### PR TITLE
Fix: False Positive VPN Connectivity State on Sub-Expiration

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -713,9 +713,16 @@ def _get_wireguard_state(interface_name: str = WG_INTERFACE_NAME) -> Tuple[str, 
     wg_pubkey = ""
 
     try:
-        output = subprocess.check_output(["wg", "show", interface_name], stderr=subprocess.STDOUT).decode("utf-8")
+        output = subprocess.check_output(
+            ["wg", "show", interface_name],
+            stderr=subprocess.STDOUT,
+            timeout=5,
+        ).decode("utf-8")
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        app.logger.debug(f"WireGuard state check info (expected failure): {exc}")
+        return wg_status, wg_pubkey
     except Exception as exc:
-        app.logger.warning(f"Failed to run 'wg show {interface_name}': {exc}")
+        app.logger.warning(f"Unexpected error running 'wg show {interface_name}': {exc}")
         return wg_status, wg_pubkey
 
     if f"interface: {interface_name}" not in output:
@@ -730,9 +737,13 @@ def _get_wireguard_state(interface_name: str = WG_INTERFACE_NAME) -> Tuple[str, 
         handshakes_output = subprocess.check_output(
             ["wg", "show", interface_name, "latest-handshakes"],
             stderr=subprocess.STDOUT,
+            timeout=5,
         ).decode("utf-8")
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        app.logger.debug(f"WireGuard latest-handshakes info (expected failure): {exc}")
+        return wg_status, wg_pubkey
     except Exception as exc:
-        app.logger.warning(f"Failed to read WireGuard latest-handshakes: {exc}")
+        app.logger.warning(f"Unexpected error reading WireGuard latest-handshakes: {exc}")
         return wg_status, wg_pubkey
 
     now_epoch = int(time.time())

--- a/server/app.py
+++ b/server/app.py
@@ -714,7 +714,8 @@ def _get_wireguard_state(interface_name: str = WG_INTERFACE_NAME) -> Tuple[str, 
 
     try:
         output = subprocess.check_output(["wg", "show", interface_name], stderr=subprocess.STDOUT).decode("utf-8")
-    except Exception:
+    except Exception as exc:
+        app.logger.warning(f"Failed to run 'wg show {interface_name}': {exc}")
         return wg_status, wg_pubkey
 
     if f"interface: {interface_name}" not in output:

--- a/server/app.py
+++ b/server/app.py
@@ -97,6 +97,8 @@ LND_RESTART_DELAY = 3  # Seconds to wait for middleware to generate umbrel-lnd.c
 LND_CONTAINER_PATTERN = r"^lightning[_-]lnd[_-]\d+$"
 LND_MIDDLEWARE_PATTERN = r"^lightning[_-]app[_-]\d+$"
 CLN_CONTAINER_PATTERN = r"(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)"
+WG_INTERFACE_NAME = "tunnelsatsv2"
+WG_HANDSHAKE_MAX_AGE_SECONDS = 180
 
 ALLOWED_NETWORKS = (
     ip_network("127.0.0.0/8"),
@@ -706,6 +708,53 @@ def _derive_wg_public_key(private_key):
         return ""
 
 
+def _get_wireguard_state(interface_name: str = WG_INTERFACE_NAME) -> Tuple[str, str]:
+    wg_status = "Disconnected"
+    wg_pubkey = ""
+
+    try:
+        output = subprocess.check_output(["wg", "show", interface_name], stderr=subprocess.STDOUT).decode("utf-8")
+    except Exception:
+        return wg_status, wg_pubkey
+
+    if f"interface: {interface_name}" not in output:
+        return wg_status, wg_pubkey
+
+    for line in output.splitlines():
+        if line.strip().startswith("public key:"):
+            wg_pubkey = line.split(":", 1)[1].strip()
+            break
+
+    try:
+        handshakes_output = subprocess.check_output(
+            ["wg", "show", interface_name, "latest-handshakes"],
+            stderr=subprocess.STDOUT,
+        ).decode("utf-8")
+    except Exception as exc:
+        app.logger.warning(f"Failed to read WireGuard latest-handshakes: {exc}")
+        return wg_status, wg_pubkey
+
+    now_epoch = int(time.time())
+    for line in handshakes_output.splitlines():
+        parts = line.strip().split()
+        if len(parts) < 2:
+            continue
+
+        try:
+            latest_handshake_epoch = int(parts[-1])
+        except ValueError:
+            continue
+
+        if latest_handshake_epoch <= 0:
+            continue
+
+        if (now_epoch - latest_handshake_epoch) <= WG_HANDSHAKE_MAX_AGE_SECONDS:
+            wg_status = "Connected"
+            break
+
+    return wg_status, wg_pubkey
+
+
 def _server_id_from_domain(server_domain):
     server_domain = str(server_domain or "").strip()
     if not server_domain:
@@ -1308,17 +1357,7 @@ def renew_subscription():
 @app.route("/api/local/status", methods=["GET"])
 def local_status():
     app.logger.debug("Action Request: Fetching local status")
-    wg_status = "Disconnected"
-    wg_pubkey = ""
-    try:
-        output = subprocess.check_output(["wg", "show", "tunnelsatsv2"], stderr=subprocess.STDOUT).decode("utf-8")
-        if "interface: tunnelsatsv2" in output:
-            wg_status = "Connected"
-            for line in output.split("\n"):
-                if line.strip().startswith("public key:"):
-                    wg_pubkey = line.split(":", 1)[1].strip()
-    except Exception:
-        pass
+    wg_status, wg_pubkey = _get_wireguard_state()
 
     configs = []
     if os.path.exists(DATA_DIR):
@@ -1363,7 +1402,7 @@ def local_status():
     try:
         # Source of Truth: the live interface state. 
         # check=False in subprocess.run is more robust than check_output if "ip" is missing.
-        res = subprocess.run(["ip", "-4", "addr", "show", "dev", "tunnelsatsv2"], 
+        res = subprocess.run(["ip", "-4", "addr", "show", "dev", WG_INTERFACE_NAME], 
                              capture_output=True, text=True, timeout=2)
         if res.returncode == 0:
             if match := re.search(r"inet\s+(\d+\.\d+\.\d+\.\d+)", res.stdout):

--- a/server/app.py
+++ b/server/app.py
@@ -749,7 +749,7 @@ def _get_wireguard_state(interface_name: str = WG_INTERFACE_NAME) -> Tuple[str, 
         if latest_handshake_epoch <= 0:
             continue
 
-        if (now_epoch - latest_handshake_epoch) <= WG_HANDSHAKE_MAX_AGE_SECONDS:
+        if 0 <= (now_epoch - latest_handshake_epoch) <= WG_HANDSHAKE_MAX_AGE_SECONDS:
             wg_status = "Connected"
             break
 

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -89,6 +89,7 @@ def test_local_status_reports_disconnected_when_latest_handshake_is_stale(mock_c
     data = json.loads(res.data)
     assert data['wg_status'] == 'Disconnected'
     assert data['vpn_active'] is False
+    assert data['wg_pubkey'] == 'localPubKey123'
 
 
 @patch('app.time.time', return_value=1_000_000)

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import pytest
 import json
 import stat
+import subprocess
 import tempfile
 import time
 from unittest.mock import patch, MagicMock

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -41,6 +41,128 @@ def test_status_endpoint(client):
     assert 'wg_status' in data
 
 
+@patch('app.time.time', return_value=1_000_000)
+@patch('app.docker_api', return_value=[])
+@patch('app.subprocess.check_output')
+def test_local_status_reports_disconnected_when_latest_handshake_is_zero(mock_check_output, _mock_docker_api, _mock_time, client):
+    def check_output_side_effect(cmd, **kwargs):
+        if cmd == ["wg", "show", "tunnelsatsv2"]:
+            return (
+                b"interface: tunnelsatsv2\n"
+                b"  public key: localPubKey123\n"
+                b"peer: remotePeerKey123\n"
+            )
+        if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+            return b"remotePeerKey123\t0\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    mock_check_output.side_effect = check_output_side_effect
+
+    res = client.get('/api/local/status')
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data['wg_status'] == 'Disconnected'
+    assert data['vpn_active'] is False
+    assert data['wg_pubkey'] == 'localPubKey123'
+
+
+@patch('app.time.time', return_value=1_000_000)
+@patch('app.docker_api', return_value=[])
+@patch('app.subprocess.check_output')
+def test_local_status_reports_disconnected_when_latest_handshake_is_stale(mock_check_output, _mock_docker_api, _mock_time, client):
+    def check_output_side_effect(cmd, **kwargs):
+        if cmd == ["wg", "show", "tunnelsatsv2"]:
+            return (
+                b"interface: tunnelsatsv2\n"
+                b"  public key: localPubKey123\n"
+                b"peer: remotePeerKey123\n"
+            )
+        if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+            return b"remotePeerKey123\t999819\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    mock_check_output.side_effect = check_output_side_effect
+
+    res = client.get('/api/local/status')
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data['wg_status'] == 'Disconnected'
+    assert data['vpn_active'] is False
+
+
+@patch('app.time.time', return_value=1_000_000)
+@patch('app.docker_api', return_value=[])
+@patch('app.subprocess.check_output')
+def test_local_status_reports_connected_when_latest_handshake_is_recent(mock_check_output, _mock_docker_api, _mock_time, client):
+    def check_output_side_effect(cmd, **kwargs):
+        if cmd == ["wg", "show", "tunnelsatsv2"]:
+            return (
+                b"interface: tunnelsatsv2\n"
+                b"  public key: localPubKey123\n"
+                b"peer: remotePeerKey123\n"
+            )
+        if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+            return b"remotePeerKey123\t999950\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    mock_check_output.side_effect = check_output_side_effect
+
+    res = client.get('/api/local/status')
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data['wg_status'] == 'Connected'
+    assert data['vpn_active'] is True
+
+
+@patch('app.time.time', return_value=1_000_000)
+@patch('app.docker_api', return_value=[])
+@patch('app.subprocess.check_output')
+def test_local_status_reports_connected_when_latest_handshake_is_exactly_threshold(mock_check_output, _mock_docker_api, _mock_time, client):
+    def check_output_side_effect(cmd, **kwargs):
+        if cmd == ["wg", "show", "tunnelsatsv2"]:
+            return (
+                b"interface: tunnelsatsv2\n"
+                b"  public key: localPubKey123\n"
+                b"peer: remotePeerKey123\n"
+            )
+        if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+            return b"remotePeerKey123\t999820\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    mock_check_output.side_effect = check_output_side_effect
+
+    res = client.get('/api/local/status')
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data['wg_status'] == 'Connected'
+    assert data['vpn_active'] is True
+
+
+@patch('app.time.time', return_value=1_000_000)
+@patch('app.docker_api', return_value=[])
+@patch('app.subprocess.check_output')
+def test_local_status_reports_disconnected_when_latest_handshakes_query_fails(mock_check_output, _mock_docker_api, _mock_time, client):
+    def check_output_side_effect(cmd, **kwargs):
+        if cmd == ["wg", "show", "tunnelsatsv2"]:
+            return (
+                b"interface: tunnelsatsv2\n"
+                b"  public key: localPubKey123\n"
+                b"peer: remotePeerKey123\n"
+            )
+        if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd, output=b"")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    mock_check_output.side_effect = check_output_side_effect
+
+    res = client.get('/api/local/status')
+    assert res.status_code == 200
+    data = json.loads(res.data)
+    assert data['wg_status'] == 'Disconnected'
+    assert data['vpn_active'] is False
+    assert data['wg_pubkey'] == 'localPubKey123'
+
+
 def test_security_headers_present(client):
     """Test that security headers (CSP, X-Frame-Options) are present on all responses."""
     res = client.get('/')
@@ -1643,7 +1765,20 @@ class TestFullE2E_Workflow:
         assert res.status_code == 200
 
         # 5. Status Check
-        mock_subprocess.return_value = b"interface: tunnelsatsv2\n  public key: pubKey123\n  private key: (hidden)\n  listening port: 51820\n"
+        def mock_wg_show_side_effect(cmd, **kwargs):
+            if cmd == ["wg", "show", "tunnelsatsv2"]:
+                return (
+                    b"interface: tunnelsatsv2\n"
+                    b"  public key: pubKey123\n"
+                    b"  private key: (hidden)\n"
+                    b"  listening port: 51820\n"
+                    b"peer: peerPubKey123\n"
+                )
+            if cmd == ["wg", "show", "tunnelsatsv2", "latest-handshakes"]:
+                return f"peerPubKey123\t{int(time.time())}\n".encode('utf-8')
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        mock_subprocess.side_effect = mock_wg_show_side_effect
         
         res = client.get('/api/local/status')
         assert res.status_code == 200


### PR DESCRIPTION
Fixes #77 

Implemented on this branch with a TDD cycle (RED -> GREEN -> REFACTOR).

What I changed

1) RED tests for handshake-based status detection in server/tests/test_app.py (line 44):
- latest-handshake == 0 => wg_status=Disconnected, vpn_active=False
- stale handshake (>180s) => disconnected
- recent handshake (<=180s) => connected

2) GREEN backend fix in server/app.py (line 711):
- Added _get_wireguard_state() that:
- reads wg show tunnelsatsv2
- parses wg show tunnelsatsv2 latest-handshakes
- marks connected only if a peer handshake is recent (<= 180s)

- Introduced constants in server/app.py (line 100):
- WG_INTERFACE_NAME
- WG_HANDSHAKE_MAX_AGE_SECONDS

3) Refactor wiring in server/app.py (line 1357):
- local_status() now uses _get_wireguard_state() instead of inline interface-only detection.
- Reused WG_INTERFACE_NAME for internal IP lookup in server/app.py (line 1405).

4) Updated existing E2E workflow test mock for the second wg call in server/tests/test_app.py (line 1719).

Verification

- Ran focused RED/GREEN set: passed.
- Ran full test file:

.venv-tests/bin/pytest -q server/tests/test_app.py
Result: 76 passed.