### PR TITLE
feat(secure-mode): introduce Secure Mode for official App Store and stability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ While we await review for the official Umbrel App Store - Appreciate the upvote 
 
 ---
 
+## 🔒 Secure Mode (Official App Store Sandbox)
+
+To comply with Umbrel's strict security guidelines, the version of TunnelSats submitted to the official Umbrel App Store runs in **Secure Mode** (with `SECURE_MODE=true` set in the environment).
+
+### What changes in Secure Mode?
+1. **No Docker Socket Access**: The container does not mount `/var/run/docker.sock`, preventing it from inspecting or mutating other containers on the host.
+2. **Dynamic Probing**: Instead of using the Docker API, the app detects LND or Core-Lightning nodes by dynamically probing their default TCP ports (`10.21.21.9:9735` and `10.21.21.96:9736`) and checking configuration file paths.
+3. **Manual Node Configuration**: The app cannot automatically edit your node's configuration files or restart the containers. Instead, the UI provides copy-to-clipboard blocks and step-by-step instructions so you can easily copy and paste the parameters yourself.
+
+### Swapping Modes
+By default, the Community App Store version runs with automated setup (`SECURE_MODE=false`), while the Official Store version defaults to Secure Mode. 
+
+You can manually force either behavior by editing `tunnelsats/docker-compose.yml` or setting the environment variable:
+- **Force Secure Mode**: `SECURE_MODE=true`
+- **Force Automated Mode**: `SECURE_MODE=false` (requires mounting `/var/run/docker.sock:/var/run/docker.sock:ro` in your compose file)
+
+---
+
 ## ☸️ Running on k3s / Kubernetes
 
 Besides Umbrel, TunnelSats can run in `k3s` mode alongside an LND/CLN node in a

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,7 @@
+project-includes = ["."]
+project-excludes = ["**/venv", "**/.venv", "**/node_modules", "**/dist"]
+python-version = "3.12"
+python-interpreter-path = "venv/bin/python"
+check-unannotated-defs = false
+search-path = ["server"]
+

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1063,22 +1063,18 @@ cleanup_dataplane() {
     local max_attempts=10
     local attempt=0
 
+    # Clean up all potential node target IP routing rules in Secure Mode unconditionally to prevent stale rules persisting across mode toggles or restores
+    for cleanup_ip in "${DOCKER_TARGET_IP:-}" "10.21.21.9" "10.21.21.96"; do
+        [ -n "${cleanup_ip}" ] || continue
+        local cleanup_subnet
+        cleanup_subnet=$(get_target_subnet "${cleanup_ip}")
+        ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
+        ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
+    done
+
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
-        if [[ "${SECURE_MODE}" == "true" ]]; then
-            for cleanup_ip in "${DOCKER_TARGET_IP:-}" "10.21.21.9" "10.21.21.96"; do
-                [ -n "${cleanup_ip}" ] || continue
-                local cleanup_subnet
-                cleanup_subnet=$(get_target_subnet "${cleanup_ip}")
-                ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
-                ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
-            done
-        else
+        if [[ "${SECURE_MODE}" != "true" ]]; then
             ip rule del fwmark 51820 table 51820 pref 32764 >/dev/null 2>&1 || true
-            # Also remove any legacy IP-source rules from older deployments.
-            if [ -n "${DOCKER_TARGET_IP:-}" ]; then
-                ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
-                ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
-            fi
         fi
     else
         # Remove local bypass rule (pref 32500)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -855,34 +855,32 @@ ensure_nat_forward_rules() {
             changed=1
         fi
 
-        if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
-            # Mangle rules for conntrack fwmark routing.
-            if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
-                log INFO "Syncing mangle CONNMARK restore rule"
-                remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
-                if ! iptables -t mangle -A PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-                    -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c; then
-                    LAST_ERROR="Failed to add CONNMARK restore-mark rule"
-                    return 1
-                fi
-                changed=1
+        # Mangle rules for conntrack fwmark routing.
+        if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+            -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
+            log INFO "Syncing mangle CONNMARK restore rule"
+            remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
+            if ! iptables -t mangle -A PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c; then
+                LAST_ERROR="Failed to add CONNMARK restore-mark rule"
+                return 1
             fi
+            changed=1
+        fi
 
-            # Remove legacy wg-mark rule (MARK --set-mark) if it exists from a previous deployment.
-            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
+        # Remove legacy wg-mark rule (MARK --set-mark) if it exists from a previous deployment.
+        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
 
-            if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
-                log INFO "Syncing mangle CONNMARK set-mark rule"
-                remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
-                if ! iptables -t mangle -A FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-                    -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c; then
-                    LAST_ERROR="Failed to add CONNMARK set-mark rule"
-                    return 1
-                fi
-                changed=1
+        if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+            -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
+            log INFO "Syncing mangle CONNMARK set-mark rule"
+            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
+            if ! iptables -t mangle -A FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c; then
+                LAST_ERROR="Failed to add CONNMARK set-mark rule"
+                return 1
             fi
+            changed=1
         fi
     else
         # Docker mode: bridge-interface FORWARD rules.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -648,9 +648,9 @@ ensure_policy_routing() {
         # 1. Discover target's bridge network subnet dynamically
         local route_info dev_iface subnet
         route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-        dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+        dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
         if [ -n "${dev_iface}" ]; then
-            subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+            subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
         fi
         if [ -n "${subnet}" ]; then
             subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
@@ -937,9 +937,9 @@ rules_are_synced() {
             # Discover target's bridge network subnet dynamically
             local route_info dev_iface subnet
             route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-            dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+            dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
             if [ -n "${dev_iface}" ]; then
-                subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+                subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
             fi
             if [ -n "${subnet}" ]; then
                 subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
@@ -1094,9 +1094,9 @@ cleanup_dataplane() {
             # Discover target's bridge network subnet dynamically
             local route_info dev_iface subnet
             route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-            dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+            dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
             if [ -n "${dev_iface}" ]; then
-                subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+                subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
             fi
             if [ -n "${subnet}" ]; then
                 subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1047,7 +1047,11 @@ rules_are_synced() {
 }
 
 cleanup_dataplane() {
-    log INFO "Cleaning dataplane rules"
+    local keep_tunnel=false
+    if [[ "${1:-}" == "--keep-tunnel" ]]; then
+        keep_tunnel=true
+    fi
+    log INFO "Cleaning dataplane rules (keep_tunnel=${keep_tunnel})"
     remove_tagged_iptables_rules nat PREROUTING "tunnelsats-dnat"
     remove_tagged_iptables_rules nat POSTROUTING "tunnelsats-masq"
     remove_tagged_iptables_rules filter FORWARD "tunnelsats-forward-in"
@@ -1091,10 +1095,12 @@ cleanup_dataplane() {
         done
     fi
 
-    ip route flush table 51820 >/dev/null 2>&1 || true
+    if [ "${keep_tunnel}" = false ]; then
+        ip route flush table 51820 >/dev/null 2>&1 || true
 
-    if wg show "${WG_IFACE}" >/dev/null 2>&1; then
-        wg-quick down "${WG_IFACE}" >/dev/null 2>&1 || true
+        if wg show "${WG_IFACE}" >/dev/null 2>&1; then
+            wg-quick down "${WG_IFACE}" >/dev/null 2>&1 || true
+        fi
     fi
 }
 
@@ -1157,7 +1163,7 @@ reconcile_once() {
 
     if ! detect_lightning_container; then
         LAST_ERROR="${LAST_ERROR:-No running LND/CLN container detected}"
-        cleanup_dataplane
+        cleanup_dataplane "--keep-tunnel"
         write_state
         if [ -n "${request_id}" ]; then
             write_reconcile_result "${request_id}" false

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -356,14 +356,14 @@ detect_lightning_container() {
         if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
             local lnd_has_ts=0
             local cln_has_ts=0
-            if [ -f "/lightning-data/lnd/lnd.conf" ] && grep -q "externalhosts=" "/lightning-data/lnd/lnd.conf" 2>/dev/null; then
+            if [ -f "/lightning-data/lnd/lnd.conf" ] && grep -qE "^[[:space:]]*externalhosts=" "/lightning-data/lnd/lnd.conf" 2>/dev/null; then
                 lnd_has_ts=1
             fi
-            if { [ -f "/lightning-data/cln/config" ] && grep -q "announce-addr=" "/lightning-data/cln/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/bitcoin/config" ] && grep -q "announce-addr=" "/lightning-data/cln/bitcoin/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/testnet/config" ] && grep -q "announce-addr=" "/lightning-data/cln/testnet/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/signet/config" ] && grep -q "announce-addr=" "/lightning-data/cln/signet/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/regtest/config" ] && grep -q "announce-addr=" "/lightning-data/cln/regtest/config" 2>/dev/null; }; then
+            if { [ -f "/lightning-data/cln/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/bitcoin/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/bitcoin/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/testnet/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/testnet/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/signet/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/signet/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/regtest/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/regtest/config" 2>/dev/null; }; then
                 cln_has_ts=1
             fi
             
@@ -844,15 +844,15 @@ ensure_nat_forward_rules() {
             changed=1
         fi
 
-        if [[ "${K3S_MODE}" == "true" ]]; then
+        if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
             # Mangle rules for conntrack fwmark routing.
             if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
                 -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
-                log INFO "Syncing mangle CONNMARK restore rule (k3s)"
+                log INFO "Syncing mangle CONNMARK restore rule"
                 remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
                 if ! iptables -t mangle -A PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
                     -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c; then
-                    LAST_ERROR="k3s: Failed to add CONNMARK restore-mark rule"
+                    LAST_ERROR="Failed to add CONNMARK restore-mark rule"
                     return 1
                 fi
                 changed=1
@@ -863,11 +863,11 @@ ensure_nat_forward_rules() {
 
             if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
                 -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
-                log INFO "Syncing mangle CONNMARK set-mark rule (k3s)"
+                log INFO "Syncing mangle CONNMARK set-mark rule"
                 remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
                 if ! iptables -t mangle -A FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
                     -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c; then
-                    LAST_ERROR="k3s: Failed to add CONNMARK set-mark rule"
+                    LAST_ERROR="Failed to add CONNMARK set-mark rule"
                     return 1
                 fi
                 changed=1
@@ -1086,6 +1086,10 @@ cleanup_dataplane() {
     local attempt=0
 
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
+        remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
+        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
+        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
+
         if [[ "${SECURE_MODE}" == "true" ]]; then
             # Discover target's bridge network subnet dynamically
             local route_info dev_iface subnet
@@ -1107,9 +1111,6 @@ cleanup_dataplane() {
             # Also remove any legacy IP-source rules from older deployments.
             ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
             ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
-            remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
-            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
-            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
         fi
     else
         # Remove local bypass rule (pref 32500)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1090,7 +1090,7 @@ cleanup_dataplane() {
         remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
         remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
 
-        if [[ "${SECURE_MODE}" == "true" ]]; then
+        if [[ "${SECURE_MODE}" == "true" ]] && [ -n "${DOCKER_TARGET_IP:-}" ]; then
             # Discover target's bridge network subnet dynamically
             local route_info dev_iface subnet
             route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -328,7 +328,7 @@ detect_lightning_container() {
             cln_ok=1
         fi
 
-        # Load metadata node type configuration if available to break ties or fallback
+        # Load metadata node type configuration if available to break ties
         local meta_node=""
         if [ -f "/data/tunnelsats-meta.json" ]; then
             meta_node=$(jq -r '.nodeType // empty' /data/tunnelsats-meta.json 2>/dev/null | tr '[:upper:]' '[:lower:]')
@@ -340,50 +340,6 @@ detect_lightning_container() {
                 cln_ok=0
             elif [ "${meta_node}" = "cln" ]; then
                 lnd_ok=0
-            fi
-        fi
-        
-        # 3. Check metadata configuration file if both TCP probes fail
-        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
-            if [ "${meta_node}" = "lnd" ]; then
-                lnd_ok=1
-            elif [ "${meta_node}" = "cln" ]; then
-                cln_ok=1
-            fi
-        fi
-
-        # 4. Check for active config file signature (only one configured for TunnelSats)
-        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
-            local lnd_has_ts=0
-            local cln_has_ts=0
-            if [ -f "/lightning-data/lnd/lnd.conf" ] && grep -qE "^[[:space:]]*externalhosts=" "/lightning-data/lnd/lnd.conf" 2>/dev/null; then
-                lnd_has_ts=1
-            fi
-            if { [ -f "/lightning-data/cln/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/bitcoin/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/bitcoin/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/testnet/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/testnet/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/signet/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/signet/config" 2>/dev/null; } || \
-               { [ -f "/lightning-data/cln/regtest/config" ] && grep -qE "^[[:space:]]*announce-addr=" "/lightning-data/cln/regtest/config" 2>/dev/null; }; then
-                cln_has_ts=1
-            fi
-            
-            if [ "${lnd_has_ts}" -eq 1 ] && [ "${cln_has_ts}" -eq 0 ]; then
-                lnd_ok=1
-            elif [ "${cln_has_ts}" -eq 1 ] && [ "${lnd_has_ts}" -eq 0 ]; then
-                cln_ok=1
-            fi
-        fi
-
-        # 5. Fallback to raw file existence
-        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
-            if [ -f "/lightning-data/lnd/lnd.conf" ]; then
-                lnd_ok=1
-            elif [ -f "/lightning-data/cln/config" ] || \
-                 [ -f "/lightning-data/cln/bitcoin/config" ] || \
-                 [ -f "/lightning-data/cln/testnet/config" ] || \
-                 [ -f "/lightning-data/cln/signet/config" ] || \
-                 [ -f "/lightning-data/cln/regtest/config" ]; then
-                cln_ok=1
             fi
         fi
 
@@ -919,7 +875,9 @@ ensure_nat_forward_rules() {
     else
         masq_src="${DOCKER_NETWORK_SUBNET}"
     fi
-    if ! iptables -t nat -S POSTROUTING 1 | grep -F "tunnelsats-masq" | grep -F -- "-s ${masq_src}" | grep -F -- "-o ${WG_IFACE}" | grep -qF -- "-j MASQUERADE"; then
+    local first_rule
+    first_rule=$(iptables -t nat -S POSTROUTING 2>/dev/null | grep -v '^-P' | head -n 1 || true)
+    if ! echo "${first_rule}" | grep -F "tunnelsats-masq" | grep -F -- "-s ${masq_src}" | grep -F -- "-o ${WG_IFACE}" | grep -qF -- "-j MASQUERADE"; then
         log INFO "Rule rotation: TunnelSats MASQUERADE is not at position 1. Re-positioning for ${WG_IFACE}..."
 
         # Deterministic cleanup before re-insertion at position 1 (Grep ID 3033104618)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,6 +21,7 @@ RECONCILE_INTERVAL=30
 # These are explicitly exported so the Python dashboard (launched as a child process below)
 # always sees them, even if a future caller passes them as plain shell vars instead of env.
 export K3S_MODE="${K3S_MODE:-false}"
+export SECURE_MODE="${SECURE_MODE:-false}"
 export LND_K8S_SERVICE="${LND_K8S_SERVICE:-}"
 export CLN_K8S_SERVICE="${CLN_K8S_SERVICE:-}"
 export K8S_NAMESPACE="${K8S_NAMESPACE:-default}"
@@ -77,7 +78,13 @@ write_state() {
     tmp="$(mktemp "${STATE_FILE}.tmp.XXXXXX")"
 
     local dataplane_mode
-    dataplane_mode="$([[ "${K3S_MODE}" == "true" ]] && echo "k3s" || echo "docker-full-parity")"
+    if [[ "${K3S_MODE}" == "true" ]]; then
+        dataplane_mode="k3s"
+    elif [[ "${SECURE_MODE}" == "true" ]]; then
+        dataplane_mode="secure-mode"
+    else
+        dataplane_mode="docker-full-parity"
+    fi
 
     if jq -n \
         --arg dataplane_mode "${dataplane_mode}" \
@@ -309,6 +316,96 @@ detect_lightning_container() {
         return 0
     fi
 
+    if [[ "${SECURE_MODE}" == "true" ]]; then
+        local lnd_ok=0
+        local cln_ok=0
+        
+        # 1. Active TCP probes first (indicates a running, listening node)
+        if timeout 2 bash -c 'cat < /dev/null > /dev/tcp/10.21.21.9/9735' 2>/dev/null; then
+            lnd_ok=1
+        fi
+        if timeout 2 bash -c 'cat < /dev/null > /dev/tcp/10.21.21.96/9736' 2>/dev/null; then
+            cln_ok=1
+        fi
+
+        # Load metadata node type configuration if available to break ties or fallback
+        local meta_node=""
+        if [ -f "/data/tunnelsats-meta.json" ]; then
+            meta_node=$(jq -r '.nodeType // empty' /data/tunnelsats-meta.json 2>/dev/null | tr '[:upper:]' '[:lower:]')
+        fi
+
+        # 2. Tie resolution if both TCP probes succeeded
+        if [ "${lnd_ok}" -eq 1 ] && [ "${cln_ok}" -eq 1 ]; then
+            if [ "${meta_node}" = "lnd" ]; then
+                cln_ok=0
+            elif [ "${meta_node}" = "cln" ]; then
+                lnd_ok=0
+            fi
+        fi
+        
+        # 3. Check metadata configuration file if both TCP probes fail
+        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
+            if [ "${meta_node}" = "lnd" ]; then
+                lnd_ok=1
+            elif [ "${meta_node}" = "cln" ]; then
+                cln_ok=1
+            fi
+        fi
+
+        # 4. Check for active config file signature (only one configured for TunnelSats)
+        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
+            local lnd_has_ts=0
+            local cln_has_ts=0
+            if [ -f "/lightning-data/lnd/lnd.conf" ] && grep -q "externalhosts=" "/lightning-data/lnd/lnd.conf" 2>/dev/null; then
+                lnd_has_ts=1
+            fi
+            if { [ -f "/lightning-data/cln/config" ] && grep -q "announce-addr=" "/lightning-data/cln/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/bitcoin/config" ] && grep -q "announce-addr=" "/lightning-data/cln/bitcoin/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/testnet/config" ] && grep -q "announce-addr=" "/lightning-data/cln/testnet/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/signet/config" ] && grep -q "announce-addr=" "/lightning-data/cln/signet/config" 2>/dev/null; } || \
+               { [ -f "/lightning-data/cln/regtest/config" ] && grep -q "announce-addr=" "/lightning-data/cln/regtest/config" 2>/dev/null; }; then
+                cln_has_ts=1
+            fi
+            
+            if [ "${lnd_has_ts}" -eq 1 ] && [ "${cln_has_ts}" -eq 0 ]; then
+                lnd_ok=1
+            elif [ "${cln_has_ts}" -eq 1 ] && [ "${lnd_has_ts}" -eq 0 ]; then
+                cln_ok=1
+            fi
+        fi
+
+        # 5. Fallback to raw file existence
+        if [ "${lnd_ok}" -eq 0 ] && [ "${cln_ok}" -eq 0 ]; then
+            if [ -f "/lightning-data/lnd/lnd.conf" ]; then
+                lnd_ok=1
+            elif [ -f "/lightning-data/cln/config" ] || \
+                 [ -f "/lightning-data/cln/bitcoin/config" ] || \
+                 [ -f "/lightning-data/cln/testnet/config" ] || \
+                 [ -f "/lightning-data/cln/signet/config" ] || \
+                 [ -f "/lightning-data/cln/regtest/config" ]; then
+                cln_ok=1
+            fi
+        fi
+
+        if [ "${lnd_ok}" -eq 1 ]; then
+            TARGET_IMPL="lnd"
+            TARGET_CONTAINER_NAME="lightning_lnd_1"
+            LN_TARGET_PORT="9735"
+            DOCKER_TARGET_IP="10.21.21.9"
+            log INFO "SecureMode: Detected LND node at ${DOCKER_TARGET_IP}"
+            return 0
+        elif [ "${cln_ok}" -eq 1 ]; then
+            TARGET_IMPL="cln"
+            TARGET_CONTAINER_NAME="lightning_cln_1"
+            LN_TARGET_PORT="9736"
+            DOCKER_TARGET_IP="10.21.21.96"
+            log INFO "SecureMode: Detected CLN node at ${DOCKER_TARGET_IP}"
+            return 0
+        fi
+        LAST_ERROR="SecureMode: No Lightning node detected (probed 10.21.21.9 and 10.21.21.96)"
+        return 1
+    fi
+
     local containers
     containers=$(docker_api "GET" "/containers/json?all=0") || return 1
 
@@ -357,6 +454,7 @@ detect_lightning_container() {
 
 ensure_docker_network() {
     [[ "${K3S_MODE}" == "true" ]] && return 0
+    [[ "${SECURE_MODE}" == "true" ]] && return 0
     local response body code
     response=$(docker_api_with_code "GET" "/networks/${DOCKER_NETWORK_NAME}") || true
     body="${response%HTTPSTATUS:*}"
@@ -386,7 +484,7 @@ ensure_docker_network() {
 }
 
 resolve_bridge_name() {
-    if [[ "${K3S_MODE}" == "true" ]]; then
+    if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
         BRIDGE_NAME=""
         return 0
     fi
@@ -405,6 +503,7 @@ resolve_bridge_name() {
 
 ensure_container_attached() {
     [[ "${K3S_MODE}" == "true" ]] && return 0
+    [[ "${SECURE_MODE}" == "true" ]] && return 0
     local inspect
     inspect=$(docker_api "GET" "/containers/${TARGET_CONTAINER_ID}/json") || return 1
 
@@ -539,6 +638,44 @@ ensure_policy_routing() {
             if ! ip rule add fwmark 51820 table 51820 pref 32764 >/dev/null 2>&1; then
                 if ! ip rule show pref 32764 | grep -q "fwmark"; then
                     LAST_ERROR="k3s: Failed to add fwmark policy routing rule"
+                    return 1
+                fi
+            fi
+            changed=1
+        fi
+    elif [[ "${SECURE_MODE}" == "true" ]]; then
+        # Secure Mode: Direct IP policy routing
+        # 1. Discover target's bridge network subnet dynamically
+        local route_info dev_iface subnet
+        route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
+        dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+        if [ -n "${dev_iface}" ]; then
+            subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+        fi
+        if [ -n "${subnet}" ]; then
+            subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
+        else
+            subnet="10.21.0.0/16"
+        fi
+        
+        # 2. Local-to-Local bypass rule (so LND can talk to local Bitcoind/Tor on 10.21.x.x)
+        if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
+            ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
+            if ! ip rule add from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1; then
+                if ! ip rule show pref 32500 | grep -q "from ${DOCKER_TARGET_IP}"; then
+                    LAST_ERROR="SecureMode: Failed to add local bypass rule"
+                    return 1
+                fi
+            fi
+            changed=1
+        fi
+        
+        # 3. Route external traffic through the VPN table 51820
+        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+lookup[[:space:]]+51820[[:space:]]*$"; then
+            ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+            if ! ip rule add from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1; then
+                if ! ip rule show pref 32764 | grep -q "from ${DOCKER_TARGET_IP}"; then
+                    LAST_ERROR="SecureMode: Failed to add policy routing rule"
                     return 1
                 fi
             fi
@@ -681,17 +818,15 @@ ensure_nat_forward_rules() {
         fi
     fi
 
-    if [[ "${K3S_MODE}" == "true" ]]; then
-        # k3s mode: scope FORWARD rules to the target pod IP rather than accepting all
-        # established connections / all WG-ingress traffic. This keeps tunnelsats off the
-        # path for traffic it should not touch and minimizes blast radius.
+    if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
+        # Scope FORWARD rules to the target IP
         if ! iptables -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
             -m comment --comment "tunnelsats-forward-in" -j ACCEPT 2>/dev/null; then
-            log INFO "Syncing FORWARD inbound rules (k3s)"
+            log INFO "Syncing FORWARD inbound rules"
             remove_tagged_iptables_rules filter FORWARD "tunnelsats-forward-in"
             if ! iptables -I FORWARD 1 -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
                 -m comment --comment "tunnelsats-forward-in" -j ACCEPT; then
-                LAST_ERROR="k3s: Failed to add FORWARD inbound rule"
+                LAST_ERROR="Failed to add FORWARD inbound rule"
                 return 1
             fi
             changed=1
@@ -699,42 +834,44 @@ ensure_nat_forward_rules() {
 
         if ! iptables -C FORWARD -s "${DOCKER_TARGET_IP}" -o "${WG_IFACE}" \
             -m comment --comment "tunnelsats-forward-out" -j ACCEPT 2>/dev/null; then
-            log INFO "Syncing FORWARD outbound rules (k3s)"
+            log INFO "Syncing FORWARD outbound rules"
             remove_tagged_iptables_rules filter FORWARD "tunnelsats-forward-out"
             if ! iptables -I FORWARD 2 -s "${DOCKER_TARGET_IP}" -o "${WG_IFACE}" \
                 -m comment --comment "tunnelsats-forward-out" -j ACCEPT; then
-                LAST_ERROR="k3s: Failed to add FORWARD outbound rule"
+                LAST_ERROR="Failed to add FORWARD outbound rule"
                 return 1
             fi
             changed=1
         fi
 
-        # Mangle rules for conntrack fwmark routing.
-        if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-            -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
-            log INFO "Syncing mangle CONNMARK restore rule (k3s)"
-            remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
-            if ! iptables -t mangle -A PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c; then
-                LAST_ERROR="k3s: Failed to add CONNMARK restore-mark rule"
-                return 1
+        if [[ "${K3S_MODE}" == "true" ]]; then
+            # Mangle rules for conntrack fwmark routing.
+            if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
+                log INFO "Syncing mangle CONNMARK restore rule (k3s)"
+                remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
+                if ! iptables -t mangle -A PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+                    -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c; then
+                    LAST_ERROR="k3s: Failed to add CONNMARK restore-mark rule"
+                    return 1
+                fi
+                changed=1
             fi
-            changed=1
-        fi
 
-        # Remove legacy wg-mark rule (MARK --set-mark) if it exists from a previous deployment.
-        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
+            # Remove legacy wg-mark rule (MARK --set-mark) if it exists from a previous deployment.
+            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
 
-        if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-            -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
-            log INFO "Syncing mangle CONNMARK set-mark rule (k3s)"
-            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
-            if ! iptables -t mangle -A FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c; then
-                LAST_ERROR="k3s: Failed to add CONNMARK set-mark rule"
-                return 1
+            if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
+                log INFO "Syncing mangle CONNMARK set-mark rule (k3s)"
+                remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
+                if ! iptables -t mangle -A FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+                    -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c; then
+                    LAST_ERROR="k3s: Failed to add CONNMARK set-mark rule"
+                    return 1
+                fi
+                changed=1
             fi
-            changed=1
         fi
     else
         # Docker mode: bridge-interface FORWARD rules.
@@ -767,10 +904,11 @@ ensure_nat_forward_rules() {
 
     # Verify MASQUERADE positioning to ensure deterministic routing priority (Grep ID 3033104618)
     # Check if the exact rule exists at position 1 (first entry in POSTROUTING)
-    if [[ "${K3S_MODE}" == "true" ]]; then
-        local masq_src="${DOCKER_TARGET_IP}"
+    local masq_src
+    if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
+        masq_src="${DOCKER_TARGET_IP}"
     else
-        local masq_src="${DOCKER_NETWORK_SUBNET}"
+        masq_src="${DOCKER_NETWORK_SUBNET}"
     fi
     if ! iptables -t nat -S POSTROUTING 1 | grep -F "tunnelsats-masq" | grep -F -- "-s ${masq_src}" | grep -F -- "-o ${WG_IFACE}" | grep -qF -- "-j MASQUERADE"; then
         log INFO "Rule rotation: TunnelSats MASQUERADE is not at position 1. Re-positioning for ${WG_IFACE}..."
@@ -794,25 +932,49 @@ rules_are_synced() {
     # We match the config-defined VPNPort on the tunnel interface to catch these packets.
     local internal_match_port="${FORWARDING_PORT}"
 
-    if [[ "${K3S_MODE}" == "true" ]]; then
-        # 1. fwmark policy routing rule
-        if ! ip rule show | grep -qE "fwmark 0x[cC][aA]6[cC].*lookup 51820"; then
-            log WARN "rules_are_synced: k3s fwmark rule FAIL"
-            return 1
-        fi
+    if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
+        if [[ "${SECURE_MODE}" == "true" ]]; then
+            # Discover target's bridge network subnet dynamically
+            local route_info dev_iface subnet
+            route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
+            dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+            if [ -n "${dev_iface}" ]; then
+                subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+            fi
+            if [ -n "${subnet}" ]; then
+                subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
+            else
+                subnet="10.21.0.0/16"
+            fi
 
-        # 1b. mangle CONNMARK restore rule
-        if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-            -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
-            log WARN "rules_are_synced: k3s mangle conn-restore FAIL (missing or wrong form)"
-            return 1
-        fi
+            if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
+                log WARN "rules_are_synced: SecureMode local bypass rule FAIL"
+                return 1
+            fi
+            if ! ip rule show | grep -F "from ${DOCKER_TARGET_IP}" | grep -q "lookup 51820"; then
+                log WARN "rules_are_synced: SecureMode policy routing rule FAIL"
+                return 1
+            fi
+        else
+            # 1. fwmark policy routing rule
+            if ! ip rule show | grep -qE "fwmark 0x[cC][aA]6[cC].*lookup 51820"; then
+                log WARN "rules_are_synced: k3s fwmark rule FAIL"
+                return 1
+            fi
 
-        # 1c. mangle CONNMARK set rule
-        if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-            -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
-            log WARN "rules_are_synced: k3s mangle conn-save FAIL (missing or wrong form)"
-            return 1
+            # 1b. mangle CONNMARK restore rule
+            if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
+                log WARN "rules_are_synced: k3s mangle conn-restore FAIL (missing or wrong form)"
+                return 1
+            fi
+
+            # 1c. mangle CONNMARK set rule
+            if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
+                log WARN "rules_are_synced: k3s mangle conn-save FAIL (missing or wrong form)"
+                return 1
+            fi
         fi
 
         # 2. NAT PREROUTING check (DNAT)
@@ -822,24 +984,24 @@ rules_are_synced() {
             return 1
         fi
 
-        # 2b. NAT PREROUTING fallback check for translated 9735 traffic (k3s)
+        # 2b. NAT PREROUTING fallback check for translated 9735 traffic
         if [ "${internal_match_port}" != "9735" ] && ! iptables -t nat -C PREROUTING -i "${WG_IFACE}" -p tcp --dport 9735 \
             -m comment --comment "tunnelsats-dnat" -j DNAT --to-destination "${DOCKER_TARGET_IP}:${LN_TARGET_PORT}" 2>/dev/null; then
             log WARN "rules_are_synced: NAT fallback rule FAIL"
             return 1
         fi
 
-        # 3. FORWARD Inbound check (scoped to target pod IP)
+        # 3. FORWARD Inbound check (scoped to target IP)
         if ! iptables -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
             -m comment --comment "tunnelsats-forward-in" -j ACCEPT 2>/dev/null; then
-            log WARN "rules_are_synced: k3s FORWARD in FAIL"
+            log WARN "rules_are_synced: FORWARD in FAIL"
             return 1
         fi
 
-        # 4. FORWARD Outbound check (scoped to target pod IP)
+        # 4. FORWARD Outbound check (scoped to target IP)
         if ! iptables -C FORWARD -s "${DOCKER_TARGET_IP}" -o "${WG_IFACE}" \
             -m comment --comment "tunnelsats-forward-out" -j ACCEPT 2>/dev/null; then
-            log WARN "rules_are_synced: k3s FORWARD out FAIL"
+            log WARN "rules_are_synced: FORWARD out FAIL"
             return 1
         fi
 
@@ -923,14 +1085,32 @@ cleanup_dataplane() {
     local max_attempts=10
     local attempt=0
 
-    if [[ "${K3S_MODE}" == "true" ]]; then
-        ip rule del fwmark 51820 table 51820 pref 32764 >/dev/null 2>&1 || true
-        # Also remove any legacy IP-source rules from older deployments.
-        ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
-        ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
-        remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
-        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
-        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
+    if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
+        if [[ "${SECURE_MODE}" == "true" ]]; then
+            # Discover target's bridge network subnet dynamically
+            local route_info dev_iface subnet
+            route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
+            dev_iface=$(echo "${route_info}" | grep -oP 'dev \K\S+' || true)
+            if [ -n "${dev_iface}" ]; then
+                subnet=$(ip addr show dev "${dev_iface}" | grep -oP 'inet \K\S+' | head -n1 || true)
+            fi
+            if [ -n "${subnet}" ]; then
+                subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
+            else
+                subnet="10.21.0.0/16"
+            fi
+            
+            ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
+            ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+        else
+            ip rule del fwmark 51820 table 51820 pref 32764 >/dev/null 2>&1 || true
+            # Also remove any legacy IP-source rules from older deployments.
+            ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
+            ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+            remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
+            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
+            remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
+        fi
     else
         # Remove local bypass rule (pref 32500)
         ip rule del from "${DOCKER_NETWORK_SUBNET}" to "${DOCKER_NETWORK_SUBNET}" table main pref 32500 >/dev/null 2>&1 || true
@@ -1001,7 +1181,7 @@ reconcile_once() {
 
     log INFO "reconcile_start reason=${reason}"
 
-    if [[ "${K3S_MODE}" != "true" ]] && [ ! -S "${DOCKER_SOCK}" ]; then
+    if [[ "${K3S_MODE}" != "true" ]] && [[ "${SECURE_MODE}" != "true" ]] && [ ! -S "${DOCKER_SOCK}" ]; then
         LAST_ERROR="Docker socket unavailable"
         write_state
         if [ -n "${request_id}" ]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1048,18 +1048,21 @@ cleanup_dataplane() {
     local attempt=0
 
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
-        if [[ "${SECURE_MODE}" == "true" ]] && [ -n "${DOCKER_TARGET_IP:-}" ]; then
-            # Discover target's bridge network subnet dynamically
-            local subnet
-            subnet=$(get_target_subnet)
-            
-            ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
-            ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+        if [[ "${SECURE_MODE}" == "true" ]]; then
+            for cleanup_ip in "${DOCKER_TARGET_IP:-}" "10.21.21.9" "10.21.21.96"; do
+                [ -n "${cleanup_ip}" ] || continue
+                local cleanup_subnet
+                cleanup_subnet=$(get_target_subnet "${cleanup_ip}")
+                ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
+                ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
+            done
         else
             ip rule del fwmark 51820 table 51820 pref 32764 >/dev/null 2>&1 || true
             # Also remove any legacy IP-source rules from older deployments.
-            ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
-            ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+            if [ -n "${DOCKER_TARGET_IP:-}" ]; then
+                ip rule del from "${DOCKER_TARGET_IP}" to "${DOCKER_TARGET_IP}" table main pref 32500 >/dev/null 2>&1 || true
+                ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
+            fi
         fi
     else
         # Remove local bypass rule (pref 32500)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -673,7 +673,7 @@ ensure_policy_routing() {
         if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
             ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1; then
-                if ! ip rule show pref 32500 | grep -q "from ${DOCKER_TARGET_IP}"; then
+                if ! ip rule show pref 32500 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
                     LAST_ERROR="SecureMode: Failed to add local bypass rule"
                     return 1
                 fi
@@ -685,7 +685,7 @@ ensure_policy_routing() {
         if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+lookup[[:space:]]+51820[[:space:]]*$"; then
             ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1; then
-                if ! ip rule show pref 32764 | grep -q "from ${DOCKER_TARGET_IP}"; then
+                if ! ip rule show pref 32764 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
                     LAST_ERROR="SecureMode: Failed to add policy routing rule"
                     return 1
                 fi
@@ -951,7 +951,7 @@ rules_are_synced() {
                 log WARN "rules_are_synced: SecureMode local bypass rule FAIL"
                 return 1
             fi
-            if ! ip rule show | grep -F "from ${DOCKER_TARGET_IP}" | grep -q "lookup 51820"; then
+            if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+lookup[[:space:]]+51820"; then
                 log WARN "rules_are_synced: SecureMode policy routing rule FAIL"
                 return 1
             fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -625,8 +625,20 @@ ensure_policy_routing() {
         local subnet
         subnet=$(get_target_subnet)
         
+        # 1b. Sweep stale source-IP rules for the other possible node IP to prevent route leakage
+        local other_ip
+        if [ "${DOCKER_TARGET_IP}" = "10.21.21.9" ]; then
+            other_ip="10.21.21.96"
+        else
+            other_ip="10.21.21.9"
+        fi
+        local other_subnet
+        other_subnet=$(get_target_subnet "${other_ip}")
+        ip rule del from "${other_ip}" to "${other_subnet}" table main pref 32500 >/dev/null 2>&1 || true
+        ip rule del from "${other_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
+
         # 2. Local-to-Local bypass rule (so LND can talk to local Bitcoind/Tor on 10.21.x.x)
-        if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
+        if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+to[[:space:]]+${subnet//./\\.}[[:space:]]+(lookup|table)[[:space:]]+main"; then
             ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1; then
                 if ! ip rule show pref 32500 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
@@ -638,7 +650,7 @@ ensure_policy_routing() {
         fi
         
         # 3. Route external traffic through the VPN table 51820
-        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+lookup[[:space:]]+51820[[:space:]]*$"; then
+        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+(lookup|table)[[:space:]]+51820[[:space:]]*$"; then
             ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1; then
                 if ! ip rule show pref 32764 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
@@ -905,17 +917,17 @@ rules_are_synced() {
             local subnet
             subnet=$(get_target_subnet)
 
-            if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
+            if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+to[[:space:]]+${subnet//./\\.}[[:space:]]+(lookup|table)[[:space:]]+main"; then
                 log WARN "rules_are_synced: SecureMode local bypass rule FAIL"
                 return 1
             fi
-            if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+lookup[[:space:]]+51820"; then
+            if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+(lookup|table)[[:space:]]+51820"; then
                 log WARN "rules_are_synced: SecureMode policy routing rule FAIL"
                 return 1
             fi
         else
             # 1. fwmark policy routing rule
-            if ! ip rule show | grep -qE "fwmark 0x[cC][aA]6[cC].*lookup 51820"; then
+            if ! ip rule show | grep -qE "fwmark 0x[cC][aA]6[cC].*(lookup|table)[[:space:]]+51820"; then
                 log WARN "rules_are_synced: k3s fwmark rule FAIL"
                 return 1
             fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -601,6 +601,26 @@ ${rules}
 EOF_RULES
 }
 
+get_target_subnet() {
+    local target_ip="${1:-${DOCKER_TARGET_IP:-}}"
+    if [ -z "${target_ip}" ]; then
+        echo "10.21.0.0/16"
+        return
+    fi
+    local route_info dev_iface subnet
+    route_info=$(ip route get "${target_ip}" 2>/dev/null || true)
+    dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
+    if [ -n "${dev_iface}" ]; then
+        subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
+    fi
+    if [ -n "${subnet}" ]; then
+        subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
+    else
+        subnet="10.21.0.0/16"
+    fi
+    echo "${subnet}"
+}
+
 ensure_policy_routing() {
     local changed=0
     POLICY_CHANGED="0"
@@ -646,17 +666,8 @@ ensure_policy_routing() {
     elif [[ "${SECURE_MODE}" == "true" ]]; then
         # Secure Mode: Direct IP policy routing
         # 1. Discover target's bridge network subnet dynamically
-        local route_info dev_iface subnet
-        route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-        dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
-        if [ -n "${dev_iface}" ]; then
-            subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
-        fi
-        if [ -n "${subnet}" ]; then
-            subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
-        else
-            subnet="10.21.0.0/16"
-        fi
+        local subnet
+        subnet=$(get_target_subnet)
         
         # 2. Local-to-Local bypass rule (so LND can talk to local Bitcoind/Tor on 10.21.x.x)
         if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
@@ -935,17 +946,8 @@ rules_are_synced() {
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
         if [[ "${SECURE_MODE}" == "true" ]]; then
             # Discover target's bridge network subnet dynamically
-            local route_info dev_iface subnet
-            route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-            dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
-            if [ -n "${dev_iface}" ]; then
-                subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
-            fi
-            if [ -n "${subnet}" ]; then
-                subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
-            else
-                subnet="10.21.0.0/16"
-            fi
+            local subnet
+            subnet=$(get_target_subnet)
 
             if ! ip rule show | grep -qF "from ${DOCKER_TARGET_IP} to ${subnet} lookup main"; then
                 log WARN "rules_are_synced: SecureMode local bypass rule FAIL"
@@ -1092,17 +1094,8 @@ cleanup_dataplane() {
 
         if [[ "${SECURE_MODE}" == "true" ]] && [ -n "${DOCKER_TARGET_IP:-}" ]; then
             # Discover target's bridge network subnet dynamically
-            local route_info dev_iface subnet
-            route_info=$(ip route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
-            dev_iface=$(echo "${route_info}" | awk '{for(i=1;i<=NF;i++) if($i=="dev") print $(i+1)}' || true)
-            if [ -n "${dev_iface}" ]; then
-                subnet=$(ip addr show dev "${dev_iface}" | awk '$1 == "inet" {print $2; exit}' || true)
-            fi
-            if [ -n "${subnet}" ]; then
-                subnet=$(python3 -c "import sys, ipaddress; print(ipaddress.IPv4Network(sys.stdin.read().strip(), strict=False))" 2>/dev/null <<< "${subnet}" || echo "10.21.0.0/16")
-            else
-                subnet="10.21.0.0/16"
-            fi
+            local subnet
+            subnet=$(get_target_subnet)
             
             ip rule del from "${DOCKER_TARGET_IP}" to "${subnet}" table main pref 32500 >/dev/null 2>&1 || true
             ip rule del from "${DOCKER_TARGET_IP}" table 51820 pref 32764 >/dev/null 2>&1 || true

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -919,20 +919,21 @@ rules_are_synced() {
                 log WARN "rules_are_synced: k3s fwmark rule FAIL"
                 return 1
             fi
+        fi
 
-            # 1b. mangle CONNMARK restore rule
-            if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
-                log WARN "rules_are_synced: k3s mangle conn-restore FAIL (missing or wrong form)"
-                return 1
-            fi
+        # Both K3S_MODE and SECURE_MODE use conntrack mangle rules
+        # 1b. mangle CONNMARK restore rule
+        if ! iptables -t mangle -C PREROUTING ! -i "${WG_IFACE}" -s "${DOCKER_TARGET_IP}" \
+            -m comment --comment "tunnelsats-conn-restore" -j CONNMARK --restore-mark --mask 0xca6c 2>/dev/null; then
+            log WARN "rules_are_synced: mangle conn-restore FAIL (missing or wrong form)"
+            return 1
+        fi
 
-            # 1c. mangle CONNMARK set rule
-            if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
-                -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
-                log WARN "rules_are_synced: k3s mangle conn-save FAIL (missing or wrong form)"
-                return 1
-            fi
+        # 1c. mangle CONNMARK set rule
+        if ! iptables -t mangle -C FORWARD -i "${WG_IFACE}" -d "${DOCKER_TARGET_IP}" \
+            -m comment --comment "tunnelsats-conn-save" -j CONNMARK --set-mark 0xca6c/0xca6c 2>/dev/null; then
+            log WARN "rules_are_synced: mangle conn-save FAIL (missing or wrong form)"
+            return 1
         fi
 
         # 2. NAT PREROUTING check (DNAT)
@@ -1039,15 +1040,14 @@ cleanup_dataplane() {
     remove_tagged_iptables_rules nat POSTROUTING "tunnelsats-masq"
     remove_tagged_iptables_rules filter FORWARD "tunnelsats-forward-in"
     remove_tagged_iptables_rules filter FORWARD "tunnelsats-forward-out"
+    remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
+    remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
+    remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
 
     local max_attempts=10
     local attempt=0
 
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
-        remove_tagged_iptables_rules mangle PREROUTING "tunnelsats-conn-restore"
-        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-wg-mark"
-        remove_tagged_iptables_rules mangle FORWARD "tunnelsats-conn-save"
-
         if [[ "${SECURE_MODE}" == "true" ]] && [ -n "${DOCKER_TARGET_IP:-}" ]; then
             # Discover target's bridge network subnet dynamically
             local subnet
@@ -1142,6 +1142,7 @@ reconcile_once() {
 
     if ! detect_lightning_container; then
         LAST_ERROR="${LAST_ERROR:-No running LND/CLN container detected}"
+        cleanup_dataplane
         write_state
         if [ -n "${request_id}" ]; then
             write_reconcile_result "${request_id}" false

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -84,10 +84,9 @@ run_node() {
 
     # 3. Recreate → Inject → Restart (the deploy.py pattern)
     log_info "Injecting (rm → up → cp → restart)..."
-    ${SSH_PREFIX}ssh -o StrictHostKeyChecking=accept-new -T umbrel@${UMBREL_HOST} bash -s "${SSHPASS}" << 'EOF'
-SSHPASS="$1"
-export SSHPASS
-
+    (
+        echo "SSHPASS=\"${SSHPASS}\""
+        cat << 'EOF'
 APP_ID="tunnelsats"
 UMBREL_APP_DATA="/home/umbrel/umbrel/app-data/tunnelsats"
 UMBREL_COMPOSE="${UMBREL_APP_DATA}/docker-compose.yml"
@@ -115,6 +114,7 @@ run_sudo docker cp /home/umbrel/dev-patch/tunnelsats/umbrel-app.yml "${APP_ID}":
 run_sudo docker exec "${APP_ID}" chmod +x /app/scripts/entrypoint.sh /app/scripts/sync.sh 2>/dev/null
 run_sudo docker restart "${APP_ID}"
 EOF
+    ) | ${SSH_PREFIX}ssh -o StrictHostKeyChecking=accept-new -T umbrel@${UMBREL_HOST} bash
 
     log_info "Deploy successful! tunnelsats hot-patched on ${UMBREL_HOST}."
 }

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -302,8 +302,8 @@ run_promote() {
 
     log_info "Pinning image digest and setting SECURE_MODE default to true in docker-compose.yml..."
     local target_compose="${target_dir}/docker-compose.yml"
-    sed -E -e "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
-           -e "s/SECURE_MODE=\\\$\{SECURE_MODE:-false\}/SECURE_MODE=\\\$\{SECURE_MODE:-true\}/" \
+    sed -E -e "s#(ts-umbrel-app:)v?[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
+           -e "s/SECURE_MODE=.*/SECURE_MODE=\\\${SECURE_MODE:-true}/" \
            -e "/# Host socket/d" \
            -e "/\/var\/run\/docker.sock/d" \
            "${target_compose}" > "${target_compose}.tmp" && mv "${target_compose}.tmp" "${target_compose}"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -94,7 +94,7 @@ UMBREL_COMPOSE="${UMBREL_APP_DATA}/docker-compose.yml"
 
 run_sudo() {
     if [ -n "${SSHPASS}" ]; then
-        echo "${SSHPASS}" | sudo -S "$@"
+        printf '%s\n' "${SSHPASS}" | sudo -S "$@"
     else
         sudo "$@"
     fi

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -84,17 +84,37 @@ run_node() {
 
     # 3. Recreate → Inject → Restart (the deploy.py pattern)
     log_info "Injecting (rm → up → cp → restart)..."
-    REMOTE_CMD="docker rm -f ${APP_ID} 2>/dev/null || true && \
-                APP_DATA_DIR=${UMBREL_APP_DATA} docker compose -f ${UMBREL_COMPOSE} up -d && \
-                for i in \$(seq 1 10); do [ \"\$(docker inspect -f '{{.State.Running}}' ${APP_ID} 2>/dev/null)\" = \"true\" ] && break; sleep 1; done && \
-                docker cp /home/umbrel/dev-patch/server/. ${APP_ID}:/app/server/ && \
-                docker cp /home/umbrel/dev-patch/web/. ${APP_ID}:/app/web/ && \
-                docker cp /home/umbrel/dev-patch/scripts/. ${APP_ID}:/app/scripts/ && \
-                docker cp /home/umbrel/dev-patch/tunnelsats/umbrel-app.yml ${APP_ID}:/app/umbrel-app.yml && \
-                docker exec ${APP_ID} chmod +x /app/scripts/entrypoint.sh /app/scripts/sync.sh 2>/dev/null; \
-                docker restart ${APP_ID}"
+    ${SSH_PREFIX}ssh -o StrictHostKeyChecking=accept-new -T umbrel@${UMBREL_HOST} bash -s "${SSHPASS}" << 'EOF'
+SSHPASS="$1"
+export SSHPASS
 
-    ${SSH_PREFIX}ssh -o StrictHostKeyChecking=accept-new umbrel@${UMBREL_HOST} "${REMOTE_CMD}"
+APP_ID="tunnelsats"
+UMBREL_APP_DATA="/home/umbrel/umbrel/app-data/tunnelsats"
+UMBREL_COMPOSE="${UMBREL_APP_DATA}/docker-compose.yml"
+
+run_sudo() {
+    if [ -n "${SSHPASS}" ]; then
+        echo "${SSHPASS}" | sudo -S "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+run_sudo docker rm -f "${APP_ID}" 2>/dev/null || true
+run_sudo env APP_DATA_DIR="${UMBREL_APP_DATA}" docker compose -f "${UMBREL_COMPOSE}" up -d
+for i in $(seq 1 10); do
+    if [ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_ID}" 2>/dev/null)" = "true" ]; then
+        break
+    fi
+    sleep 1
+done
+run_sudo docker cp /home/umbrel/dev-patch/server/. "${APP_ID}":/app/server/
+run_sudo docker cp /home/umbrel/dev-patch/web/. "${APP_ID}":/app/web/
+run_sudo docker cp /home/umbrel/dev-patch/scripts/. "${APP_ID}":/app/scripts/
+run_sudo docker cp /home/umbrel/dev-patch/tunnelsats/umbrel-app.yml "${APP_ID}":/app/umbrel-app.yml
+run_sudo docker exec "${APP_ID}" chmod +x /app/scripts/entrypoint.sh /app/scripts/sync.sh 2>/dev/null
+run_sudo docker restart "${APP_ID}"
+EOF
 
     log_info "Deploy successful! tunnelsats hot-patched on ${UMBREL_HOST}."
 }
@@ -243,7 +263,11 @@ run_version() {
 }
 
 run_promote() {
+    local dry_run="${1:-false}"
     log_info "Starting Release Promotion..."
+    if [ "${dry_run}" = "true" ]; then
+        log_info "[DRY RUN] Previewing changes without writing to target..."
+    fi
 
     VERSION="${VERSION:-$(grep "^version: " "${REPO_ROOT}/tunnelsats/umbrel-app.yml" | sed -E 's/version: "?([^" ]+)"?.*/\1/' | head -1)}"
     if [ -z "$VERSION" ]; then log_error "Could not extract version"; return 1; fi
@@ -260,44 +284,71 @@ run_promote() {
     log_info "Discovered Digest: ${DIGEST}"
 
     UMBREL_APPS_DIR="${UMBREL_APPS_DIR:-${REPO_ROOT}/../umbrel-apps}"
-    if [ ! -d "$UMBREL_APPS_DIR" ]; then
+    if [ ! -d "$UMBREL_APPS_DIR" ] && [ "${dry_run}" = "false" ]; then
         log_error "Umbrel Apps store repo not found at ${UMBREL_APPS_DIR}. Set UMBREL_APPS_DIR manually."
         return 1
     fi
 
-    log_info "Synchronizing to official monorepo at ${UMBREL_APPS_DIR}..."
-    rsync -av --delete --exclude=".gitkeep" "${REPO_ROOT}/tunnelsats/" "${UMBREL_APPS_DIR}/tunnelsats/"
+    local target_dir="${UMBREL_APPS_DIR}/tunnelsats"
+    if [ "${dry_run}" = "true" ]; then
+        target_dir="/tmp/tunnelsats_promote_dry_run"
+        rm -rf "${target_dir}"
+        mkdir -p "${target_dir}"
+        rsync -a --exclude=".gitkeep" "${REPO_ROOT}/tunnelsats/" "${target_dir}/"
+    else
+        log_info "Synchronizing to official monorepo at ${UMBREL_APPS_DIR}..."
+        rsync -av --delete --exclude=".gitkeep" "${REPO_ROOT}/tunnelsats/" "${UMBREL_APPS_DIR}/tunnelsats/"
+    fi
 
-    log_info "Pinning image digest in monorepo docker-compose.yml..."
-    TARGET_COMPOSE="${UMBREL_APPS_DIR}/tunnelsats/docker-compose.yml"
-    sed -E "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" "${TARGET_COMPOSE}" > "${TARGET_COMPOSE}.tmp" && mv "${TARGET_COMPOSE}.tmp" "${TARGET_COMPOSE}"
-    log_info "Monorepo docker-compose.yml pinned to ${VERSION#v}@${DIGEST}."
+    log_info "Pinning image digest and setting SECURE_MODE default to true in docker-compose.yml..."
+    local target_compose="${target_dir}/docker-compose.yml"
+    sed -E -e "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
+           -e "s/SECURE_MODE=\\\$\{SECURE_MODE:-false\}/SECURE_MODE=\\\$\{SECURE_MODE:-true\}/" \
+           -e "/# Host socket/d" \
+           -e "/\/var\/run\/docker.sock/d" \
+           "${target_compose}" > "${target_compose}.tmp" && mv "${target_compose}.tmp" "${target_compose}"
 
-    TARGET_MANIFEST="${UMBREL_APPS_DIR}/tunnelsats/umbrel-app.yml"
+    local target_manifest="${target_dir}/umbrel-app.yml"
 
     # Strip raw GitHub URLs for monorepo (assets are local)
-    sed -E "s@https://raw.githubusercontent.com/Tunnelsats/ts-umbrel-app/(master|main)/tunnelsats/@@g" "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
+    sed -E "s@https://raw.githubusercontent.com/Tunnelsats/ts-umbrel-app/(master|main)/tunnelsats/@@g" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
     # Remove trailing period from tagline
-    sed -E 's/^(tagline:.*)\.$/\1/' "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
+    sed -E 's/^(tagline:.*)\.$/\1/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
     # Inject submitter and submission PR URL (if provided)
-    if grep -qE "^submitter:" "${TARGET_MANIFEST}"; then
+    if grep -qE "^submitter:" "${target_manifest}"; then
         log_info "submitter/submission already present, skipping injection."
     elif [ -n "${SUBMISSION_URL:-}" ]; then
-        sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${SUBMISSION_URL}@" "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
+        sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${SUBMISSION_URL}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     fi
 
     # Clear releaseNotes
     sed -e '/^releaseNotes:/,/^developer:/ { /^releaseNotes:/! { /^developer:/! d } }' \
-        -e 's/^releaseNotes:.*/releaseNotes: ""/' "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
+        -e 's/^releaseNotes:.*/releaseNotes: ""/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
     # Clear icon and gallery for monorepo submission
     sed -e 's/^icon:.*/icon: ""/' \
         -e '/^gallery:/,/^path:/ { /^gallery:/! { /^path:/! d } }' \
-        -e 's/^gallery:.*/gallery: []/' "${TARGET_MANIFEST}" > "${TARGET_MANIFEST}.tmp" && mv "${TARGET_MANIFEST}.tmp" "${TARGET_MANIFEST}"
+        -e 's/^gallery:.*/gallery: []/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
-    log_info "Promotion complete. Commit changes in ${UMBREL_APPS_DIR}."
+    if [ "${dry_run}" = "true" ]; then
+        log_info "Monorepo files generated in temporary dry-run directory: ${target_dir}."
+        if [ -d "${UMBREL_APPS_DIR}/tunnelsats" ]; then
+            log_info "Comparing against existing files at ${UMBREL_APPS_DIR}/tunnelsats..."
+            diff -urN "${UMBREL_APPS_DIR}/tunnelsats" "${target_dir}" || true
+        else
+            log_info "Target directory ${UMBREL_APPS_DIR}/tunnelsats does not exist yet. Showing preview of generated files:"
+            log_info "--- docker-compose.yml ---"
+            cat "${target_compose}"
+            log_info "--- umbrel-app.yml ---"
+            cat "${target_manifest}"
+        fi
+        rm -rf "${target_dir}"
+        log_info "[DRY RUN] Complete."
+    else
+        log_info "Promotion complete. Commit changes in ${UMBREL_APPS_DIR}."
+    fi
 }
 
 if [ "$#" -lt 1 ]; then usage; fi
@@ -307,6 +358,13 @@ case "${1}" in
     monorepo) run_monorepo ;;
     vendor) shift; run_vendor "$@" ;;
     version) shift; run_version "$@" ;;
-    promote) run_promote ;;
+    promote)
+        shift
+        dry_run=false
+        if [ "${1:-}" = "--dry-run" ]; then
+            dry_run=true
+        fi
+        run_promote "${dry_run}"
+        ;;
     *) usage ;;
 esac

--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import socket
 import subprocess
 import uuid
 import threading
@@ -96,15 +97,132 @@ RECONCILE_RESULT_LEGACY = "/tmp/tunnelsats_reconcile_result.json"
 REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 LND_CONFIG_PATH = "/lightning-data/lnd/lnd.conf"
 CLN_CONFIG_PATH = "/lightning-data/cln/config"
+LND_HOST_CONFIG_PATH = "/home/umbrel/umbrel/app-data/lightning/data/lnd/lnd.conf"
+LND_PROBE_IP = "10.21.21.9"
+LND_PROBE_PORT = 9735
+CLN_PROBE_IP = "10.21.21.96"
+CLN_PROBE_PORT = 9736
 LND_RESTART_DELAY = 3  # Seconds to wait for middleware to generate umbrel-lnd.conf
 LND_CONTAINER_PATTERN = r"^lightning[_-]lnd[_-]\d+$"
 LND_MIDDLEWARE_PATTERN = r"^lightning[_-]app[_-]\d+$"
-CLN_CONTAINER_PATTERN = r"(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)"
+CLN_CONTAINER_PATTERN = r"(^|[_-])(core-lightning|clightning|lightningd|cln)([_-]|$)"
 WG_INTERFACE_NAME = "tunnelsatsv2"
 WG_HANDSHAKE_MAX_AGE_SECONDS = 180
 
 # k3s mode: set via env var K3S_MODE=true to use the Kubernetes API instead of the Docker socket
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
+SECURE_MODE = os.environ.get("SECURE_MODE", "false").lower() == "true"
+
+def check_tcp_port(ip, port):
+    try:
+        with socket.create_connection((ip, port), timeout=1.0):
+            return True
+    except (socket.timeout, OSError):
+        return False
+
+_PROBE_CACHE_TTL_SECONDS = 5
+_probe_cache = {}
+_probe_cache_lock = threading.Lock()
+_in_flight_probes = {}
+_in_flight_lock = threading.Lock()
+
+def check_tcp_port_cached(ip, port):
+    key = f"{ip}:{port}"
+    with _probe_cache_lock:
+        entry = _probe_cache.get(key)
+        if entry is not None:
+            ts, val = entry
+            if time.time() - ts <= _PROBE_CACHE_TTL_SECONDS:
+                return val
+
+    initiator = False
+    with _in_flight_lock:
+        if key in _in_flight_probes:
+            event = _in_flight_probes[key]
+        else:
+            # Re-check cache inside lock to prevent TOCTOU window
+            with _probe_cache_lock:
+                entry = _probe_cache.get(key)
+                if entry is not None:
+                    ts, val = entry
+                    if time.time() - ts <= _PROBE_CACHE_TTL_SECONDS:
+                        return val
+            event = threading.Event()
+            _in_flight_probes[key] = event
+            initiator = True
+
+    if not initiator:
+        if event.wait(timeout=3.0):
+            with _probe_cache_lock:
+                entry = _probe_cache.get(key)
+                if entry is not None:
+                    return entry[1]
+        # Fallback to direct check if timeout or cache is empty
+        return check_tcp_port(ip, port)
+
+    val = False
+    try:
+        val = check_tcp_port(ip, port)
+        with _probe_cache_lock:
+            _probe_cache[key] = (time.time(), val)
+    finally:
+        with _in_flight_lock:
+            finished_event = _in_flight_probes.pop(key, None)
+            if finished_event is not None:
+                finished_event.set()
+
+    return val
+
+def detect_cln_network():
+    """Detect the active CLN network by checking subdirectories in /lightning-data/cln/."""
+    networks = ["bitcoin", "testnet", "signet", "regtest"]
+    active_net = "bitcoin"
+    latest_mtime = 0.0
+
+    for net in networks:
+        db_path = f"/lightning-data/cln/{net}/lightningd.sqlite3"
+        if os.path.exists(db_path):
+            try:
+                mtime = os.path.getmtime(db_path)
+                if mtime > latest_mtime:
+                    latest_mtime = mtime
+                    active_net = net
+            except Exception:
+                pass
+
+    # If no sqlite database was found, fall back to checking config file presence using mtime recency
+    if latest_mtime == 0.0:
+        latest_config_mtime = 0.0
+        for net in networks:
+            config_path = f"/lightning-data/cln/{net}/config"
+            try:
+                mtime = os.path.getmtime(config_path)
+                if mtime > latest_config_mtime:
+                    latest_config_mtime = mtime
+                    active_net = net
+            except Exception:
+                pass
+
+    return active_net
+
+
+def resolve_node_config(node_type):
+    """Return (config_path_container, config_path_host) for LND or CLN."""
+    if node_type == "lnd":
+        return LND_CONFIG_PATH, LND_HOST_CONFIG_PATH
+    elif node_type == "cln":
+        net = detect_cln_network()
+        container_path = f"/lightning-data/cln/{net}/config"
+        # Test-only sentinel: when CLN_CONFIG_PATH is patched to a temp file by a test,
+        # use that path as the container path so file-presence assertions resolve correctly.
+        # NOTE: host_path is still derived from detect_cln_network(); patch detect_cln_network
+        # too if the test needs a consistent (container_path, host_path) pair.
+        if CLN_CONFIG_PATH != "/lightning-data/cln/config":
+            container_path = CLN_CONFIG_PATH
+        host_path = f"/home/umbrel/umbrel/app-data/core-lightning/data/lightningd/{net}/config"
+        return container_path, host_path
+    return None, None
+
 K8S_NAMESPACE = os.environ.get("K8S_NAMESPACE", "default")
 LND_K8S_NAMESPACE = os.environ.get("LND_K8S_NAMESPACE", K8S_NAMESPACE)
 CLN_K8S_NAMESPACE = os.environ.get("CLN_K8S_NAMESPACE", K8S_NAMESPACE)
@@ -338,7 +456,7 @@ def upsert_config_line(path: str, prefix: str, replacement_line: str) -> Tuple[b
     normalized_line = f"{replacement_line}\n"
 
     for line in lines:
-        line_str = str(line)
+        line_str = line
         stripped = line_str.lstrip()
         candidate = stripped.removeprefix("#").lstrip()
         if candidate.startswith(prefix):
@@ -521,7 +639,7 @@ def upsert_config_line_in_section(path: str, section_header: str, prefix: str, r
         found = False
         updated_section: List[str] = []
         for line in lines[section_start + 1 : section_end]:
-            line_str = str(line)
+            line_str = line
             stripped: str = line_str.lstrip()
             candidate: str = stripped.removeprefix("#").lstrip()
             if candidate.startswith(prefix):
@@ -533,7 +651,7 @@ def upsert_config_line_in_section(path: str, section_header: str, prefix: str, r
                 else:
                     changed = True
                 continue
-            updated_section.append(str(line))
+            updated_section.append(line)
 
         if not found:
             updated_section.append(normalized_line)
@@ -975,6 +1093,25 @@ def list_containers():
     """Return the running container/pod list for the active mode."""
     if K3S_MODE:
         return k8s_list_pods()
+    if SECURE_MODE:
+        containers = []
+        # Note: Falling back to config file existence handles a "possibly installed but down"
+        # heuristic when the active TCP port probe fails, allowing users to still trigger manual
+        # configuration/restore flows for stopped containers.
+        if check_tcp_port_cached(LND_PROBE_IP, LND_PROBE_PORT) or os.path.exists(LND_CONFIG_PATH):
+            containers.append({
+                "Names": ["/lightning_lnd_1"],
+                "Id": "lnd_probe_id",
+                "NetworkSettings": {"Networks": {"umbrel_main_network": {"IPAddress": LND_PROBE_IP}}}
+            })
+        cln_container_config, _ = resolve_node_config("cln")
+        if check_tcp_port_cached(CLN_PROBE_IP, CLN_PROBE_PORT) or (cln_container_config and os.path.exists(cln_container_config)):
+            containers.append({
+                "Names": ["/lightning_cln_1"],
+                "Id": "cln_probe_id",
+                "NetworkSettings": {"Networks": {"umbrel_main_network": {"IPAddress": CLN_PROBE_IP}}}
+            })
+        return containers
     return docker_api("/containers/json?all=0")
 
 
@@ -982,6 +1119,8 @@ def lnd_exists():
     """Return True if an LND container/pod is reachable in the current mode."""
     if K3S_MODE:
         return bool(k8s_get_pod_name(LND_K8S_POD_SELECTOR, namespace=LND_K8S_NAMESPACE))
+    if SECURE_MODE:
+        return check_tcp_port_cached(LND_PROBE_IP, LND_PROBE_PORT) or os.path.exists(LND_CONFIG_PATH)
     return bool(container_ids_by_match(LND_CONTAINER_PATTERN))
 
 
@@ -989,6 +1128,9 @@ def cln_exists():
     """Return True if a CLN container/pod is reachable in the current mode."""
     if K3S_MODE:
         return bool(k8s_get_pod_name(CLN_K8S_POD_SELECTOR, namespace=CLN_K8S_NAMESPACE))
+    if SECURE_MODE:
+        container_path, _ = resolve_node_config("cln")
+        return check_tcp_port_cached(CLN_PROBE_IP, CLN_PROBE_PORT) or (container_path and os.path.exists(container_path))
     return bool(container_ids_by_match(CLN_CONTAINER_PATTERN))
 
 
@@ -1246,12 +1388,14 @@ def proxy_request(method, endpoint, payload=None):
 
 @app.route("/")
 def serve_index():
-    return send_from_directory(app.static_folder, "index.html")
+    static_folder = app.static_folder or "web"
+    return send_from_directory(static_folder, "index.html")
 
 
 @app.route("/<path:path>")
 def serve_static(path):
-    return send_from_directory(app.static_folder, path)
+    static_folder = app.static_folder or "web"
+    return send_from_directory(static_folder, path)
 
 
 # --- API PROXY ROUTES ---
@@ -1291,7 +1435,7 @@ def _fetch_subscription_status_cached(wg_public_key: str) -> Optional[Dict[str, 
         _SUBSCRIPTION_CACHE.pop(wg_public_key, None)
     return info
 
-def _is_timestamp_expired(timestamp_str: str) -> bool:
+def _is_timestamp_expired(timestamp_str: Optional[str]) -> bool:
     """Checks if a given ISO timestamp string is in the past."""
     if not timestamp_str:
         return False
@@ -1475,13 +1619,12 @@ def _update_local_metadata(
 
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
-        if not os.path.exists(meta_path):
-            app.logger.warning(f"Metadata file not found at {meta_path}; skipping sync.")
-            return False
-
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
+        except FileNotFoundError:
+            app.logger.warning(f"Metadata file not found at {meta_path}; skipping sync.")
+            return False
         except (IOError, json.JSONDecodeError) as exc:
             app.logger.warning(f"Failed to read metadata for sync: {exc}")
             return False
@@ -1616,16 +1759,17 @@ def renew_subscription():
         payload = {}
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
-        if os.path.exists(meta_path):
-            try:
-                with open(meta_path, "r", encoding="utf-8") as fp:
-                    meta = json.load(fp)
-                    if not payload.get("serverId") and "serverId" in meta:
-                        payload["serverId"] = meta["serverId"]
-                    if not payload.get("wgPublicKey") and "wgPublicKey" in meta:
-                        payload["wgPublicKey"] = meta["wgPublicKey"]
-            except (IOError, json.JSONDecodeError) as exc:
-                app.logger.warning(f"Failed to read metadata for renew autofill: {exc}")
+        try:
+            with open(meta_path, "r", encoding="utf-8") as fp:
+                meta = json.load(fp)
+                if not payload.get("serverId") and "serverId" in meta:
+                    payload["serverId"] = meta["serverId"]
+                if not payload.get("wgPublicKey") and "wgPublicKey" in meta:
+                    payload["wgPublicKey"] = meta["wgPublicKey"]
+        except FileNotFoundError:
+            pass
+        except (IOError, json.JSONDecodeError) as exc:
+            app.logger.warning(f"Failed to read metadata for renew autofill: {exc}")
 
     app.logger.info("Initiating renewal upstream...")
     res = proxy_request("POST", "subscription/renew", payload)
@@ -1674,10 +1818,21 @@ def local_status():
             return resolved
         lnd_ip = _resolve_svc("LND_K8S_SERVICE", LND_K8S_NAMESPACE)
         cln_ip = _resolve_svc("CLN_K8S_SERVICE", CLN_K8S_NAMESPACE)
-        lnd_detected = lnd_exists()
-        cln_detected = cln_exists()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            future_lnd = executor.submit(lnd_exists)
+            future_cln = executor.submit(cln_exists)
+            lnd_detected = future_lnd.result()
+            cln_detected = future_cln.result()
+    elif SECURE_MODE:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            future_lnd = executor.submit(lnd_exists)
+            future_cln = executor.submit(cln_exists)
+            lnd_detected = future_lnd.result()
+            cln_detected = future_cln.result()
+        lnd_ip = LND_PROBE_IP if lnd_detected else ""
+        cln_ip = CLN_PROBE_IP if cln_detected else ""
     else:
-        containers = docker_api("/containers/json?all=0") or []
+        containers = list_containers() or []
         lnd_ip = container_ip_by_match(LND_CONTAINER_PATTERN, containers=containers)
         cln_ip = container_ip_by_match(CLN_CONTAINER_PATTERN, containers=containers)
         lnd_detected = bool(container_ids_by_match(LND_CONTAINER_PATTERN, containers=containers))
@@ -1687,24 +1842,28 @@ def local_status():
     vpn_active = (wg_status == "Connected")
 
     lnd_routing_active = False
-    if os.path.exists(LND_CONFIG_PATH):
-        try:
-            with open(LND_CONFIG_PATH, "r", encoding="utf-8") as f:
-                for line in f:
-                    if line.lstrip().startswith("externalhosts="):
-                        lnd_routing_active = True
-                        break
-        except (IOError, OSError) as exc:
-            app.logger.warning(f"Failed to read LND config for routing detection: {exc}")
+    try:
+        with open(LND_CONFIG_PATH, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.lstrip().startswith("externalhosts="):
+                    lnd_routing_active = True
+                    break
+    except FileNotFoundError:
+        pass
+    except (IOError, OSError) as exc:
+        app.logger.warning(f"Failed to read LND config for routing detection: {exc}")
 
     cln_routing_active = False
-    if os.path.exists(CLN_CONFIG_PATH):
+    cln_container_config, _ = resolve_node_config("cln")
+    if cln_container_config:
         try:
-            with open(CLN_CONFIG_PATH, "r", encoding="utf-8") as f:
+            with open(cln_container_config, "r", encoding="utf-8") as f:
                 for line in f:
                     if line.lstrip().startswith("announce-addr="):
                         cln_routing_active = True
                         break
+        except FileNotFoundError:
+            pass
         except (IOError, OSError) as exc:
             app.logger.warning(f"Failed to read CLN config for routing detection: {exc}")
 
@@ -1727,16 +1886,16 @@ def local_status():
     vpn_port = ""
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
-        if os.path.exists(meta_path):
-            try:
-                with open(meta_path, "r", encoding="utf-8") as fp:
-                    meta = json.load(fp)
-                    server_domain = meta.get("serverDomain", "")
-                    expires_at = meta.get("expiresAt", "")
-                    vpn_port = meta.get("vpnPort", "")
-            except (IOError, OSError, json.JSONDecodeError) as exc:
-                app.logger.warning(f"Failed to read or parse metadata file {meta_path}: {exc}")
-                pass
+        try:
+            with open(meta_path, "r", encoding="utf-8") as fp:
+                meta = json.load(fp)
+                server_domain = meta.get("serverDomain", "")
+                expires_at = meta.get("expiresAt", "")
+                vpn_port = meta.get("vpnPort", "")
+        except FileNotFoundError:
+            pass
+        except (IOError, OSError, json.JSONDecodeError) as exc:
+            app.logger.warning(f"Failed to read or parse metadata file {meta_path}: {exc}")
 
     # Enrich with location metadata using unified helper
     lat, lng, label, flag = None, None, None, None
@@ -1772,6 +1931,7 @@ def local_status():
             "expires_at": expires_at,
             "vpn_port": vpn_port,
             "dataplane_mode": dataplane["dataplane_mode"],
+            "secure_mode": SECURE_MODE,
             "target_container": dataplane["target_container"],
             "target_ip": dataplane["target_ip"],
             "target_impl": dataplane["target_impl"],
@@ -1951,14 +2111,15 @@ def get_metadata():
     meta_data = {}
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
-        if os.path.exists(meta_path):
-            try:
-                with open(meta_path, "r", encoding="utf-8") as fp:
-                    meta_data = json.load(fp)
-                    meta_data.pop("presharedKey", None)
-                    meta_data.pop("paymentHash", None)
-            except (json.JSONDecodeError, IOError) as exc:
-                app.logger.error(f"Error reading metadata file {meta_path}: {exc}")
+        try:
+            with open(meta_path, "r", encoding="utf-8") as fp:
+                meta_data = json.load(fp)
+                meta_data.pop("presharedKey", None)
+                meta_data.pop("paymentHash", None)
+        except FileNotFoundError:
+            pass
+        except (json.JSONDecodeError, IOError) as exc:
+            app.logger.error(f"Error reading metadata file {meta_path}: {exc}")
     return jsonify(meta_data)
 
 
@@ -1973,23 +2134,55 @@ def configure_node():
 
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
-        if not os.path.exists(meta_path):
-            return jsonify({"success": False, "error": "Missing tunnelsats metadata file."}), 400
-
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
+        except FileNotFoundError:
+            return jsonify({"success": False, "error": "Missing tunnelsats metadata file."}), 400
         except (IOError, OSError, json.JSONDecodeError):
             return jsonify({"success": False, "error": "Unable to read tunnelsats metadata file."}), 500
 
-    dns = str(meta.get("serverDomain", "")).strip()
-    try:
-        port = int(meta.get("vpnPort", 0))
-    except (TypeError, ValueError):
-        port = 0
+        dns = str(meta.get("serverDomain", "")).strip()
+        try:
+            port = int(meta.get("vpnPort", 0))
+        except (TypeError, ValueError):
+            port = 0
 
-    if not dns or port <= 0:
-        return jsonify({"success": False, "error": "Metadata is missing vpnPort or serverDomain."}), 400
+        if not dns or port <= 0:
+            return jsonify({"success": False, "error": "Metadata is missing vpnPort or serverDomain."}), 400
+
+        if SECURE_MODE:
+            if meta.get("nodeType") != node_type:
+                meta["nodeType"] = node_type
+                try:
+                    _write_file_secure(meta_path, json.dumps(meta, indent=2))
+                except (IOError, OSError) as exc:
+                    app.logger.error(f"Failed to save nodeType to metadata: {exc}")
+                    return jsonify({"success": False, "error": "Failed to update metadata file."}), 500
+
+    if SECURE_MODE:
+        _, config_path = resolve_node_config(node_type)
+        config_lines = []
+        if node_type == "lnd":
+            config_lines = [
+                f"externalhosts={dns}:{port}"
+            ]
+        else:
+            config_lines = [
+                "bind-addr=0.0.0.0:9736",
+                f"announce-addr={dns}:{port}",
+                "always-use-proxy=false"
+            ]
+
+        return jsonify({
+            "success": True,
+            "manual_mode": True,
+            "node_type": node_type,
+            "config_path": config_path,
+            "config_lines": config_lines,
+            "port": port,
+            "dns": dns
+        })
 
     lnd_pending_key = "lndRestartPending"
     cln_pending_key = "clnRestartPending"
@@ -2049,7 +2242,8 @@ def configure_node():
         ("announce-addr=", f"announce-addr={dns}:{port}"),
         ("always-use-proxy=", "always-use-proxy=false"),
     )
-    cln_processed, cln_changed = upsert_config_lines(CLN_CONFIG_PATH, cln_steps)
+    cln_container_config, _ = resolve_node_config("cln")
+    cln_processed, cln_changed = upsert_config_lines(cln_container_config, cln_steps)
     if not cln_processed:
         return jsonify({"success": False, "error": "Failed to modify CLN config."}), 500
 
@@ -2072,6 +2266,35 @@ def configure_node():
 @app.route("/api/local/restore-node", methods=["POST"])
 def restore_node():
     app.logger.info("Action Request: Restoring networking to default")
+    if SECURE_MODE:
+        targets = []
+        if lnd_exists():
+            _, lnd_path = resolve_node_config("lnd")
+            targets.append({
+                "node_type": "lnd",
+                "config_path": lnd_path,
+                "config_lines": [
+                    "externalhosts="
+                ]
+            })
+        if cln_exists():
+            _, cln_path = resolve_node_config("cln")
+            targets.append({
+                "node_type": "cln",
+                "config_path": cln_path,
+                "config_lines": [
+                    "bind-addr=",
+                    "announce-addr=",
+                    "always-use-proxy="
+                ]
+            })
+        return jsonify({
+            "success": True,
+            "manual_mode": True,
+            "restore": True,
+            "targets": targets
+        })
+
     lnd_processed, lnd_changed, cln_processed, cln_changed = False, False, False, False
     errors = []
     lnd_detected = lnd_exists()
@@ -2090,8 +2313,9 @@ def restore_node():
     elif lnd_processed and not lnd_detected:
         app.logger.info("LND config restored, but no running LND container detected. Skipping restart.")
 
+    cln_container_config, _ = resolve_node_config("cln")
     cln_processed, cln_changed = comment_out_config_lines(
-        CLN_CONFIG_PATH,
+        cln_container_config,
         (
             "bind-addr=",
             "announce-addr=",

--- a/server/app.py
+++ b/server/app.py
@@ -1401,13 +1401,13 @@ def proxy_request(method, endpoint, payload=None):
 
 @app.route("/")
 def serve_index():
-    static_folder = app.static_folder or "web"
+    static_folder = app.static_folder or "../web"
     return send_from_directory(static_folder, "index.html")
 
 
 @app.route("/<path:path>")
 def serve_static(path):
-    static_folder = app.static_folder or "web"
+    static_folder = app.static_folder or "../web"
     return send_from_directory(static_folder, path)
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -233,7 +233,12 @@ def resolve_node_config(node_type):
         # too if the test needs a consistent (container_path, host_path) pair.
         if CLN_CONFIG_PATH != "/lightning-data/cln/config":
             container_path = CLN_CONFIG_PATH
+        elif not os.path.exists(container_path) and os.path.exists("/lightning-data/cln/config"):
+            container_path = "/lightning-data/cln/config"
+
         host_path = f"/home/umbrel/umbrel/app-data/core-lightning/data/lightningd/{net}/config"
+        if container_path == "/lightning-data/cln/config":
+            host_path = "/home/umbrel/umbrel/app-data/core-lightning/data/lightningd/config"
         return container_path, host_path
     return None, None
 
@@ -1860,7 +1865,10 @@ def local_status():
     try:
         with open(LND_CONFIG_PATH, "r", encoding="utf-8") as f:
             for line in f:
-                if line.lstrip().startswith("externalhosts="):
+                cleaned = line.strip()
+                if cleaned.startswith("#"):
+                    continue
+                if re.match(r"^externalhosts\s*=\s*", cleaned):
                     lnd_routing_active = True
                     break
     except FileNotFoundError:
@@ -1874,7 +1882,10 @@ def local_status():
         try:
             with open(cln_container_config, "r", encoding="utf-8") as f:
                 for line in f:
-                    if line.lstrip().startswith("announce-addr="):
+                    cleaned = line.strip()
+                    if cleaned.startswith("#"):
+                        continue
+                    if re.match(r"^announce-addr\s*=\s*", cleaned):
                         cln_routing_active = True
                         break
         except FileNotFoundError:

--- a/server/app.py
+++ b/server/app.py
@@ -1120,7 +1120,7 @@ def lnd_exists():
     if K3S_MODE:
         return bool(k8s_get_pod_name(LND_K8S_POD_SELECTOR, namespace=LND_K8S_NAMESPACE))
     if SECURE_MODE:
-        return check_tcp_port_cached(LND_PROBE_IP, LND_PROBE_PORT) or os.path.exists(LND_CONFIG_PATH)
+        return check_tcp_port_cached(LND_PROBE_IP, LND_PROBE_PORT)
     return bool(container_ids_by_match(LND_CONTAINER_PATTERN))
 
 
@@ -1129,8 +1129,7 @@ def cln_exists():
     if K3S_MODE:
         return bool(k8s_get_pod_name(CLN_K8S_POD_SELECTOR, namespace=CLN_K8S_NAMESPACE))
     if SECURE_MODE:
-        container_path, _ = resolve_node_config("cln")
-        return check_tcp_port_cached(CLN_PROBE_IP, CLN_PROBE_PORT) or (container_path and os.path.exists(container_path))
+        return check_tcp_port_cached(CLN_PROBE_IP, CLN_PROBE_PORT)
     return bool(container_ids_by_match(CLN_CONTAINER_PATTERN))
 
 
@@ -1818,17 +1817,15 @@ def local_status():
             return resolved
         lnd_ip = _resolve_svc("LND_K8S_SERVICE", LND_K8S_NAMESPACE)
         cln_ip = _resolve_svc("CLN_K8S_SERVICE", CLN_K8S_NAMESPACE)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            future_lnd = executor.submit(lnd_exists)
-            future_cln = executor.submit(cln_exists)
-            lnd_detected = future_lnd.result()
-            cln_detected = future_cln.result()
+        future_lnd = _dns_executor.submit(lnd_exists)
+        future_cln = _dns_executor.submit(cln_exists)
+        lnd_detected = future_lnd.result()
+        cln_detected = future_cln.result()
     elif SECURE_MODE:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-            future_lnd = executor.submit(lnd_exists)
-            future_cln = executor.submit(cln_exists)
-            lnd_detected = future_lnd.result()
-            cln_detected = future_cln.result()
+        future_lnd = _dns_executor.submit(lnd_exists)
+        future_cln = _dns_executor.submit(cln_exists)
+        lnd_detected = future_lnd.result()
+        cln_detected = future_cln.result()
         lnd_ip = LND_PROBE_IP if lnd_detected else ""
         cln_ip = CLN_PROBE_IP if cln_detected else ""
     else:

--- a/server/app.py
+++ b/server/app.py
@@ -173,8 +173,18 @@ def check_tcp_port_cached(ip, port):
 
     return val
 
+_cln_network_cache = None
+_cln_network_cache_time = 0.0
+_cln_network_lock = threading.Lock()
+
 def detect_cln_network():
     """Detect the active CLN network by checking subdirectories in /lightning-data/cln/."""
+    global _cln_network_cache, _cln_network_cache_time
+    now = time.time()
+    with _cln_network_lock:
+        if _cln_network_cache is not None and now - _cln_network_cache_time < 60.0:
+            return _cln_network_cache
+
     networks = ["bitcoin", "testnet", "signet", "regtest"]
     active_net = "bitcoin"
     latest_mtime = 0.0
@@ -202,6 +212,10 @@ def detect_cln_network():
                     active_net = net
             except Exception:
                 pass
+
+    with _cln_network_lock:
+        _cln_network_cache = active_net
+        _cln_network_cache_time = now
 
     return active_net
 
@@ -2265,7 +2279,10 @@ def restore_node():
     app.logger.info("Action Request: Restoring networking to default")
     if SECURE_MODE:
         targets = []
-        if lnd_exists():
+        lnd_detected = lnd_exists() or os.path.exists(LND_CONFIG_PATH)
+        cln_container_config, _ = resolve_node_config("cln")
+        cln_detected = cln_exists() or (cln_container_config and os.path.exists(cln_container_config))
+        if lnd_detected:
             _, lnd_path = resolve_node_config("lnd")
             targets.append({
                 "node_type": "lnd",
@@ -2274,7 +2291,7 @@ def restore_node():
                     "externalhosts="
                 ]
             })
-        if cln_exists():
+        if cln_detected:
             _, cln_path = resolve_node_config("cln")
             targets.append({
                 "node_type": "cln",

--- a/server/app.py
+++ b/server/app.py
@@ -791,6 +791,9 @@ def _set_restart_pending(meta_path, _ignored_meta, key, is_pending):
         except (IOError, OSError, json.JSONDecodeError):
             return False
 
+        if not isinstance(meta, dict):
+            return False
+
         has_key = key in meta
         current_pending = bool(meta.get(key))
 
@@ -1775,10 +1778,11 @@ def renew_subscription():
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
-                if not payload.get("serverId") and "serverId" in meta:
-                    payload["serverId"] = meta["serverId"]
-                if not payload.get("wgPublicKey") and "wgPublicKey" in meta:
-                    payload["wgPublicKey"] = meta["wgPublicKey"]
+                if isinstance(meta, dict):
+                    if not payload.get("serverId") and "serverId" in meta:
+                        payload["serverId"] = meta["serverId"]
+                    if not payload.get("wgPublicKey") and "wgPublicKey" in meta:
+                        payload["wgPublicKey"] = meta["wgPublicKey"]
         except FileNotFoundError:
             pass
         except (IOError, json.JSONDecodeError) as exc:
@@ -1900,9 +1904,10 @@ def local_status():
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
-                server_domain = meta.get("serverDomain", "")
-                expires_at = meta.get("expiresAt", "")
-                vpn_port = meta.get("vpnPort", "")
+                if isinstance(meta, dict):
+                    server_domain = meta.get("serverDomain", "")
+                    expires_at = meta.get("expiresAt", "")
+                    vpn_port = meta.get("vpnPort", "")
         except FileNotFoundError:
             pass
         except (IOError, OSError, json.JSONDecodeError) as exc:
@@ -2125,8 +2130,11 @@ def get_metadata():
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta_data = json.load(fp)
-                meta_data.pop("presharedKey", None)
-                meta_data.pop("paymentHash", None)
+                if isinstance(meta_data, dict):
+                    meta_data.pop("presharedKey", None)
+                    meta_data.pop("paymentHash", None)
+                else:
+                    meta_data = {}
         except FileNotFoundError:
             pass
         except (json.JSONDecodeError, IOError) as exc:
@@ -2148,6 +2156,8 @@ def configure_node():
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
+            if not isinstance(meta, dict):
+                return jsonify({"success": False, "error": "Invalid tunnelsats metadata format."}), 400
         except FileNotFoundError:
             return jsonify({"success": False, "error": "Missing tunnelsats metadata file."}), 400
         except (IOError, OSError, json.JSONDecodeError):

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -16,9 +16,13 @@ import app as app_module
 # --- Fixtures ---
 
 @pytest.fixture(autouse=True)
-def clear_subscription_cache():
-    """Ensure the server-side subscription cache is cleared between every test to prevent isolation leaks."""
+def clear_caches():
+    """Ensure server-side caches are cleared between every test to prevent isolation leaks."""
     app_module._SUBSCRIPTION_CACHE.clear()
+    if hasattr(app_module, '_probe_cache'):
+        app_module._probe_cache.clear()
+    if hasattr(app_module, '_in_flight_probes'):
+        app_module._in_flight_probes.clear()
     yield
 
 @pytest.fixture
@@ -1227,7 +1231,7 @@ class TestDataplaneAndRegressionFixes:
             assert payload['cln'] is True
             assert payload['port'] == 35825
             assert payload['dns'] == 'de2.tunnelsats.com'
-            mock_restart.assert_called_once_with(r'(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)')
+            mock_restart.assert_called_once_with(r'(^|[_-])(core-lightning|clightning|lightningd|cln)([_-]|$)')
 
             with open(cln_path, 'r') as f:
                 cln_content = f.read()
@@ -1530,7 +1534,7 @@ class TestDataplaneAndRegressionFixes:
             # Should have called restart for both LND and CLN
             assert mock_restart.call_count == 2
             mock_restart.assert_any_call(r'^lightning[_-]lnd[_-]\d+$', is_lnd=True)
-            mock_restart.assert_any_call(r'(^|[_-])(core-lightning|clightning|lightningd)([_-]|$)')
+            mock_restart.assert_any_call(r'(^|[_-])(core-lightning|clightning|lightningd|cln)([_-]|$)')
 
     @patch('app.read_dataplane_state')
     @patch('app.docker_api')
@@ -2071,5 +2075,49 @@ class TestK3SModeSupport:
         # Without caching, it would be called at least 4 times (2 calls * 2 endpoints)
         svc_calls = [c for c in mock_getaddrinfo.call_args_list if "svc" in c[0][0]]
         assert len(svc_calls) == 2
+
+
+class TestSecureModeToggle:
+    @patch('app.SECURE_MODE', True)
+    @patch('app.check_tcp_port', return_value=True)
+    def test_list_containers_secure_mode(self, mock_tcp):
+        from app import list_containers
+        containers = list_containers()
+        assert len(containers) == 2
+        assert containers[0]["Names"] == ["/lightning_lnd_1"]
+        assert containers[1]["Names"] == ["/lightning_cln_1"]
+
+    @patch('app.SECURE_MODE', True)
+    @patch('app.lnd_exists', return_value=True)
+    @patch('app.cln_exists', return_value=True)
+    def test_configure_node_secure_mode_returns_instructions(self, mock_cln, mock_lnd, client):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            meta_path = os.path.join(tmp_dir, app_module.META_FILE)
+            with open(meta_path, 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+
+            with patch('app.DATA_DIR', tmp_dir):
+                res = client.post('/api/local/configure-node', json={'nodeType': 'lnd'})
+                assert res.status_code == 200
+                payload = json.loads(res.data)
+                assert payload['success'] is True
+                assert payload['manual_mode'] is True
+                assert payload['node_type'] == 'lnd'
+                assert 'externalhosts=de2.tunnelsats.com:35825' in payload['config_lines'][0]
+
+    @patch('app.SECURE_MODE', True)
+    @patch('app.lnd_exists', return_value=True)
+    @patch('app.cln_exists', return_value=True)
+    def test_restore_node_secure_mode_returns_instructions(self, mock_cln, mock_lnd, client):
+        res = client.post('/api/local/restore-node')
+        assert res.status_code == 200
+        payload = json.loads(res.data)
+        assert payload['success'] is True
+        assert payload['manual_mode'] is True
+        assert payload['restore'] is True
+        assert len(payload['targets']) == 2
+        assert payload['targets'][0]['node_type'] == 'lnd'
+        assert 'externalhosts=' in payload['targets'][0]['config_lines']
+
 
 

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -2119,5 +2119,31 @@ class TestSecureModeToggle:
         assert payload['targets'][0]['node_type'] == 'lnd'
         assert 'externalhosts=' in payload['targets'][0]['config_lines']
 
+    def test_detect_cln_network_caching(self):
+        import app
+        # Reset cache
+        app._cln_network_cache = None
+        app._cln_network_cache_time = 0.0
+
+        with patch('os.path.exists', return_value=True), \
+             patch('os.path.getmtime', side_effect=[100.0, 50.0, 50.0, 50.0, 200.0, 50.0, 50.0, 50.0]) as mock_mtime:
+            # First call: bitcoin has mtime 100.0
+            net1 = app.detect_cln_network()
+            assert net1 == "bitcoin"
+            assert mock_mtime.call_count == 4
+
+            # Second call: within 60s TTL, should use cache and not call getmtime
+            net2 = app.detect_cln_network()
+            assert net2 == "bitcoin"
+            assert mock_mtime.call_count == 4
+
+            # Advance time by 61 seconds
+            with patch('time.time', return_value=time.time() + 61.0):
+                # Third call: cache expired, calls getmtime again
+                net3 = app.detect_cln_network()
+                assert net3 == "bitcoin"
+                assert mock_mtime.call_count == 8
+
+
 
 

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.2.0
+    image: tunnelsats/ts-umbrel-app:3.3.0
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"
@@ -12,6 +12,8 @@ services:
       - NET_RAW
     security_opt:
       - apparmor:unconfined
+    environment:
+      - SECURE_MODE=${SECURE_MODE:-false}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data
@@ -20,6 +22,6 @@ services:
       # Lightning Node config mounts (Graceful discovery via relative paths)
       # These use relative paths to avoid the strict Umbrel "AND" dependency requirement
       - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd
-      - ${APP_DATA_DIR}/../core-lightning/data/lightningd/bitcoin:/lightning-data/cln
+      - ${APP_DATA_DIR}/../core-lightning/data/lightningd:/lightning-data/cln
       # Host socket (For container detection & Docker API access)
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.2.0"
+version: "3.3.0"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -168,6 +168,44 @@ describe('UI Routing and Initialization', () => {
         }
     });
 
+    test('delegated data-scroll-to click switches tab when target is inside a hidden section', () => {
+        const faq3 = document.getElementById('faq-3');
+        const tocLink = document.querySelector('[data-scroll-to="faq-3"]');
+        faq3.scrollIntoView = jest.fn();
+
+        const faqView = document.getElementById('view-faq');
+        faqView.classList.add('hidden');
+        window.switchTab = jest.fn();
+
+        const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+        tocLink.dispatchEvent(clickEvent);
+
+        expect(clickEvent.defaultPrevented).toBe(true);
+        expect(window.switchTab).toHaveBeenCalledWith('faq');
+        expect(faq3.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+        faqView.classList.remove('hidden');
+        delete window.switchTab;
+    });
+
+    test('hash routing switches to FAQ tab on load/hashchange', () => {
+        jest.useFakeTimers();
+        const faq6 = document.getElementById('faq-6');
+        faq6.scrollIntoView = jest.fn();
+        window.switchTab = jest.fn();
+
+        window.location.hash = '#faq-6';
+        window.__tsHashHandler();
+
+        expect(window.switchTab).toHaveBeenCalledWith('faq');
+        jest.advanceTimersByTime(150);
+        expect(faq6.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+        window.location.hash = '';
+        delete window.switchTab;
+        jest.useRealTimers();
+    });
+
     test('all target=_blank links include noopener and noreferrer', () => {
         const links = Array.from(document.querySelectorAll('a[target="_blank"]'));
         expect(links.length).toBeGreaterThan(0);
@@ -219,6 +257,279 @@ describe('UI Routing and Initialization', () => {
 
         expect(document.getElementById('statusBadge').textContent).toBe('Connected');
         expect(document.getElementById('txt-routing-status').textContent).toBe('No Nodes Detected');
+    });
+
+    test('fetchStatus adjusts UI for secure_mode: true', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    vpn_active: true,
+                    lnd_detected: true,
+                    cln_detected: false,
+                    lnd_routing_active: true,
+                    cln_routing_active: false,
+                    wg_status: 'Connected',
+                    wg_pubkey: 'testpubkey123',
+                    server_domain: 'au1.tunnelsats.com',
+                    vpn_port: 39486,
+                    expires_at: '2027-03-10T12:00:00Z',
+                    target_impl: 'lnd',
+                    configs_found: [],
+                    version: 'v3.0.0',
+                    secure_mode: true
+                }),
+                ok: true
+            })
+        );
+
+        await window.fetchStatus();
+
+        expect(document.getElementById('install-desc').textContent).toContain('Since TunnelSats is running in Secure Mode, the configuration cannot be applied automatically');
+        expect(document.getElementById('uninstall-desc').textContent).toContain('Since TunnelSats is running in Secure Mode, the configuration cannot be modified automatically');
+        expect(document.getElementById('faq-uninstall-steps').innerHTML).toContain('Follow the modal instructions to manually comment out or delete');
+        
+        const warningBox = document.getElementById('secure-mode-warning-box');
+        const uninstallWarningBox = document.getElementById('secure-mode-uninstall-warning-box');
+        expect(warningBox.classList.contains('hidden')).toBe(false);
+        expect(warningBox.textContent).toContain('Files app');
+        expect(uninstallWarningBox.classList.contains('hidden')).toBe(false);
+        expect(uninstallWarningBox.textContent).toContain('manually revert configuration changes');
+        
+        expect(document.getElementById('faq-6')).toBeTruthy();
+        expect(document.getElementById('faq-6').textContent).toContain('In Secure Mode, why must I edit my config manually');
+        
+        expect(window.secureModeActive).toBe(true);
+    });
+
+    test('fetchStatus adjusts UI for secure_mode: false', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    vpn_active: true,
+                    lnd_detected: true,
+                    cln_detected: false,
+                    lnd_routing_active: true,
+                    cln_routing_active: false,
+                    wg_status: 'Connected',
+                    wg_pubkey: 'testpubkey123',
+                    server_domain: 'au1.tunnelsats.com',
+                    vpn_port: 39486,
+                    expires_at: '2027-03-10T12:00:00Z',
+                    target_impl: 'lnd',
+                    configs_found: [],
+                    version: 'v3.0.0',
+                    secure_mode: false
+                }),
+                ok: true
+            })
+        );
+
+        await window.fetchStatus();
+
+        expect(document.getElementById('install-desc').textContent).toContain('Choose your node implementation and inject the TunnelSats forwarding host');
+        expect(document.getElementById('uninstall-desc').textContent).toContain('Revert TunnelSats node configuration changes before uninstalling');
+        expect(document.getElementById('faq-uninstall-steps').innerHTML).toContain('Wait for the UI to confirm that your node configuration has been restored');
+        
+        expect(document.getElementById('secure-mode-warning-box').classList.contains('hidden')).toBe(true);
+        expect(document.getElementById('secure-mode-uninstall-warning-box').classList.contains('hidden')).toBe(true);
+        
+        expect(window.secureModeActive).toBe(false);
+    });
+
+    test('configureNode bypasses confirmRestartModal in secure mode', async () => {
+        window.secureModeActive = true;
+        window.confirmRestartModal = jest.fn().mockResolvedValue(true);
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    success: true,
+                    manual_mode: true,
+                    node_type: 'lnd',
+                    config_path: '/path/to/lnd.conf',
+                    config_lines: ['line1', 'line2']
+                }),
+                ok: true
+            })
+        );
+
+        await window.configureNode();
+
+        expect(window.confirmRestartModal).not.toHaveBeenCalled();
+        expect(document.getElementById('manual-config-modal')).toBeTruthy();
+        
+        document.getElementById('manual-config-modal').remove();
+    });
+
+    test('restoreNode bypasses confirmRestartModal in secure mode', async () => {
+        window.secureModeActive = true;
+        window.confirmRestartModal = jest.fn().mockResolvedValue(true);
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    success: true,
+                    manual_mode: true,
+                    restore: true,
+                    targets: [
+                        {
+                            node_type: 'lnd',
+                            config_path: '/path/to/lnd.conf',
+                            config_lines: ['remove1']
+                        }
+                    ]
+                }),
+                ok: true
+            })
+        );
+
+        await window.restoreNode();
+
+        expect(window.confirmRestartModal).not.toHaveBeenCalled();
+        expect(document.getElementById('manual-restore-modal')).toBeTruthy();
+
+        document.getElementById('manual-restore-modal').remove();
+    });
+
+    test('FAQ layout ordering matches Q5 -> Q6 (Secure Mode) -> Q7 (Troubleshooting)', () => {
+        const anchors = Array.from(document.querySelectorAll('#view-faq a[data-scroll-to]'));
+        const index5 = anchors.findIndex(a => a.getAttribute('data-scroll-to') === 'faq-5');
+        const index6 = anchors.findIndex(a => a.getAttribute('data-scroll-to') === 'faq-6');
+        const index7 = anchors.findIndex(a => a.getAttribute('data-scroll-to') === 'faq-7');
+        
+        expect(index5).toBeLessThan(index6);
+        expect(index6).toBeLessThan(index7);
+
+        const faq5 = document.getElementById('faq-5');
+        const faq6 = document.getElementById('faq-6');
+        const faq7 = document.getElementById('faq-7');
+
+        expect(faq5.compareDocumentPosition(faq6)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+        expect(faq6.compareDocumentPosition(faq7)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+
+    test('Install/Uninstall tab descriptions and warning boxes have increased font sizes', () => {
+        const installDesc = document.getElementById('install-desc');
+        const uninstallDesc = document.getElementById('uninstall-desc');
+        const warningBox = document.getElementById('secure-mode-warning-box');
+        const uninstallWarningBox = document.getElementById('secure-mode-uninstall-warning-box');
+
+        expect(installDesc.className).toContain('text-base');
+        expect(uninstallDesc.className).toContain('text-base');
+        expect(warningBox.className).toContain('text-sm');
+        expect(uninstallWarningBox.className).toContain('text-sm');
+    });
+
+    test('Manual configuration and restore modals have increased font sizes and correct typography styling', async () => {
+        // Test manual config modal font sizes
+        window.showManualConfigModal('lnd', '/path/to/lnd.conf', ['line1']);
+        const configModal = document.getElementById('manual-config-modal');
+        expect(configModal).toBeTruthy();
+        expect(configModal.querySelector('p').className).toContain('text-sm'); // desc has text-sm
+        expect(configModal.querySelector('ol').className).toContain('text-sm'); // instructions have text-sm
+        expect(configModal.querySelector('pre').className).toContain('text-sm'); // pre code block has text-sm
+        const configBtns = configModal.querySelectorAll('button');
+        const configDoneBtn = Array.from(configBtns).find(btn => btn.textContent === 'Done');
+        expect(configDoneBtn.className).toContain('text-base'); // Done btn has text-base
+        configDoneBtn.click();
+        await new Promise(resolve => setTimeout(resolve, 250));
+
+        // Test manual restore modal font sizes and formatting
+        window.showManualRestoreModal([{
+            node_type: 'lnd',
+            config_path: '/path/to/lnd.conf',
+            config_lines: ['remove1']
+        }]);
+        const restoreModal = document.getElementById('manual-restore-modal');
+        expect(restoreModal).toBeTruthy();
+        expect(restoreModal.querySelector('p').className).toContain('text-sm'); // desc has text-sm
+        const restoreDoneBtn = Array.from(restoreModal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');
+        expect(restoreDoneBtn.className).toContain('text-base'); // Done btn has text-base
+        
+        // Check formatting of the configuration lines list
+        const ul = restoreModal.querySelector('ul');
+        expect(ul.className).toContain('list-disc');
+        expect(ul.className).toContain('text-sm');
+        expect(ul.className).toContain('text-gray-300'); // normal sans-serif gray text for list item
+        expect(ul.className).not.toContain('font-mono'); // ul shouldn't force monospace globally
+        expect(ul.className).not.toContain('text-tsyellow'); // ul shouldn't force yellow globally
+
+        const li = ul.querySelector('li');
+        expect(li.className).toContain('text-sm');
+        expect(li.innerHTML).toContain('Remove/comment out:');
+        const code = li.querySelector('code');
+        expect(code).toBeTruthy();
+        expect(code.className).toContain('font-mono');
+        expect(code.className).toContain('text-tsyellow');
+        expect(code.textContent).toBe('remove1');
+
+        restoreDoneBtn.click();
+        await new Promise(resolve => setTimeout(resolve, 250));
+    });
+
+    test('manual configuration modal closes on clicking the overlay outside the panel but not inside', async () => {
+        window.secureModeActive = true;
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    success: true,
+                    manual_mode: true,
+                    node_type: 'lnd',
+                    config_path: '/path/to/lnd.conf',
+                    config_lines: ['line1']
+                }),
+                ok: true
+            })
+        );
+
+        await window.configureNode();
+
+        const overlay = document.getElementById('manual-config-modal');
+        expect(overlay).toBeTruthy();
+
+        // Click inside panel
+        const panel = overlay.querySelector('div');
+        panel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(document.getElementById('manual-config-modal')).toBeTruthy();
+
+        // Click outside panel (on overlay itself)
+        overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(document.getElementById('manual-config-modal')).toBeNull();
+    });
+
+    test('manual restore modal closes on clicking the overlay outside the panel but not inside', async () => {
+        window.secureModeActive = true;
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    success: true,
+                    manual_mode: true,
+                    restore: true,
+                    targets: [{
+                        node_type: 'lnd',
+                        config_path: '/path/to/lnd.conf',
+                        config_lines: ['remove1']
+                    }]
+                }),
+                ok: true
+            })
+        );
+
+        await window.restoreNode();
+
+        const overlay = document.getElementById('manual-restore-modal');
+        expect(overlay).toBeTruthy();
+
+        // Click inside panel
+        const panel = overlay.querySelector('div');
+        panel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(document.getElementById('manual-restore-modal')).toBeTruthy();
+
+        // Click outside panel (on overlay itself)
+        overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(document.getElementById('manual-restore-modal')).toBeNull();
     });
 
     test('switchTab resumes polling and restores UI if activePaymentHash exists', () => {
@@ -1037,6 +1348,75 @@ describe('Phase 3b: Install Config', () => {
         const msg = document.getElementById('restore-node-msg').textContent;
         expect(msg).toContain('LND: config not found');
         expect(msg).toContain('CLN: config not found');
+    });
+
+    test('configureNode handles manual_mode and renders instructions modal', async () => {
+        global.fetch = jest.fn((url) => {
+            if (url === '/api/local/configure-node') {
+                return Promise.resolve({
+                    json: () => Promise.resolve({
+                        success: true,
+                        manual_mode: true,
+                        node_type: 'lnd',
+                        config_path: '/path/to/lnd.conf',
+                        config_lines: ['line1', 'line2']
+                    }),
+                    ok: true
+                });
+            }
+            return Promise.resolve({ json: () => Promise.resolve({}), ok: true });
+        });
+
+        await window.configureNode();
+
+        const modal = document.getElementById('manual-config-modal');
+        expect(modal).toBeTruthy();
+        expect(modal.textContent).toContain('Manual Setup Required');
+        expect(modal.textContent).toContain('/path/to/lnd.conf');
+        expect(modal.textContent).toContain('line1\nline2');
+
+        // Close modal
+        const doneBtn = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');
+        doneBtn.click();
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(document.getElementById('manual-config-modal')).toBeNull();
+    });
+
+    test('restoreNode handles manual_mode and renders manual restore modal', async () => {
+        global.fetch = jest.fn((url) => {
+            if (url === '/api/local/restore-node') {
+                return Promise.resolve({
+                    json: () => Promise.resolve({
+                        success: true,
+                        manual_mode: true,
+                        restore: true,
+                        targets: [
+                            {
+                                node_type: 'lnd',
+                                config_path: '/path/to/lnd.conf',
+                                config_lines: ['remove1', 'remove2']
+                            }
+                        ]
+                    }),
+                    ok: true
+                });
+            }
+            return Promise.resolve({ json: () => Promise.resolve({}), ok: true });
+        });
+
+        await window.restoreNode();
+
+        const modal = document.getElementById('manual-restore-modal');
+        expect(modal).toBeTruthy();
+        expect(modal.textContent).toContain('Manual Restore Required');
+        expect(modal.textContent).toContain('/path/to/lnd.conf');
+        expect(modal.textContent).toContain('remove1');
+
+        // Close modal
+        const doneBtn = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');
+        doneBtn.click();
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(document.getElementById('manual-restore-modal')).toBeNull();
     });
 
 // Removed pollReconcileStatus tests

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -430,7 +430,7 @@ describe('UI Routing and Initialization', () => {
         const configDoneBtn = Array.from(configBtns).find(btn => btn.textContent === 'Done');
         expect(configDoneBtn.className).toContain('text-base'); // Done btn has text-base
         configDoneBtn.click();
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
 
         // Test manual restore modal font sizes and formatting
         window.showManualRestoreModal([{
@@ -462,7 +462,7 @@ describe('UI Routing and Initialization', () => {
         expect(code.textContent).toBe('remove1');
 
         restoreDoneBtn.click();
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
     });
 
     test('manual configuration modal closes on clicking the overlay outside the panel but not inside', async () => {
@@ -493,7 +493,7 @@ describe('UI Routing and Initialization', () => {
 
         // Click outside panel (on overlay itself)
         overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
         expect(document.getElementById('manual-config-modal')).toBeNull();
     });
 
@@ -528,7 +528,7 @@ describe('UI Routing and Initialization', () => {
 
         // Click outside panel (on overlay itself)
         overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
         expect(document.getElementById('manual-restore-modal')).toBeNull();
     });
 
@@ -1378,7 +1378,7 @@ describe('Phase 3b: Install Config', () => {
         // Close modal
         const doneBtn = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');
         doneBtn.click();
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
         expect(document.getElementById('manual-config-modal')).toBeNull();
     });
 
@@ -1415,7 +1415,7 @@ describe('Phase 3b: Install Config', () => {
         // Close modal
         const doneBtn = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');
         doneBtn.click();
-        await new Promise(resolve => setTimeout(resolve, 250));
+        await new Promise(resolve => setTimeout(resolve, 350));
         expect(document.getElementById('manual-restore-modal')).toBeNull();
     });
 

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -141,6 +141,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('delegated data-scroll-to click prevents default and smooth-scrolls when target exists', () => {
+        jest.useFakeTimers();
         const faq3 = document.getElementById('faq-3');
         const tocLink = document.querySelector('[data-scroll-to="faq-3"]');
         faq3.scrollIntoView = jest.fn();
@@ -149,8 +150,10 @@ describe('UI Routing and Initialization', () => {
         tocLink.dispatchEvent(clickEvent);
 
         expect(clickEvent.defaultPrevented).toBe(true);
+        jest.runAllTimers();
         expect(faq3.scrollIntoView).toHaveBeenCalledTimes(1);
         expect(faq3.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+        jest.useRealTimers();
     });
 
     test('delegated data-scroll-to click does not prevent default when target does not exist', () => {
@@ -169,6 +172,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('delegated data-scroll-to click switches tab when target is inside a hidden section', () => {
+        jest.useFakeTimers();
         const faq3 = document.getElementById('faq-3');
         const tocLink = document.querySelector('[data-scroll-to="faq-3"]');
         faq3.scrollIntoView = jest.fn();
@@ -182,10 +186,12 @@ describe('UI Routing and Initialization', () => {
 
         expect(clickEvent.defaultPrevented).toBe(true);
         expect(window.switchTab).toHaveBeenCalledWith('faq');
+        jest.runAllTimers();
         expect(faq3.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
 
         faqView.classList.remove('hidden');
         delete window.switchTab;
+        jest.useRealTimers();
     });
 
     test('hash routing switches to FAQ tab on load/hashchange', () => {

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -1419,6 +1419,30 @@ describe('Phase 3b: Install Config', () => {
         expect(document.getElementById('manual-restore-modal')).toBeNull();
     });
 
+    test('restoreNode handles manual_mode with empty targets gracefully', async () => {
+        global.fetch = jest.fn((url) => {
+            if (url === '/api/local/restore-node') {
+                return Promise.resolve({
+                    json: () => Promise.resolve({
+                        success: true,
+                        manual_mode: true,
+                        restore: true,
+                        targets: []
+                    }),
+                    ok: true
+                });
+            }
+            return Promise.resolve({ json: () => Promise.resolve({}), ok: true });
+        });
+
+        await window.restoreNode();
+
+        const modal = document.getElementById('manual-restore-modal');
+        expect(modal).toBeNull();
+        const msg = document.getElementById('restore-node-msg');
+        expect(msg.textContent).toContain('No active Lightning nodes detected for manual restore.');
+    });
+
 // Removed pollReconcileStatus tests
 });
 

--- a/web/index.html
+++ b/web/index.html
@@ -505,7 +505,7 @@
                             <li>Select LND or CLN below and click <strong>Configure Node</strong> to fetch the exact configuration parameters.</li>
                             <li>Open the Umbrel <strong>Files</strong> app (or connect via SSH).</li>
                             <li>Navigate to the target file path shown in the instructions.</li>
-                            <li>Paste the configuration lines, save the file, and then restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard.</li>
+                            <li>Paste the configuration lines, save the file, and then restart your <strong>Lightning Node or Core Lightning</strong> app from the Umbrel dashboard.</li>
                         </ol>
                     </div>
 
@@ -550,7 +550,7 @@
                                 <li>Click <strong>Restore Node Networking</strong> below to view the lines that need to be removed.</li>
                                 <li>Open the Umbrel <strong>Files</strong> app (or connect via SSH).</li>
                                 <li>Open your node config file, delete or comment out the specified lines, and save.</li>
-                                <li>Restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard to apply the defaults.</li>
+                                <li>Restart your <strong>Lightning Node or Core Lightning</strong> app from the Umbrel dashboard to apply the defaults.</li>
                             </ol>
                         </div>
                         <button id="btn-restore-node" type="button"
@@ -805,7 +805,7 @@
                                     <li>Copy the target config file path and the configuration lines.</li>
                                     <li>Open the Umbrel <strong>Files</strong> app, navigate to the config file (e.g. <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">~/umbrel/app-data/lightning/data/lnd/lnd.conf</code> for LND), paste the lines, and save.</li>
                                     <li>Alternatively, connect via SSH and edit the files using <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">nano</code> or <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">vim</code>.</li>
-                                    <li>Go back to your Umbrel dashboard, open the <strong>Lightning Node</strong> app settings, and click <strong>Restart</strong>.</li>
+                                    <li>Go back to your Umbrel dashboard, open the <strong>Lightning Node</strong> or <strong>Core Lightning</strong> app settings, and click <strong>Restart</strong>.</li>
                                 </ol>
                             </div>
                         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -491,9 +491,23 @@
 
                 <div>
                     <h2 class="text-xl font-bold text-white mb-2">Configure Lightning Node</h2>
-                    <p class="text-sm text-gray-400 mb-4">Choose your node implementation and inject the TunnelSats
+                    <p id="install-desc" class="text-base text-gray-400 mb-4">Choose your node implementation and inject the TunnelSats
                         forwarding host. This step applies the WireGuard configuration to your node and restarts the
                         necessary containers so your Lightning node connects through the secure TunnelSats network.</p>
+
+                    <!-- Secure Mode manual config warning -->
+                    <div id="secure-mode-warning-box" class="hidden bg-yellow-950/30 border border-tsyellow/40 rounded-xl p-5 mb-6 text-sm text-gray-300 leading-relaxed shadow-lg">
+                        <strong class="text-base text-tsyellow mb-2 flex items-center gap-1.5">⚠️ Action Required: Manual Configuration (Secure Mode)</strong>
+                        <p class="mb-2">TunnelSats is running in Secure Mode (without root Docker socket access) to comply with Umbrel's security guidelines. Because of this sandbox isolation, <strong>you must manually edit your Lightning configuration file</strong> to announce your TunnelSats external IP and port.</p>
+                        <p class="mb-2 text-tsyellow"><strong>CRITICAL:</strong> If you skip this, your Lightning node will not broadcast its clearnet IP address to the network. As a result, other nodes will be unable to connect to you or open channels to you (inbound connections will fail).</p>
+                        <p class="font-semibold text-white mb-1">How to apply:</p>
+                        <ol class="list-decimal pl-5 space-y-1 text-gray-400">
+                            <li>Select LND or CLN below and click <strong>Configure Node</strong> to fetch the exact configuration parameters.</li>
+                            <li>Open the Umbrel <strong>Files</strong> app (or connect via SSH).</li>
+                            <li>Navigate to the target file path shown in the instructions.</li>
+                            <li>Paste the configuration lines, save the file, and then restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard.</li>
+                        </ol>
+                    </div>
 
                     <div class="grid grid-cols-2 gap-3 mb-4">
                         <button id="node-type-lnd" type="button"
@@ -523,8 +537,22 @@
 
                     <div class="bg-gray-800/60 border border-gray-700 rounded-lg p-6 mb-6">
                         <h3 class="text-white font-bold mb-2">Restore Node Config</h3>
-                        <p class="text-sm text-gray-300 mb-4">Revert TunnelSats node configuration changes before
+                        <p id="uninstall-desc" class="text-base text-gray-300 mb-4">Revert TunnelSats node configuration changes before
                             uninstalling.</p>
+
+                        <!-- Secure Mode manual restore warning -->
+                        <div id="secure-mode-uninstall-warning-box" class="hidden bg-red-950/30 border border-red-500/40 rounded-xl p-5 mb-6 text-sm text-gray-300 leading-relaxed shadow-lg">
+                            <strong class="text-base text-red-400 mb-2 flex items-center gap-1.5">⚠️ Action Required: Manual Restore (Secure Mode)</strong>
+                            <p class="mb-2">Because TunnelSats has read-only access to your configurations, <strong>you must manually revert configuration changes</strong> before uninstalling the TunnelSats app.</p>
+                            <p class="mb-2 text-red-400"><strong>CRITICAL:</strong> If you do not remove the TunnelSats external host parameters from your Lightning config file, your node will remain offline trying to route through a non-existent VPN IP address once the app is deleted.</p>
+                            <p class="font-semibold text-white mb-1">How to restore:</p>
+                            <ol class="list-decimal pl-5 space-y-1 text-gray-400">
+                                <li>Click <strong>Restore Node Networking</strong> below to view the lines that need to be removed.</li>
+                                <li>Open the Umbrel <strong>Files</strong> app (or connect via SSH).</li>
+                                <li>Open your node config file, delete or comment out the specified lines, and save.</li>
+                                <li>Restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard to apply the defaults.</li>
+                            </ol>
+                        </div>
                         <button id="btn-restore-node" type="button"
                             class="w-full bg-red-600 hover:bg-red-500 text-white font-bold py-3 rounded-xl transition shadow-lg">
                             Restore Node Networking
@@ -593,6 +621,13 @@
                             <li><a href="#faq-6"
                                     class="text-gray-300 hover:text-white transition-colors flex items-center gap-2"
                                     data-scroll-to="faq-6"><svg class="w-4 h-4 text-gray-500" fill="none"
+                                        stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M9 5l7 7-7 7"></path>
+                                    </svg> 6. In Secure Mode, why must I edit my config manually?</a></li>
+                            <li><a href="#faq-7"
+                                    class="text-gray-300 hover:text-white transition-colors flex items-center gap-2"
+                                    data-scroll-to="faq-7"><svg class="w-4 h-4 text-gray-500" fill="none"
                                         stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                             d="M9 5l7 7-7 7"></path>
@@ -715,7 +750,7 @@
                                     </h4>
                                     <p class="mb-2">First, we must safely detach the VPN from your Lightning node and
                                         return it to its default Tor/Clearnet state.</p>
-                                    <ol class="list-decimal pl-5 space-y-1 text-xs">
+                                    <ol id="faq-uninstall-steps" class="list-decimal pl-5 space-y-1 text-xs">
                                         <li>Go to the <strong>Uninstall</strong> tab in the TunnelSats App navigation.
                                         </li>
                                         <li>Click the <strong>Restore Node Networking</strong> button.</li>
@@ -756,9 +791,27 @@
                                 </div>
                             </div>
                         </div>
+                        <!-- Q6 (Secure Mode) -->
+                        <div id="faq-6" class="bg-yellow-950/10 border border-tsyellow/30 rounded-lg p-5 scroll-mt-6">
+                            <h3 class="text-white font-bold mb-2 text-base flex items-center gap-2">
+                                <span class="text-tsyellow">⚠️</span> 6. In Secure Mode, why must I edit my config manually?
+                            </h3>
+                            <div class="text-sm text-gray-300 space-y-3 leading-relaxed">
+                                <p>To comply with Umbrel's official security rules, TunnelSats runs in a hardened sandbox (without root system access or direct access to the Docker socket). Consequently, it cannot write to your node's config files or trigger container restarts automatically.</p>
+                                <p class="text-tsyellow font-semibold">Without these manual config changes, your Lightning node will not broadcast its TunnelSats clearnet IP/port to the gossip network. This means other nodes will not know how to connect to you, and inbound channel opens will fail.</p>
+                                <h4 class="text-white font-semibold mt-4 mb-2">How to apply manually:</h4>
+                                <ol class="list-decimal pl-5 space-y-2">
+                                    <li>Navigate to the <strong>Install</strong> tab, select your implementation, and click <strong>Configure Node</strong>.</li>
+                                    <li>Copy the target config file path and the configuration lines.</li>
+                                    <li>Open the Umbrel <strong>Files</strong> app, navigate to the config file (e.g. <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">~/umbrel/app-data/lightning/data/lnd/lnd.conf</code> for LND), paste the lines, and save.</li>
+                                    <li>Alternatively, connect via SSH and edit the files using <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">nano</code> or <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">vim</code>.</li>
+                                    <li>Go back to your Umbrel dashboard, open the <strong>Lightning Node</strong> app settings, and click <strong>Restart</strong>.</li>
+                                </ol>
+                            </div>
+                        </div>
 
                         <!-- Troubleshooting -->
-                        <div id="faq-6" class="bg-red-900/10 border border-red-500/30 rounded-lg p-5 scroll-mt-6">
+                        <div id="faq-7" class="bg-red-900/10 border border-red-500/30 rounded-lg p-5 scroll-mt-6">
                             <h3 class="text-white font-bold mb-2 text-base flex items-center gap-2"><svg
                                     class="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -770,7 +823,7 @@
                                 <p>If you skipped Step 1, your LND or CLN configuration file still contains the
                                     TunnelSats <code
                                         class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">externalhosts</code>
-                                    or <code
+                                     or <code
                                         class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">announce-addr</code>
                                     directives, but the VPN tunnel is dead. Your traffic is effectively being sent into
                                     a black hole.</p>
@@ -800,7 +853,6 @@
                                 </ol>
                             </div>
                         </div>
-
                     </div>
                 </div>
 
@@ -865,7 +917,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.2.0</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.0</span>
                 </div>
             </div>
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -687,7 +687,7 @@ function applySecureModeUI(isSecureMode) {
                 <li>Go to the <strong>Uninstall</strong> tab in the TunnelSats App navigation.</li>
                 <li>Click the <strong>Restore Node Networking</strong> button.</li>
                 <li>Follow the modal instructions to manually comment out or delete the configuration parameters from your lightning node config files.</li>
-                <li>Restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard.</li>
+                <li>Restart your <strong>Lightning Node or Core Lightning</strong> app from the Umbrel dashboard.</li>
             `
             : `
                 <li>Go to the <strong>Uninstall</strong> tab in the TunnelSats App navigation.</li>
@@ -1440,7 +1440,7 @@ function showManualConfigModal(nodeType, path, lines) {
             <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
             <li>Navigate to the configuration file path shown above.</li>
             <li>Add (or update if already present) each configuration line shown above (do not create duplicate lines).</li>
-            <li>Go back to the Umbrel dashboard and restart your <b>Core-Lightning</b> app.</li>
+            <li>Go back to the Umbrel dashboard and restart your <b>Core Lightning</b> app.</li>
         `;
     }
 
@@ -1520,7 +1520,7 @@ function showManualRestoreModal(targets) {
     const hasCln = targets.some(t => t.node_type === 'cln');
     const restartApps = [];
     if (hasLnd) restartApps.push('<b>Lightning Node</b>');
-    if (hasCln) restartApps.push('<b>Core-Lightning</b>');
+    if (hasCln) restartApps.push('<b>Core Lightning</b>');
     const restartStr = restartApps.length > 0 ? restartApps.join(' and ') : '<b>Lightning Node</b>';
     ol.innerHTML = `
         <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -448,13 +448,21 @@ function handleScrollToClick(e) {
     if (el) {
         e.preventDefault();
         const section = el.closest('main section');
+        let needsDelay = false;
         if (section && section.classList.contains('hidden')) {
             const tabId = section.id.replace('view-', '');
             if (typeof switchTab === 'function') {
                 switchTab(tabId);
+                needsDelay = true;
             }
         }
-        el.scrollIntoView({ behavior: 'smooth' });
+        if (needsDelay) {
+            setTimeout(() => {
+                el.scrollIntoView({ behavior: 'smooth' });
+            }, 100);
+        } else {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
     }
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -2,6 +2,7 @@
 var pollInterval;
 var activePaymentHash = null;
 var purchaseMode = "buy"; // "buy" or "renew"
+window.secureModeActive = false;
 
 // Pricing Configuration
 const BASE_PRICE_USD = 3;
@@ -9,6 +10,26 @@ const DISCOUNTS = { 1: 0, 3: 0.05, 6: 0.10, 12: 0.20 };
 let currentSatsPerDollar = null;
 const POLL_INTERVAL_MS = 3000;
 let tsServers = [];
+
+// Badge States Constants for Routing Status
+const BADGE_STATES = {
+    notFound: {
+        text: "Not Found",
+        className: "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-gray-700 bg-gray-900/50 text-gray-500"
+    },
+    offline: {
+        text: "Offline",
+        className: "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-red-700 bg-red-900/50 text-red-500"
+    },
+    unsecured: {
+        text: "Unsecured",
+        className: "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-yellow-700 bg-yellow-900/50 text-tsyellow pulse-yellow"
+    },
+    active: {
+        text: "Active",
+        className: "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-tsgreen bg-green-900/50 text-tsgreen pulse-green"
+    }
+};
 
 // 3D Visualization State
 let myGlobe = null;
@@ -426,11 +447,35 @@ function handleScrollToClick(e) {
     const el = document.getElementById(id);
     if (el) {
         e.preventDefault();
+        const section = el.closest('main section');
+        if (section && section.classList.contains('hidden')) {
+            const tabId = section.id.replace('view-', '');
+            if (typeof switchTab === 'function') {
+                switchTab(tabId);
+            }
+        }
         el.scrollIntoView({ behavior: 'smooth' });
     }
 }
 
+function handleHashRoute() {
+    const hash = window.location.hash;
+    if (hash && hash.startsWith('#faq-')) {
+        const id = hash.substring(1);
+        const el = document.getElementById(id);
+        if (el) {
+            if (typeof switchTab === 'function') {
+                switchTab('faq');
+            }
+            setTimeout(() => {
+                el.scrollIntoView({ behavior: 'smooth' });
+            }, 100);
+        }
+    }
+}
+
 function initApp() {
+    window._lastSecureMode = undefined;
     // Keep globe bootstrap independent from one-time app initialization.
     if (!myGlobe) initGlobe();
 
@@ -496,6 +541,14 @@ function initApp() {
     }
     window.__tsScrollToHandler = handleScrollToClick;
     document.addEventListener('click', window.__tsScrollToHandler);
+
+    // Hash routing for deep-linking
+    if (window.__tsHashHandler) {
+        window.removeEventListener('hashchange', window.__tsHashHandler);
+    }
+    window.__tsHashHandler = handleHashRoute;
+    window.addEventListener('hashchange', window.__tsHashHandler);
+    handleHashRoute();
 }
 
 if (document.readyState !== 'loading') {
@@ -598,6 +651,57 @@ function switchTab(tabId) {
     if (window.innerWidth < 768) {
         const nav = document.getElementById('sidebar-nav');
         if (nav) nav.classList.add('hidden');
+    }
+}
+
+function applySecureModeUI(isSecureMode) {
+    if (window._lastSecureMode === isSecureMode) {
+        return;
+    }
+    window._lastSecureMode = isSecureMode;
+    window.secureModeActive = isSecureMode;
+
+    const elements = {
+        installDesc: document.getElementById('install-desc'),
+        uninstallDesc: document.getElementById('uninstall-desc'),
+        faqUninstallSteps: document.getElementById('faq-uninstall-steps'),
+        warningBox: document.getElementById('secure-mode-warning-box'),
+        uninstallWarningBox: document.getElementById('secure-mode-uninstall-warning-box')
+    };
+
+    if (elements.installDesc) {
+        elements.installDesc.textContent = isSecureMode
+            ? "Choose your node implementation and follow the manual configuration steps. Since TunnelSats is running in Secure Mode, the configuration cannot be applied automatically."
+            : "Choose your node implementation and inject the TunnelSats forwarding host. This step applies the WireGuard configuration to your node and restarts the necessary containers so your Lightning node connects through the secure TunnelSats network.";
+    }
+
+    if (elements.uninstallDesc) {
+        elements.uninstallDesc.textContent = isSecureMode
+            ? "To restore your lightning node networking back to default, click the button below to view the manual steps to revert the configuration parameter changes from your config files. Since TunnelSats is running in Secure Mode, the configuration cannot be modified automatically."
+            : "Revert TunnelSats node configuration changes before uninstalling.";
+    }
+
+    if (elements.faqUninstallSteps) {
+        elements.faqUninstallSteps.innerHTML = isSecureMode
+            ? `
+                <li>Go to the <strong>Uninstall</strong> tab in the TunnelSats App navigation.</li>
+                <li>Click the <strong>Restore Node Networking</strong> button.</li>
+                <li>Follow the modal instructions to manually comment out or delete the configuration parameters from your lightning node config files.</li>
+                <li>Restart your <strong>Lightning Node or Core-Lightning</strong> app from the Umbrel dashboard.</li>
+            `
+            : `
+                <li>Go to the <strong>Uninstall</strong> tab in the TunnelSats App navigation.</li>
+                <li>Click the <strong>Restore Node Networking</strong> button.</li>
+                <li>Wait for the UI to confirm that your node configuration has been restored to its default state without TunnelSats routing.</li>
+            `;
+    }
+
+    if (elements.warningBox) {
+        elements.warningBox.classList.toggle('hidden', !isSecureMode);
+    }
+
+    if (elements.uninstallWarningBox) {
+        elements.uninstallWarningBox.classList.toggle('hidden', !isSecureMode);
     }
 }
 
@@ -730,6 +834,10 @@ async function fetchStatus() {
             document.getElementById('app-version').textContent = data.version;
         }
 
+        // Update Secure Mode dynamic description text & warning boxes
+        const isSecureMode = data.secure_mode === true;
+        applySecureModeUI(isSecureMode);
+
         // Node Routing explicit UI states
         const badgeRouting = document.getElementById('badge-routing');
         const txtRoutingStatus = document.getElementById('txt-routing-status');
@@ -744,24 +852,26 @@ async function fetchStatus() {
         if (btnDashEnable) btnDashEnable.classList.add('hidden');
         if (btnDashDisable) btnDashDisable.classList.add('hidden');
 
+        let badgeState;
         if (!hasNode) {
-            // State 1
-            if (badgeRouting) { badgeRouting.textContent = "Not Found"; badgeRouting.className = "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-gray-700 bg-gray-900/50 text-gray-500"; }
+            badgeState = BADGE_STATES.notFound;
             if (txtRoutingStatus) txtRoutingStatus.textContent = "No Nodes Detected";
         } else if (!vpnActive) {
-            // State 2
-            if (badgeRouting) { badgeRouting.textContent = "Offline"; badgeRouting.className = "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-red-700 bg-red-900/50 text-red-500"; }
+            badgeState = BADGE_STATES.offline;
             if (txtRoutingStatus) txtRoutingStatus.textContent = "VPN Disconnected";
         } else if (!routingActive) {
-            // State 3
-            if (badgeRouting) { badgeRouting.textContent = "Unsecured"; badgeRouting.className = "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-yellow-700 bg-yellow-900/50 text-tsyellow pulse-yellow"; }
+            badgeState = BADGE_STATES.unsecured;
             if (txtRoutingStatus) txtRoutingStatus.textContent = "Hybrid Lightning Connectivity";
             if (btnDashEnable) btnDashEnable.classList.remove('hidden');
         } else {
-            // State 4
-            if (badgeRouting) { badgeRouting.textContent = "Active"; badgeRouting.className = "text-[10px] uppercase font-bold px-2 py-0.5 rounded border border-tsgreen bg-green-900/50 text-tsgreen pulse-green"; }
+            badgeState = BADGE_STATES.active;
             if (txtRoutingStatus) txtRoutingStatus.textContent = "Node Routing Secured";
             if (btnDashDisable) btnDashDisable.classList.remove('hidden');
+        }
+
+        if (badgeRouting && badgeState) {
+            badgeRouting.textContent = badgeState.text;
+            badgeRouting.className = badgeState.className;
         }
 
         // Update Dashboard Banner
@@ -1233,12 +1343,208 @@ async function confirmRestartModal(nodeType) {
     });
 }
 
+function createModalOverlay(id) {
+    const existingModal = document.getElementById(id);
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    const overlay = document.createElement('div');
+    overlay.id = id;
+    overlay.className = 'absolute inset-0 z-50 flex items-center justify-center bg-black/80 px-4 backdrop-blur-sm transition-opacity duration-300';
+
+    const panel = document.createElement('div');
+    panel.className = 'w-full max-w-lg rounded-2xl border border-gray-700/50 bg-gray-950 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.5)] transform transition-all duration-300 scale-95 opacity-0 text-left';
+
+    const closeModal = () => {
+        panel.classList.add('scale-95', 'opacity-0');
+        overlay.classList.add('opacity-0');
+        setTimeout(() => overlay.remove(), 200);
+    };
+
+    overlay.onclick = (e) => {
+        if (e.target === overlay) closeModal();
+    };
+
+    const mountAndAnimate = () => {
+        overlay.appendChild(panel);
+        getAppShell().appendChild(overlay);
+        setTimeout(() => {
+            panel.classList.remove('scale-95', 'opacity-0');
+            panel.classList.add('scale-100', 'opacity-100');
+        }, 10);
+    };
+
+    return { overlay, panel, closeModal, mountAndAnimate };
+}
+
+function showManualConfigModal(nodeType, path, lines) {
+    const { overlay, panel, closeModal, mountAndAnimate } = createModalOverlay('manual-config-modal');
+
+    const title = document.createElement('h3');
+    title.className = 'text-xl font-bold text-white flex items-center gap-3 mb-4';
+    title.innerHTML = `<span class="text-tsyellow">⚠️</span> Manual Setup Required (Secure Mode)`;
+
+    const desc = document.createElement('p');
+    desc.className = 'text-sm text-gray-400 mb-6 leading-relaxed';
+    desc.textContent = `To comply with Umbrel's security guidelines, TunnelSats is running in Secure Mode (without root Docker socket access). Please follow these steps to configure your ${nodeType.toUpperCase()} node manually:`;
+
+    const pathLabel = document.createElement('span');
+    pathLabel.className = 'block text-xs text-gray-500 uppercase tracking-wider mb-2';
+    pathLabel.textContent = 'Target Config File Path';
+
+    const pathValContainer = document.createElement('div');
+    pathValContainer.className = 'flex items-center justify-between bg-black/40 border border-gray-800 rounded-xl p-3 font-mono text-sm text-gray-300 mb-6';
+    
+    const pathText = document.createElement('span');
+    pathText.className = 'truncate mr-2';
+    pathText.textContent = path;
+
+    const copyPathBtn = document.createElement('button');
+    copyPathBtn.className = 'text-tsgreen hover:text-green-400 font-bold text-sm cursor-pointer bg-transparent border-0';
+    copyPathBtn.textContent = 'Copy';
+    copyPathBtn.onclick = () => copyToClipboard(path, 'File path');
+
+    pathValContainer.append(pathText, copyPathBtn);
+
+    const linesLabel = document.createElement('span');
+    linesLabel.className = 'block text-xs text-gray-500 uppercase tracking-wider mb-2';
+    linesLabel.textContent = 'Configuration Lines to Add/Update';
+
+    const linesContent = lines.join('\n');
+    const pre = document.createElement('pre');
+    pre.className = 'bg-black/60 border border-gray-800 rounded-xl p-4 font-mono text-sm text-tsgreen overflow-x-auto mb-3';
+    pre.textContent = linesContent;
+
+    const copyLinesBtn = document.createElement('button');
+    copyLinesBtn.className = 'w-full bg-gray-900 border border-gray-800 hover:border-tsgreen text-sm text-gray-300 font-bold py-2.5 rounded-lg transition-all mb-6 cursor-pointer';
+    copyLinesBtn.textContent = 'Copy Configuration Lines';
+    copyLinesBtn.onclick = () => copyToClipboard(linesContent, 'Configuration lines');
+
+    const instructionsHeader = document.createElement('p');
+    instructionsHeader.className = 'font-bold text-sm text-white mb-2';
+    instructionsHeader.textContent = 'Instructions:';
+
+    const ol = document.createElement('ol');
+    ol.className = 'list-decimal pl-5 space-y-2 text-sm text-gray-300 mb-8 leading-relaxed';
+    if (nodeType && nodeType.toLowerCase() === "lnd") {
+        ol.innerHTML = `
+            <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
+            <li>Navigate to the configuration file path shown above.</li>
+            <li>Add (or update if already present) the configuration line under the existing <b>[Application Options]</b> section (do not create a duplicate section header or duplicate lines).</li>
+            <li>Go back to the Umbrel dashboard and restart your <b>Lightning Node</b> app.</li>
+        `;
+    } else {
+        ol.innerHTML = `
+            <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
+            <li>Navigate to the configuration file path shown above.</li>
+            <li>Add (or update if already present) each configuration line shown above (do not create duplicate lines).</li>
+            <li>Go back to the Umbrel dashboard and restart your <b>Core-Lightning</b> app.</li>
+        `;
+    }
+
+    const doneBtn = document.createElement('button');
+    doneBtn.className = 'w-full rounded-xl bg-gradient-to-r from-tsgreen to-green-500 px-6 py-3.5 text-base font-bold text-black hover:from-green-400 hover:to-green-300 transition-all shadow-lg hover:shadow-tsgreen/20 cursor-pointer';
+    doneBtn.textContent = 'Done';
+    doneBtn.onclick = closeModal;
+
+    panel.append(title, desc, pathLabel, pathValContainer, linesLabel, pre, copyLinesBtn, instructionsHeader, ol, doneBtn);
+    mountAndAnimate();
+}
+
+function showManualRestoreModal(targets) {
+    const { overlay, panel, closeModal, mountAndAnimate } = createModalOverlay('manual-restore-modal');
+
+    const title = document.createElement('h3');
+    title.className = 'text-xl font-bold text-white flex items-center gap-3 mb-4';
+    title.innerHTML = `<span class="text-tsyellow">⚠️</span> Manual Restore Required (Secure Mode)`;
+
+    const desc = document.createElement('p');
+    desc.className = 'text-sm text-gray-400 mb-6 leading-relaxed';
+    desc.textContent = `To restore your lightning node networking back to default, please comment out or delete the following configuration parameters from your config files:`;
+
+    const container = document.createElement('div');
+    container.className = 'space-y-4 mb-6';
+
+    targets.forEach(t => {
+        const itemDiv = document.createElement('div');
+        itemDiv.className = 'border border-gray-800 rounded-xl p-4 bg-black/30';
+
+        const nodeLabel = document.createElement('h4');
+        nodeLabel.className = 'text-sm font-bold text-white mb-3 uppercase tracking-wide';
+        nodeLabel.textContent = `${t.node_type.toUpperCase()} Node`;
+
+        const pathValContainer = document.createElement('div');
+        pathValContainer.className = 'flex items-center justify-between bg-black/40 border border-gray-800 rounded-lg p-2.5 font-mono text-xs text-gray-300 mb-3';
+        
+        const pathText = document.createElement('span');
+        pathText.className = 'truncate mr-2';
+        pathText.textContent = t.config_path;
+
+        const copyPathBtn = document.createElement('button');
+        copyPathBtn.className = 'text-tsgreen hover:text-green-400 font-bold text-xs cursor-pointer bg-transparent border-0';
+        copyPathBtn.textContent = 'Copy';
+        copyPathBtn.onclick = () => copyToClipboard(t.config_path, 'File path');
+
+        pathValContainer.append(pathText, copyPathBtn);
+
+        const linesLabel = document.createElement('span');
+        linesLabel.className = 'block text-xs text-gray-500 uppercase tracking-wider mb-2';
+        linesLabel.textContent = 'Lines to delete or comment out';
+
+        const linesList = document.createElement('ul');
+        linesList.className = 'list-disc pl-5 text-sm text-gray-300 space-y-1.5';
+        t.config_lines.forEach(line => {
+            const li = document.createElement('li');
+            li.className = 'leading-relaxed text-sm';
+            li.appendChild(document.createTextNode('Remove/comment out: '));
+            const code = document.createElement('code');
+            code.className = 'bg-black/50 border border-gray-800/80 px-1.5 py-0.5 rounded text-tsyellow font-mono text-sm font-bold';
+            code.textContent = line;
+            li.appendChild(code);
+            linesList.appendChild(li);
+        });
+
+        itemDiv.append(nodeLabel, pathValContainer, linesLabel, linesList);
+        container.appendChild(itemDiv);
+    });
+
+    const instructionsHeader = document.createElement('p');
+    instructionsHeader.className = 'font-bold text-sm text-white mb-2';
+    instructionsHeader.textContent = 'Instructions:';
+
+    const ol = document.createElement('ol');
+    ol.className = 'list-decimal pl-5 space-y-2 text-sm text-gray-300 mb-8 leading-relaxed';
+    const hasLnd = targets.some(t => t.node_type === 'lnd');
+    const hasCln = targets.some(t => t.node_type === 'cln');
+    const restartApps = [];
+    if (hasLnd) restartApps.push('<b>Lightning Node</b>');
+    if (hasCln) restartApps.push('<b>Core-Lightning</b>');
+    const restartStr = restartApps.length > 0 ? restartApps.join(' and ') : '<b>Lightning Node</b>';
+    ol.innerHTML = `
+        <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
+        <li>Navigate to the configuration file path(s) shown above.</li>
+        <li>Comment out (add <code>#</code> at the start of the line) or delete each configuration line.</li>
+        <li>Go back to the Umbrel dashboard and restart your ${restartStr} app${restartApps.length > 1 ? 's' : ''}.</li>
+    `;
+
+    const doneBtn = document.createElement('button');
+    doneBtn.className = 'w-full rounded-xl bg-gradient-to-r from-tsgreen to-green-500 px-6 py-3.5 text-base font-bold text-black hover:from-green-400 hover:to-green-300 transition-all shadow-lg hover:shadow-tsgreen/20 cursor-pointer';
+    doneBtn.textContent = 'Done';
+    doneBtn.onclick = closeModal;
+
+    panel.append(title, desc, container, instructionsHeader, ol, doneBtn);
+    mountAndAnimate();
+}
+
 async function configureNode() {
     const selectedNodeType = (document.getElementById('node-type-selected') || {}).value || 'lnd';
 
-    // Warn user about restart
-    const confirmed = await confirmRestartModal(selectedNodeType);
-    if (!confirmed) return;
+    if (!window.secureModeActive) {
+        // Warn user about restart
+        const confirmed = await confirmRestartModal(selectedNodeType);
+        if (!confirmed) return;
+    }
 
     const btn = document.getElementById('btn-configure-node');
     if (btn) {
@@ -1256,8 +1562,13 @@ async function configureNode() {
         const data = await res.json();
 
         if (res.ok && data.success !== false) {
-            const location = data.dns && data.port ? `${data.dns}:${data.port}` : 'configured endpoint';
-            setActionMessage('configure-node-msg', `Node configured successfully: ${location}`, 'success');
+            if (data.manual_mode) {
+                setActionMessage('configure-node-msg', 'Manual configuration required.', 'info');
+                showManualConfigModal(data.node_type, data.config_path, data.config_lines);
+            } else {
+                const location = data.dns && data.port ? `${data.dns}:${data.port}` : 'configured endpoint';
+                setActionMessage('configure-node-msg', `Node configured successfully: ${location}`, 'success');
+            }
             fetchStatus();
         } else {
             setActionMessage('configure-node-msg', data.error || 'Failed to configure node.', 'error');
@@ -1273,9 +1584,11 @@ async function configureNode() {
 }
 
 async function restoreNode() {
-    // Warn user about restart
-    const confirmed = await confirmRestartModal('Lightning');
-    if (!confirmed) return;
+    if (!window.secureModeActive) {
+        // Warn user about restart
+        const confirmed = await confirmRestartModal('Lightning');
+        if (!confirmed) return;
+    }
 
     const btn = document.getElementById('btn-restore-node');
     if (btn) {
@@ -1289,9 +1602,14 @@ async function restoreNode() {
         const data = await res.json();
 
         if (res.ok) {
-            const lndState = data.lnd ? (data.lnd_changed ? 'updated' : 'no changes') : 'config not found';
-            const clnState = data.cln ? (data.cln_changed ? 'updated' : 'no changes') : 'config not found';
-            setActionMessage('restore-node-msg', `Restore complete. LND: ${lndState}. CLN: ${clnState}.`, 'success');
+            if (data.manual_mode) {
+                setActionMessage('restore-node-msg', 'Manual restore required.', 'info');
+                showManualRestoreModal(data.targets);
+            } else {
+                const lndState = data.lnd ? (data.lnd_changed ? 'updated' : 'no changes') : 'config not found';
+                const clnState = data.cln ? (data.cln_changed ? 'updated' : 'no changes') : 'config not found';
+                setActionMessage('restore-node-msg', `Restore complete. LND: ${lndState}. CLN: ${clnState}.`, 'success');
+            }
             fetchStatus();
         } else {
             setActionMessage('restore-node-msg', data.error || 'Failed to restore node configuration.', 'error');

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1363,9 +1363,9 @@ function createModalOverlay(id) {
         setTimeout(() => overlay.remove(), OVERLAY_TRANSITION_MS);
     };
 
-    overlay.onclick = (e) => {
+    overlay.addEventListener('click', (e) => {
         if (e.target === overlay) closeModal();
-    };
+    });
 
     const mountAndAnimate = () => {
         overlay.appendChild(panel);
@@ -1404,7 +1404,7 @@ function showManualConfigModal(nodeType, path, lines) {
     const copyPathBtn = document.createElement('button');
     copyPathBtn.className = 'text-tsgreen hover:text-green-400 font-bold text-sm cursor-pointer bg-transparent border-0';
     copyPathBtn.textContent = 'Copy';
-    copyPathBtn.onclick = () => copyToClipboard(path, 'File path');
+    copyPathBtn.addEventListener('click', () => copyToClipboard(path, 'File path'));
 
     pathValContainer.append(pathText, copyPathBtn);
 
@@ -1420,7 +1420,7 @@ function showManualConfigModal(nodeType, path, lines) {
     const copyLinesBtn = document.createElement('button');
     copyLinesBtn.className = 'w-full bg-gray-900 border border-gray-800 hover:border-tsgreen text-sm text-gray-300 font-bold py-2.5 rounded-lg transition-all mb-6 cursor-pointer';
     copyLinesBtn.textContent = 'Copy Configuration Lines';
-    copyLinesBtn.onclick = () => copyToClipboard(linesContent, 'Configuration lines');
+    copyLinesBtn.addEventListener('click', () => copyToClipboard(linesContent, 'Configuration lines'));
 
     const instructionsHeader = document.createElement('p');
     instructionsHeader.className = 'font-bold text-sm text-white mb-2';
@@ -1447,7 +1447,7 @@ function showManualConfigModal(nodeType, path, lines) {
     const doneBtn = document.createElement('button');
     doneBtn.className = 'w-full rounded-xl bg-gradient-to-r from-tsgreen to-green-500 px-6 py-3.5 text-base font-bold text-black hover:from-green-400 hover:to-green-300 transition-all shadow-lg hover:shadow-tsgreen/20 cursor-pointer';
     doneBtn.textContent = 'Done';
-    doneBtn.onclick = closeModal;
+    doneBtn.addEventListener('click', closeModal);
 
     panel.append(title, desc, pathLabel, pathValContainer, linesLabel, pre, copyLinesBtn, instructionsHeader, ol, doneBtn);
     mountAndAnimate();
@@ -1485,7 +1485,7 @@ function showManualRestoreModal(targets) {
         const copyPathBtn = document.createElement('button');
         copyPathBtn.className = 'text-tsgreen hover:text-green-400 font-bold text-xs cursor-pointer bg-transparent border-0';
         copyPathBtn.textContent = 'Copy';
-        copyPathBtn.onclick = () => copyToClipboard(t.config_path, 'File path');
+        copyPathBtn.addEventListener('click', () => copyToClipboard(t.config_path, 'File path'));
 
         pathValContainer.append(pathText, copyPathBtn);
 
@@ -1532,7 +1532,7 @@ function showManualRestoreModal(targets) {
     const doneBtn = document.createElement('button');
     doneBtn.className = 'w-full rounded-xl bg-gradient-to-r from-tsgreen to-green-500 px-6 py-3.5 text-base font-bold text-black hover:from-green-400 hover:to-green-300 transition-all shadow-lg hover:shadow-tsgreen/20 cursor-pointer';
     doneBtn.textContent = 'Done';
-    doneBtn.onclick = closeModal;
+    doneBtn.addEventListener('click', closeModal);
 
     panel.append(title, desc, container, instructionsHeader, ol, doneBtn);
     mountAndAnimate();

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1356,10 +1356,11 @@ function createModalOverlay(id) {
     const panel = document.createElement('div');
     panel.className = 'w-full max-w-lg rounded-2xl border border-gray-700/50 bg-gray-950 p-6 shadow-[0_20px_50px_rgba(0,0,0,0.5)] transform transition-all duration-300 scale-95 opacity-0 text-left';
 
+    const OVERLAY_TRANSITION_MS = 300;
     const closeModal = () => {
         panel.classList.add('scale-95', 'opacity-0');
         overlay.classList.add('opacity-0');
-        setTimeout(() => overlay.remove(), 200);
+        setTimeout(() => overlay.remove(), OVERLAY_TRANSITION_MS);
     };
 
     overlay.onclick = (e) => {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1603,8 +1603,12 @@ async function restoreNode() {
 
         if (res.ok) {
             if (data.manual_mode) {
-                setActionMessage('restore-node-msg', 'Manual restore required.', 'info');
-                showManualRestoreModal(data.targets);
+                if (!data.targets || data.targets.length === 0) {
+                    setActionMessage('restore-node-msg', 'No active Lightning nodes detected for manual restore.', 'info');
+                } else {
+                    setActionMessage('restore-node-msg', 'Manual restore required.', 'info');
+                    showManualRestoreModal(data.targets);
+                }
             } else {
                 const lndState = data.lnd ? (data.lnd_changed ? 'updated' : 'no changes') : 'config not found';
                 const clnState = data.cln ? (data.cln_changed ? 'updated' : 'no changes') : 'config not found';


### PR DESCRIPTION
# PR: feat(secure-mode): introduce Secure Mode for official App Store and stability fixes

## Summary of Changes
- Implemented **Secure Mode** (`SECURE_MODE=true`), allowing the app to run in a sandboxed, read-only environment without root Docker socket access, switching to TCP probing and filesystem-mount heuristics, and presenting manual config/restore instructions to the user.
- Broadened CLN volume mount mapping from `lightningd/bitcoin/` to `lightningd/`, enabling network path resolution across testnet, signet, and regtest networks.
- Resolved key stability issues: safe Python subnet interpolation in `entrypoint.sh`, deadlock-safe cache double-check locking for TCP probes, TOCTOU elimination on metadata access, and dynamic tab switching for FAQ scroll targets.

## Detailed Changes
- **scripts/entrypoint.sh**: Replaced unsafe inline python variable interpolation in `rules_are_synced` and `cleanup_dataplane` with safe here-strings via standard input.
- **server/app.py**:
  - Implemented lock hierarchy to nested-lock `_probe_cache_lock` inside `_in_flight_lock`.
  - Added fallback direct TCP probe for concurrent waiters when cache is empty.
  - Eliminated TOCTOU window by using atomic `try/except FileNotFoundError` on files.
  - Hardened CLN network discovery fallback using `os.path.getmtime` recency check.
- **web/js/app.js & web/index.html**:
  - Updated anchor scroll-to delegation to detect and switch to hidden sections.
  - Implemented URL hash routing for deep-linking FAQ items.
  - Memoized `applySecureModeUI` with a `_lastSecureMode` guard to prevent constant FAQ DOM recreation on polls.
  - Generically labeled LND/CLN restart instructions to prevent user confusion.
- **scripts/sync.sh**: Configured `--dry-run` and promotion script adjustments to strip the Docker socket volume and default `SECURE_MODE=true` for the production App Store.

## Testing Strategy
- **Backend tests**: `venv/bin/pytest server/tests/test_app.py` and `test_csp_sustained.py` (93 passed ✅)
- **Data Persistence & Entrypoint tests**: 9/9 logic test cases passed ✅
- **Frontend Jest tests**: `npm test` (53 passed, including new test cases for tab-switching scroll targets and hash routing ✅)
