### PR TITLE
Release v3.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,23 @@ jobs:
           chmod +x scripts/test.sh
           ./scripts/test.sh entrypoint
 
-      - name: Build locally and Start Tunnelsats
-        run: |
-          IMAGE=$(grep -E "image: tunnelsats/ts-umbrel-app" docker-compose.yml | awk '{print $2}')
-          docker build -t $IMAGE .
-          docker compose up -d tunnelsats
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Image Tag
+        run: echo "IMAGE=$(grep -E 'image: tunnelsats/ts-umbrel-app' docker-compose.yml | awk '{print $2}')" >> $GITHUB_ENV
+
+      - name: Build Docker Image with Cache
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ${{ env.IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start Tunnelsats
+        run: docker compose up -d tunnelsats
 
       - name: Assert Container Starts Successfully
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,10 @@ jobs:
           chmod +x scripts/test.sh
           ./scripts/test.sh entrypoint
 
-      - name: Build and Start Tunnelsats
+      - name: Build locally and Start Tunnelsats
         run: |
-          docker compose build tunnelsats
+          IMAGE=$(grep -E "image: tunnelsats/ts-umbrel-app" docker-compose.yml | awk '{print $2}')
+          docker build -t $IMAGE .
           docker compose up -d tunnelsats
 
       - name: Assert Container Starts Successfully

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Extract Image Tag
-        run: echo "IMAGE=$(grep -E 'image: tunnelsats/ts-umbrel-app' docker-compose.yml | awk '{print $2}')" >> $GITHUB_ENV
+        run: |
+          echo "IMAGE=$(grep -E 'image: tunnelsats/ts-umbrel-app' docker-compose.yml | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Build Docker Image with Cache
         uses: docker/build-push-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,15 +42,16 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Extract Image Tag
+        id: image_tag
         run: |
-          echo "IMAGE=$(grep -E 'image: tunnelsats/ts-umbrel-app' docker-compose.yml | awk '{print $2}')" >> $GITHUB_ENV
+          echo "IMAGE=$(grep -E 'image: tunnelsats/ts-umbrel-app' docker-compose.yml | awk '{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Build Docker Image with Cache
         uses: docker/build-push-action@v5
         with:
           context: .
           load: true
-          tags: ${{ env.IMAGE }}
+          tags: ${{ steps.image_tag.outputs.IMAGE }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -108,6 +108,9 @@ run_version() {
     log_info "Updating version to ${NEW_VERSION}..."
     sed "s/version: .*/version: \"${NEW_VERSION}\"/" "${REPO_ROOT}/tunnelsats/umbrel-app.yml" > "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" "${REPO_ROOT}/tunnelsats/umbrel-app.yml"
     sed -E "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${NEW_VERSION}#" "${REPO_ROOT}/tunnelsats/docker-compose.yml" > "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" "${REPO_ROOT}/tunnelsats/docker-compose.yml"
+    if [ -f "${REPO_ROOT}/web/index.html" ]; then
+        sed -E "s/(class=\"[^\"]* tracking-tighter\">)v?[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.-]*(<\/span>)/\1v${NEW_VERSION}\2/" "${REPO_ROOT}/web/index.html" > "${REPO_ROOT}/web/index.html.tmp" && mv "${REPO_ROOT}/web/index.html.tmp" "${REPO_ROOT}/web/index.html"
+    fi
 }
 
 run_promote() {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -109,7 +109,7 @@ run_version() {
     sed "s/version: .*/version: \"${NEW_VERSION}\"/" "${REPO_ROOT}/tunnelsats/umbrel-app.yml" > "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" "${REPO_ROOT}/tunnelsats/umbrel-app.yml"
     sed -E "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${NEW_VERSION}#" "${REPO_ROOT}/tunnelsats/docker-compose.yml" > "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" "${REPO_ROOT}/tunnelsats/docker-compose.yml"
     if [ -f "${REPO_ROOT}/web/index.html" ]; then
-        sed -E "s/(class=\"[^\"]* tracking-tighter\">)v?[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.-]*(<\/span>)/\1v${NEW_VERSION}\2/" "${REPO_ROOT}/web/index.html" > "${REPO_ROOT}/web/index.html.tmp" && mv "${REPO_ROOT}/web/index.html.tmp" "${REPO_ROOT}/web/index.html"
+        sed -E "s/(id=\"app-version\"[^>]*>v?)[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.-]*(<\/span>)/\1${NEW_VERSION}\2/" "${REPO_ROOT}/web/index.html" > "${REPO_ROOT}/web/index.html.tmp" && mv "${REPO_ROOT}/web/index.html.tmp" "${REPO_ROOT}/web/index.html"
     fi
 }
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -107,7 +107,7 @@ run_version() {
     fi
     log_info "Updating version to ${NEW_VERSION}..."
     sed "s/version: .*/version: \"${NEW_VERSION}\"/" "${REPO_ROOT}/tunnelsats/umbrel-app.yml" > "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" "${REPO_ROOT}/tunnelsats/umbrel-app.yml"
-    sed -E "s#(ts-umbrel-app:v)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${NEW_VERSION}#" "${REPO_ROOT}/tunnelsats/docker-compose.yml" > "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" "${REPO_ROOT}/tunnelsats/docker-compose.yml"
+    sed -E "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${NEW_VERSION}#" "${REPO_ROOT}/tunnelsats/docker-compose.yml" > "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" "${REPO_ROOT}/tunnelsats/docker-compose.yml"
 }
 
 run_promote() {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -100,7 +100,7 @@ run_vendor() {
 
 run_version() {
     if [ "$#" -lt 1 ]; then log_error "Version argument required"; return 1; fi
-    NEW_VERSION="$1"
+    NEW_VERSION="${1#v}"
     if [[ "$NEW_VERSION" =~ [^a-zA-Z0-9._-] ]]; then
         log_error "Invalid version string: $NEW_VERSION (only alphanumeric, '.', '_', '-' allowed)"
         return 1

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -150,7 +150,7 @@ run_promote() {
     # Inject submitter and submission PR URL (if provided)
     if grep -qE "^submitter:" "${TARGET_MANIFEST}"; then
         log_info "submitter/submission already present, skipping injection."
-    elif [ -n "$SUBMISSION_URL" ]; then
+    elif [ -n "${SUBMISSION_URL:-}" ]; then
         sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${SUBMISSION_URL}@" "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
     fi
 

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.1.0@sha256:c38f7bd28742b5e94a29351bcd44328d4080e742f5b904676b5008dc847f8f6a
+    image: tunnelsats/ts-umbrel-app:3.1.1@sha256:c38f7bd28742b5e94a29351bcd44328d4080e742f5b904676b5008dc847f8f6a
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.1.0@sha256:27be5d81fdf2a1b83de64ee097f883314875cf545a85d85b09f63f6a7aeef621
+    image: tunnelsats/ts-umbrel-app:3.1.0@sha256:c38f7bd28742b5e94a29351bcd44328d4080e742f5b904676b5008dc847f8f6a
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.1.1@sha256:c38f7bd28742b5e94a29351bcd44328d4080e742f5b904676b5008dc847f8f6a
+    image: tunnelsats/ts-umbrel-app:3.1.1
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.1.1rc"
+version: "3.1.1"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.

--- a/web/index.html
+++ b/web/index.html
@@ -865,8 +865,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version"
-                        class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.1.1</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.1.1</span>
                 </div>
             </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -866,7 +866,7 @@
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
                     <span id="app-version"
-                        class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.1.0</span>
+                        class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.1.1</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary of Changes
- Bumps application version to 3.1.1 in manifest and docker-compose
- Sets the stage for native Umbrel widget implementation

## Detailed Changes
- `tunnelsats/umbrel-app.yml`: Bump version to `3.1.1`
- `tunnelsats/docker-compose.yml`: Update tag to `3.1.1`

## Testing Strategy
- **Coverage**: N/A for manifest version bump
- **Verification**: Local manifest validation

## What's Left for Later
- [ ] Implement native Umbrel widgets in `server/app.py`
