### PR TITLE
chore(sync): compliance fixes for app store promotion

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -31,20 +31,33 @@ We utilize an automated release promotion workflow to maintain total parity betw
 When a new version is ready:
 1. Ensure `tunnelsats/umbrel-app.yml` contains the correct new `version: "x.y.z"`.
 2. Ensure the Docker image is built and pushed to Docker Hub (`tunnelsats/ts-umbrel-app:vX.Y.Z`).
-3. Run the automation:
+3. Run the automation by specifying the `SUBMISSION_URL` environment variable:
 ```bash
-npm run promote
-# Under the hood, this executes: scripts/sync.sh promote
+SUBMISSION_URL="https://github.com/getumbrel/umbrel-apps/pull/<PR_NUMBER>" npm run promote
+```
+> [!IMPORTANT]
+> The `SUBMISSION_URL` environment variable is required for production promotions to ensure proper provenance and metadata in the app store. Without it, the promotion script will exit with an error.
+
+#### Previewing Changes (Dry-Run)
+You can run a dry-run to preview the files and changes that would be generated without writing anything to the actual monorepo target. In dry-run mode, `SUBMISSION_URL` is optional and will default to a placeholder (`https://github.com/getumbrel/umbrel-apps/pull/CHANGE_ME`) if unset:
+```bash
+# Via npm script
+npm run promote -- --dry-run
+
+# Or run the script directly
+./scripts/sync.sh promote --dry-run
 ```
 
 **The `promote` automation executes the following sequence:**
+- **Validation**: Enforces that `SUBMISSION_URL` is provided (or defaults to a placeholder in `--dry-run` mode).
 - **Discovery**: Extracts the version from `umbrel-app.yml`.
 - **SHA256 Pinning**: Polls Docker Hub to fetch the official multi-arch digest index and pins it directly into `tunnelsats/docker-compose.yml`, ensuring production immutability.
 - **Monorepo Synchronization**: Recursively forces synchronization (rsync) of the local `tunnelsats/` folder into the target `umbrel-apps` structure.
+- **Metadata Injection**: Independently checks for and injects the `submitter: Tunnelsats` and `submission: <SUBMISSION_URL>` metadata fields into `umbrel-app.yml`.
 - **Hybrid Stripping**: Surgically strips our development absolute GitHub URLs (icons, gallery) from the target `umbrel-app.yml` to maintain Umbrel CDN-first submission protocol compliance.
 
 > [!TIP]
-> **Pre-Push Hook**: A Git pre-push hook intercepts pushes to `master` and prompts the developer to execute this promotion layer automatically before changes are pushed upstream.
+> **Pre-Push Hook**: A Git pre-push hook intercepts pushes to `master` and prompts the developer to execute this promotion layer automatically before changes are pushed upstream. Since promotion requires `SUBMISSION_URL`, ensure it is set in your environment if you choose to trigger promotion during `git push` (e.g., `SUBMISSION_URL="https://github.com/..." git push`).
 
 ## Important Files
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -319,12 +319,27 @@ run_promote() {
     # Remove trailing period from tagline
     sed -E 's/^(tagline:.*)\.$/\1/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
-    # Inject submitter and submission PR URL (Always required for new app validation checks)
-    local sub_url="${SUBMISSION_URL:-https://github.com/getumbrel/umbrel-apps/pull/4919}"
-    if grep -qE "^submitter:" "${target_manifest}"; then
-        log_info "submitter/submission already present, skipping injection."
+    # Validate and determine submission URL
+    if [ -z "${SUBMISSION_URL:-}" ]; then
+        if [ "${dry_run}" = "false" ]; then
+            log_error "SUBMISSION_URL environment variable is required for promotion."
+            return 1
+        fi
+        local sub_url="https://github.com/getumbrel/umbrel-apps/pull/CHANGE_ME"
     else
-        sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+        local sub_url="${SUBMISSION_URL}"
+    fi
+
+    # Inject submitter and submission PR URL
+    if grep -qE "^submitter:" "${target_manifest}" && grep -qE "^submission:" "${target_manifest}"; then
+        log_info "submitter and submission already present, skipping injection."
+    else
+        if ! grep -qE "^submitter:" "${target_manifest}"; then
+            sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+        fi
+        if ! grep -qE "^submission:" "${target_manifest}"; then
+            sed -E "s@^(website:.*)@\1\nsubmission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+        fi
     fi
 
     # Clear releaseNotes (Must be empty for new app submissions to pass official validation checks)

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -305,8 +305,8 @@ run_promote() {
     sed -E -e "s#(ts-umbrel-app:)v?[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
            -e "s/SECURE_MODE=.*/SECURE_MODE=\\\${SECURE_MODE:-true}/" \
            -e "s#\.\./tunnelsats-data#data#" \
-           -e "s#(:/lightning-data/lnd)#\1:ro#" \
-           -e "s#(:/lightning-data/cln)#\1:ro#" \
+           -e "s#(:/lightning-data/lnd)\$#\1:ro#" \
+           -e "s#(:/lightning-data/cln)\$#\1:ro#" \
            -e "/# Host socket/d" \
            -e "/\/var\/run\/docker.sock/d" \
            "${target_compose}" > "${target_compose}.tmp" && mv "${target_compose}.tmp" "${target_compose}"
@@ -330,25 +330,23 @@ run_promote() {
         local sub_url="${SUBMISSION_URL}"
     fi
 
-    # Inject submitter and submission PR URL
-    if grep -qE "^submitter:" "${target_manifest}" && grep -qE "^submission:" "${target_manifest}"; then
-        log_info "submitter and submission already present, skipping injection."
+    # Inject submitter and submission PR URL (or update if already present)
+    if ! grep -qE "^submitter:" "${target_manifest}"; then
+        sed -E "s@^(website:.*)@\1\\"$'\n'"submitter: Tunnelsats@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+    fi
+    if grep -qE "^submission:" "${target_manifest}"; then
+        sed -E "s@^submission:.*@submission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     else
-        if ! grep -qE "^submitter:" "${target_manifest}"; then
-            sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
-        fi
-        if ! grep -qE "^submission:" "${target_manifest}"; then
-            sed -E "s@^(website:.*)@\1\nsubmission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
-        fi
+        sed -E "s@^(website:.*)@\1\\"$'\n'"submission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     fi
 
     # Clear releaseNotes (Must be empty for new app submissions to pass official validation checks)
-    sed -e '/^releaseNotes:/,/^developer:/ { /^releaseNotes:/! { /^developer:/! d } }' \
+    sed -e '/^releaseNotes:/,/^developer:/ { /^releaseNotes:/! { /^developer:/! d; } }' \
         -e 's/^releaseNotes:.*/releaseNotes: ""/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
     # Clear icon and gallery for monorepo submission (assets must not be committed to the store)
     sed -e 's/^icon:.*/icon: ""/' \
-        -e '/^gallery:/,/^path:/ { /^gallery:/! { /^path:/! d } }' \
+        -e '/^gallery:/,/^path:/ { /^gallery:/! { /^path:/! d; } }' \
         -e 's/^gallery:.*/gallery: []/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
     if [ "${dry_run}" = "true" ]; then

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -294,16 +294,19 @@ run_promote() {
         target_dir="/tmp/tunnelsats_promote_dry_run"
         rm -rf "${target_dir}"
         mkdir -p "${target_dir}"
-        rsync -a --exclude=".gitkeep" "${REPO_ROOT}/tunnelsats/" "${target_dir}/"
+        rsync -a --exclude="/icon.svg" --exclude="/gallery" "${REPO_ROOT}/tunnelsats/" "${target_dir}/"
     else
         log_info "Synchronizing to official monorepo at ${UMBREL_APPS_DIR}..."
-        rsync -av --delete --exclude=".gitkeep" "${REPO_ROOT}/tunnelsats/" "${UMBREL_APPS_DIR}/tunnelsats/"
+        rsync -av --delete --exclude="/icon.svg" --exclude="/gallery" "${REPO_ROOT}/tunnelsats/" "${UMBREL_APPS_DIR}/tunnelsats/"
     fi
 
-    log_info "Pinning image digest and setting SECURE_MODE default to true in docker-compose.yml..."
+    log_info "Pinning image digest, adjusting data volume path, and setting SECURE_MODE default to true in docker-compose.yml..."
     local target_compose="${target_dir}/docker-compose.yml"
     sed -E -e "s#(ts-umbrel-app:)v?[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
            -e "s/SECURE_MODE=.*/SECURE_MODE=\\\${SECURE_MODE:-true}/" \
+           -e "s#\.\./tunnelsats-data#data#" \
+           -e "s#(:/lightning-data/lnd)#\1:ro#" \
+           -e "s#(:/lightning-data/cln)#\1:ro#" \
            -e "/# Host socket/d" \
            -e "/\/var\/run\/docker.sock/d" \
            "${target_compose}" > "${target_compose}.tmp" && mv "${target_compose}.tmp" "${target_compose}"
@@ -316,18 +319,19 @@ run_promote() {
     # Remove trailing period from tagline
     sed -E 's/^(tagline:.*)\.$/\1/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
-    # Inject submitter and submission PR URL (if provided)
+    # Inject submitter and submission PR URL (Always required for new app validation checks)
+    local sub_url="${SUBMISSION_URL:-https://github.com/getumbrel/umbrel-apps/pull/4919}"
     if grep -qE "^submitter:" "${target_manifest}"; then
         log_info "submitter/submission already present, skipping injection."
-    elif [ -n "${SUBMISSION_URL:-}" ]; then
-        sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${SUBMISSION_URL}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+    else
+        sed -E "s@^(website:.*)@\1\nsubmitter: Tunnelsats\nsubmission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     fi
 
-    # Clear releaseNotes
+    # Clear releaseNotes (Must be empty for new app submissions to pass official validation checks)
     sed -e '/^releaseNotes:/,/^developer:/ { /^releaseNotes:/! { /^developer:/! d } }' \
         -e 's/^releaseNotes:.*/releaseNotes: ""/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
 
-    # Clear icon and gallery for monorepo submission
+    # Clear icon and gallery for monorepo submission (assets must not be committed to the store)
     sed -e 's/^icon:.*/icon: ""/' \
         -e '/^gallery:/,/^path:/ { /^gallery:/! { /^path:/! d } }' \
         -e 's/^gallery:.*/gallery: []/' "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -305,8 +305,8 @@ run_promote() {
     sed -E -e "s#(ts-umbrel-app:)v?[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
            -e "s/SECURE_MODE=.*/SECURE_MODE=\\\${SECURE_MODE:-true}/" \
            -e "s#\.\./tunnelsats-data#data#" \
-           -e "s#(:/lightning-data/lnd)\$#\1:ro#" \
-           -e "s#(:/lightning-data/cln)\$#\1:ro#" \
+           -e 's#(:/lightning-data/lnd)$#\1:ro#' \
+           -e 's#(:/lightning-data/cln)$#\1:ro#' \
            -e "/# Host socket/d" \
            -e "/\/var\/run\/docker.sock/d" \
            "${target_compose}" > "${target_compose}.tmp" && mv "${target_compose}.tmp" "${target_compose}"
@@ -330,14 +330,19 @@ run_promote() {
         local sub_url="${SUBMISSION_URL}"
     fi
 
+    # Escape special characters for sed replacement to prevent delimiter injection and ampersand expansion
+    local escaped_sub_url="${sub_url//\\/\\\\}"
+    escaped_sub_url="${escaped_sub_url//&/\\&}"
+    escaped_sub_url="${escaped_sub_url//@/\\@}"
+
     # Inject submitter and submission PR URL (or update if already present)
     if ! grep -qE "^submitter:" "${target_manifest}"; then
         sed -E "s@^(website:.*)@\1\\"$'\n'"submitter: Tunnelsats@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     fi
     if grep -qE "^submission:" "${target_manifest}"; then
-        sed -E "s@^submission:.*@submission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+        sed -E "s@^submission:.*@submission: ${escaped_sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     else
-        sed -E "s@^(website:.*)@\1\\"$'\n'"submission: ${sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
+        sed -E "s@^(website:.*)@\1\\"$'\n'"submission: ${escaped_sub_url}@" "${target_manifest}" > "${target_manifest}.tmp" && mv "${target_manifest}.tmp" "${target_manifest}"
     fi
 
     # Clear releaseNotes (Must be empty for new app submissions to pass official validation checks)

--- a/tunnelsats/data/.gitkeep
+++ b/tunnelsats/data/.gitkeep
@@ -1,0 +1,1 @@
+# Track empty data directory for Umbrel App Store volume mounts


### PR DESCRIPTION
# PR: chore(sync): compliance fixes for app store promotion

## Summary of Changes
- Updated the release promotion pipeline and manifest structure to comply with official getumbrel/umbrel-apps validation requirements.

## Detailed Changes
- **scripts/sync.sh**: 
  - Excluded `icon.svg` and `gallery/` assets from the rsync copy transfer to avoid committing large binary image assets to the monorepo.
  - Adjusted the data directory bind mount substitution to use `${APP_DATA_DIR}/data` instead of `${APP_DATA_DIR}/../tunnelsats-data` for official sandbox lifecycle alignment.
  - Formatted the Lightning Node directory mounts to be read-only (`:ro`) in Secure Mode.
  - Ensured `releaseNotes: ""` is maintained in the promoted manifest to pass the new app validation checks.
  - Pre-filled required `submitter` and `submission` properties.
- **tunnelsats/data/.gitkeep**:
  - Added a `.gitkeep` file to track the `data/` directory, satisfying the monorepo volume mount validation checks.

## Testing Strategy
- **Verification**: Verified that the official PR #4919 is fully green and checks are passing after executing the promotion run.