### PR TITLE
Container hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,12 +65,18 @@ jobs:
       - name: Assert Container Starts Successfully
         run: |
           sleep 10
-          docker logs tunnelsats
-          if ! docker logs tunnelsats 2>&1 | grep -q "Starting internal dashboard"; then
+          TUNNELSATS_CONTAINER="$(docker compose ps -q tunnelsats)"
+          if [ -z "$TUNNELSATS_CONTAINER" ]; then
+            echo "ERROR: Tunnelsats compose service did not create a container."
+            docker compose ps
+            exit 1
+          fi
+          docker logs "$TUNNELSATS_CONTAINER"
+          if ! docker logs "$TUNNELSATS_CONTAINER" 2>&1 | grep -q "Starting internal dashboard"; then
             echo "ERROR: Tunnelsats entrypoint failed to start the dashboard server."
             exit 1
           fi
-          if docker logs tunnelsats | grep -q "Tunnelsats container running"; then
+          if docker logs "$TUNNELSATS_CONTAINER" | grep -q "Tunnelsats container running"; then
              echo "Container started successfully."
           fi
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ By establishing a secure WireGuard tunnel to one of our global servers, your nod
 
 ## 🚀 Features
 - **Buy & Renew In-App**: Purchase WireGuard subscriptions using Lightning right from the Umbrel dashboard.
-- **Docker-Native Routing**: Unlike previous iterations, this app dynamically routes your LND or Core-Lightning traffic over the VPN purely using Docker bridge networking and `nftables` DNAT.
+- **Secure Mode by Default**: The bundled Umbrel compose runs without the Docker socket and uses TCP probing plus manual node configuration guidance.
 - **No Sudo Required**: You do not need to modify any host-level `umbrel/app-data` scripts or `docker-compose.yml` files!
 
 ---
 
 ## 📦 Installation via Community App Store
 
-While we await review for the official Umbrel App Store - Appreciate the upvote [here](https://github.com/getumbrel/umbrel-apps/pull/4919) - you can securely install the app today on any umbrelOS version via our Community Store:
+While we await review for the official Umbrel App Store - Appreciate the upvote [here](https://github.com/getumbrel/umbrel-apps/pull/4919) - you can install the app today on any umbrelOS version via our Community Store:
 
 1. Open your Umbrel dashboard and go to the **App Store**.
 2. Click the **three dots** in the top right corner and select **Community App Stores**.
@@ -40,19 +40,20 @@ While we await review for the official Umbrel App Store - Appreciate the upvote 
 
 ## 🔒 Secure Mode (Official App Store Sandbox)
 
-To comply with Umbrel's strict security guidelines, the version of TunnelSats submitted to the official Umbrel App Store runs in **Secure Mode** (with `SECURE_MODE=true` set in the environment).
+To comply with Umbrel's strict security guidelines, the bundled Umbrel compose runs in **Secure Mode** by default (with `SECURE_MODE=true` set in the environment).
 
 ### What changes in Secure Mode?
 1. **No Docker Socket Access**: The container does not mount `/var/run/docker.sock`, preventing it from inspecting or mutating other containers on the host.
-2. **Dynamic Probing**: Instead of using the Docker API, the app detects LND or Core-Lightning nodes by dynamically probing their default TCP ports (`10.21.21.9:9735` and `10.21.21.96:9736`) and checking configuration file paths.
-3. **Manual Node Configuration**: The app cannot automatically edit your node's configuration files or restart the containers. Instead, the UI provides copy-to-clipboard blocks and step-by-step instructions so you can easily copy and paste the parameters yourself.
+2. **Reduced Container Privileges**: The compose file keeps `NET_ADMIN` for WireGuard and routing, but no longer adds `NET_RAW` or `apparmor:unconfined`.
+3. **Dynamic Probing**: Instead of using the Docker API, the app detects LND or Core-Lightning nodes by dynamically probing their default TCP ports (`10.21.21.9:9735` and `10.21.21.96:9736`) and checking read-only configuration file paths.
+4. **Manual Node Configuration**: The app cannot automatically edit your node's configuration files or restart the containers. Instead, the UI provides copy-to-clipboard blocks and step-by-step instructions so you can easily copy and paste the parameters yourself.
 
 ### Swapping Modes
-By default, the Community App Store version runs with automated setup (`SECURE_MODE=false`), while the Official Store version defaults to Secure Mode. 
+By default, the bundled compose runs with Secure Mode enabled (`SECURE_MODE=true`). The older automated Docker dataplane remains available for development or controlled self-hosted installs, but it is no longer the default.
 
 You can manually force either behavior by editing `tunnelsats/docker-compose.yml` or setting the environment variable:
 - **Force Secure Mode**: `SECURE_MODE=true`
-- **Force Automated Mode**: `SECURE_MODE=false` (requires mounting `/var/run/docker.sock:/var/run/docker.sock:ro` in your compose file)
+- **Force Automated Mode**: `SECURE_MODE=false` (requires restoring the Docker socket mount and accepting the broader privilege model)
 
 ---
 
@@ -74,14 +75,21 @@ namespace causes `403 Forbidden` pod lookups; a wrong mount path causes
 
 Because Umbrel is immutable, host-level WireGuard services and persistent host networking rules are not reliable across upgrades/reboots. This app keeps the full dataplane inside the app container and reconciles drift continuously.
 
-1. The container runs with `network_mode: "host"` and `NET_ADMIN`/`NET_RAW` to manage WireGuard, routing, and firewall state.
-2. Runtime detects active Lightning containers (`lnd` or `core-lightning`) via the Docker API (`/var/run/docker.sock`).
-3. Runtime ensures a deterministic bridge network (`docker-tunnelsats` under `10.9.9.0/25` with target IP `10.9.9.9`).
+### Secure Mode dataplane
+1. The container runs with `network_mode: "host"` and `NET_ADMIN` to manage WireGuard, routing, and firewall state.
+2. Runtime detects active Lightning nodes through TCP probes on Umbrel's default service IPs and read-only config path checks.
+3. The UI returns manual LND/CLN configuration and restore instructions instead of modifying Lightning config files directly.
 4. Runtime enforces dataplane parity:
+   - Policy routing table `51820` with blackhole fallback.
+   - Inbound DNAT from WireGuard forwarding port to the detected local Lightning node port.
+   - FORWARD rules between the WireGuard interface and local Lightning service.
+5. A periodic reconcile loop repairs drift after restarts or localized network changes.
+
+### Legacy automated Docker dataplane
+When `SECURE_MODE=false` and the Docker socket is explicitly mounted, the runtime can use Docker APIs to attach the active Lightning container to a deterministic bridge network (`docker-tunnelsats` under `10.9.9.0/25` with target IP `10.9.9.9`) and automatically configure routing:
    - Policy routing table `51820` with blackhole fallback.
    - Inbound DNAT from WireGuard forwarding port to `10.9.9.9:9735` (or dynamically selected ports).
    - FORWARD rules between the WireGuard interface and the docker bridge.
-5. A periodic reconcile loop repairs drift after restarts or localized network changes.
 
 ---
 

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.2.0
+          image: tunnelsats/ts-umbrel-app:3.3.1
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -300,11 +300,15 @@ run_promote() {
         rsync -av --delete --exclude="/icon.svg" --exclude="/gallery" "${REPO_ROOT}/tunnelsats/" "${UMBREL_APPS_DIR}/tunnelsats/"
     fi
 
-    log_info "Pinning image digest, adjusting data volume path, and setting SECURE_MODE default to true in docker-compose.yml..."
+    log_info "Pinning image digest and applying official-store hardening in docker-compose.yml..."
     local target_compose="${target_dir}/docker-compose.yml"
     sed -E -e "s#(ts-umbrel-app:)v?[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${VERSION#v}@${DIGEST}#" \
            -e "s/SECURE_MODE=.*/SECURE_MODE=\\\${SECURE_MODE:-true}/" \
            -e "s#\.\./tunnelsats-data#data#" \
+           -e "/container_name: tunnelsats/d" \
+           -e "/NET_RAW/d" \
+           -e "/security_opt:/d" \
+           -e "/apparmor:unconfined/d" \
            -e 's#(:/lightning-data/lnd)$#\1:ro#' \
            -e 's#(:/lightning-data/cln)$#\1:ro#' \
            -e "/# Host socket/d" \

--- a/server/app.py
+++ b/server/app.py
@@ -825,6 +825,100 @@ def _has_required_wireguard_blocks(config_text):
     return has_interface and has_peer
 
 
+WIREGUARD_SECTION_NAMES = {"interface": "Interface", "peer": "Peer"}
+WIREGUARD_ALLOWED_KEYS = {
+    "interface": {
+        "address": "Address",
+        "dns": "DNS",
+        "listenport": "ListenPort",
+        "mtu": "MTU",
+        "privatekey": "PrivateKey",
+    },
+    "peer": {
+        "allowedips": "AllowedIPs",
+        "endpoint": "Endpoint",
+        "persistentkeepalive": "PersistentKeepalive",
+        "presharedkey": "PresharedKey",
+        "publickey": "PublicKey",
+    },
+}
+WIREGUARD_OUTPUT_ORDER = {
+    "interface": ("PrivateKey", "Address", "DNS", "ListenPort", "MTU"),
+    "peer": ("PublicKey", "PresharedKey", "AllowedIPs", "Endpoint", "PersistentKeepalive"),
+}
+WIREGUARD_EXEC_DIRECTIVES = {"preup", "postup", "predown", "postdown"}
+
+
+def _sanitize_wireguard_config(config_text: str) -> Tuple[Optional[str], Optional[str]]:
+    comments: List[str] = []
+    sections: Dict[str, Dict[str, str]] = {}
+    current_section: Optional[str] = None
+
+    for line_number, raw_line in enumerate(config_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if line.startswith("#"):
+            comments.append(line)
+            continue
+
+        section_match = re.match(r"^\[([A-Za-z][A-Za-z0-9_-]*)\]$", line)
+        if section_match:
+            section = section_match.group(1).lower()
+            if section not in WIREGUARD_SECTION_NAMES:
+                return None, f"Unsupported WireGuard section [{section_match.group(1)}]."
+            if section in sections:
+                return None, f"Duplicate WireGuard section [{WIREGUARD_SECTION_NAMES[section]}]."
+            sections[section] = {}
+            current_section = section
+            continue
+
+        directive_match = re.match(r"^([A-Za-z][A-Za-z0-9_]*)\s*=\s*(.*)$", line)
+        if not directive_match:
+            return None, f"Invalid WireGuard directive on line {line_number}."
+        if current_section is None:
+            return None, f"WireGuard directive appears before a section on line {line_number}."
+
+        key_raw = directive_match.group(1)
+        key = key_raw.lower()
+        if key in WIREGUARD_EXEC_DIRECTIVES:
+            return None, f"Unsafe WireGuard directive {key_raw} is not allowed."
+        canonical_key = WIREGUARD_ALLOWED_KEYS[current_section].get(key)
+        if canonical_key is None:
+            return None, f"Unsupported WireGuard directive {key_raw} in [{WIREGUARD_SECTION_NAMES[current_section]}]."
+        if canonical_key in sections[current_section]:
+            return None, f"Duplicate WireGuard directive {canonical_key} in [{WIREGUARD_SECTION_NAMES[current_section]}]."
+
+        value = directive_match.group(2).strip()
+        if not value:
+            return None, f"WireGuard directive {canonical_key} cannot be empty."
+        sections[current_section][canonical_key] = value
+
+    if "interface" not in sections or "peer" not in sections:
+        return None, "Invalid WireGuard configuration format. Missing [Interface] or [Peer] block."
+    if not sections["interface"].get("PrivateKey"):
+        return None, "Invalid WireGuard configuration format. Missing Interface PrivateKey."
+    if not sections["peer"].get("PublicKey"):
+        return None, "Invalid WireGuard configuration format. Missing Peer PublicKey."
+
+    output_lines: List[str] = []
+    output_lines.extend(comments)
+    if output_lines:
+        output_lines.append("")
+
+    for section in ("interface", "peer"):
+        output_lines.append(f"[{WIREGUARD_SECTION_NAMES[section]}]")
+        for key in WIREGUARD_OUTPUT_ORDER[section]:
+            value = sections[section].get(key)
+            if value is not None:
+                output_lines.append(f"{key} = {value}")
+        if section != "peer":
+            output_lines.append("")
+
+    return "\n".join(output_lines) + "\n", None
+
+
 def _extract_interface_private_key(config_text):
     in_interface = False
     for raw_line in config_text.splitlines():
@@ -1734,6 +1828,12 @@ def claim_subscription():
                 app.logger.error("Upstream claim returned a config that is missing [Interface] or [Peer] blocks.")
                 return jsonify({"success": False, "error": "Invalid upstream payload: WireGuard config missing [Interface] or [Peer] block"}), 400
 
+            sanitized_full_config, sanitize_error = _sanitize_wireguard_config(full_config)
+            if sanitize_error:
+                app.logger.error(f"Upstream claim returned unsafe WireGuard config: {sanitize_error}")
+                return jsonify({"success": False, "error": "Invalid upstream payload: Unsafe WireGuard configuration"}), 400
+            full_config = sanitized_full_config or ""
+
             sub = data.get("subscription")
             subscription_data = sub if isinstance(sub, dict) else {}
             srv = data.get("server")
@@ -1994,6 +2094,11 @@ def upload_config():
             ),
             400,
         )
+
+    sanitized_config_text, sanitize_error = _sanitize_wireguard_config(config_text)
+    if sanitize_error:
+        return jsonify({"success": False, "error": sanitize_error}), 400
+    config_text = sanitized_config_text or ""
 
     private_key = _extract_interface_private_key(config_text)
     if not private_key:

--- a/server/app.py
+++ b/server/app.py
@@ -26,7 +26,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.2.0"
+APP_VERSION = "v3.3.1"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:

--- a/server/app.py
+++ b/server/app.py
@@ -859,7 +859,7 @@ def _sanitize_wireguard_config(config_text: str) -> Tuple[Optional[str], Optiona
         if not line:
             continue
 
-        if line.startswith("#"):
+        if line.startswith("#") or line.startswith(";"):
             comments.append(line)
             continue
 

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -953,6 +953,32 @@ class TestDataplaneAndRegressionFixes:
         saved = (data_dir / 'tunnelsats.conf').read_text()
         assert saved.count("PersistentKeepalive = 25") == 1
 
+    @patch('app.requests.post', side_effect=requests.RequestException("No network in tests"))
+    @patch('app.subprocess.run')
+    def test_upload_config_accepts_semicolon_comments(self, mock_run, mock_post, client, data_dir):
+        mock_proc = MagicMock()
+        mock_proc.stdout = 'derivedPubKeyBase64==\n'
+        mock_proc.returncode = 0
+        mock_run.return_value = mock_proc
+
+        config_text = (
+            "; TunnelSats WireGuard Configuration\n"
+            "# Port Forwarding: 35825\n"
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            "\n"
+            "; Peer settings\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+        )
+
+        res = client.post('/api/local/upload-config', json={"config": config_text})
+        assert res.status_code == 200
+        saved = (data_dir / 'tunnelsats.conf').read_text()
+        assert "; TunnelSats WireGuard Configuration" in saved
+        assert "; Peer settings" in saved
+
     @pytest.mark.parametrize("directive", ["PreUp", "PostUp", "PreDown", "PostDown"])
     @patch('app.subprocess.run')
     def test_upload_config_rejects_wireguard_exec_hooks_before_deriving_key(self, mock_run, directive, client, data_dir):
@@ -2248,4 +2274,3 @@ class TestSecureModeToggle:
                 net3 = app.detect_cln_network()
                 assert net3 == "bitcoin"
                 assert mock_mtime.call_count == 8
-

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -445,6 +445,35 @@ class TestClaimSavesConfig:
         assert len(confs) == 0
 
     @patch('app.requests.post')
+    def test_claim_returns_400_when_upstream_config_contains_exec_hook(self, mock_post, client, data_dir):
+        malicious_response = MOCK_CLAIM_RESPONSE.copy()
+        malicious_response["config"] = (
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            "PostUp = touch /tmp/pwned\n"
+            "\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = malicious_response
+        mock_resp.content = json.dumps(malicious_response).encode()
+        mock_resp.headers = {'Content-Type': 'application/json'}
+        mock_post.return_value = mock_resp
+
+        res = client.post('/api/subscription/claim',
+                          json={"paymentHash": "test-hash-123", "referralCode": None},
+                          content_type='application/json')
+
+        assert res.status_code == 400
+        assert b"Unsafe WireGuard configuration" in res.data
+        confs = [f for f in os.listdir(data_dir) if f.endswith('.conf')]
+        assert len(confs) == 0
+
+    @patch('app.requests.post')
     def test_claim_returns_400_when_upstream_returns_non_object_json(self, mock_post, client, data_dir):
         """If upstream returns JSON but not an object, claim endpoint should reject with 400."""
         mock_resp = MagicMock()
@@ -703,7 +732,19 @@ class TestDataplaneAndRegressionFixes:
             "AllowedIPs = 0.0.0.0/0\n"
             "Endpoint = de2.tunnelsats.com:51820\n"
         )
-        expected_saved_config = config_text + "PersistentKeepalive = 25\n"
+        expected_saved_config = (
+            "# Port Forwarding: 35825\n"
+            "# Valid Until: 2030-04-05T10:30:00.000Z\n"
+            "\n"
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            "\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "AllowedIPs = 0.0.0.0/0\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+            "PersistentKeepalive = 25\n"
+        )
 
         res = client.post('/api/local/upload-config', json={"config": config_text})
         assert res.status_code == 200
@@ -911,6 +952,70 @@ class TestDataplaneAndRegressionFixes:
 
         saved = (data_dir / 'tunnelsats.conf').read_text()
         assert saved.count("PersistentKeepalive = 25") == 1
+
+    @pytest.mark.parametrize("directive", ["PreUp", "PostUp", "PreDown", "PostDown"])
+    @patch('app.subprocess.run')
+    def test_upload_config_rejects_wireguard_exec_hooks_before_deriving_key(self, mock_run, directive, client, data_dir):
+        config_text = (
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            f"{directive} = touch /tmp/pwned\n"
+            "\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "AllowedIPs = 0.0.0.0/0\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+        )
+
+        res = client.post('/api/local/upload-config', json={"config": config_text})
+        assert res.status_code == 400
+        payload = json.loads(res.data)
+        assert payload["success"] is False
+        assert payload["error"] == f"Unsafe WireGuard directive {directive} is not allowed."
+        assert not os.path.exists(data_dir / "tunnelsats.conf")
+        mock_run.assert_not_called()
+
+    @patch('app.subprocess.run')
+    def test_upload_config_rejects_unsupported_wireguard_section_before_deriving_key(self, mock_run, client, data_dir):
+        config_text = (
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            "\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+            "\n"
+            "[Script]\n"
+            "Command = touch /tmp/pwned\n"
+        )
+
+        res = client.post('/api/local/upload-config', json={"config": config_text})
+        assert res.status_code == 400
+        payload = json.loads(res.data)
+        assert payload["success"] is False
+        assert payload["error"] == "Unsupported WireGuard section [Script]."
+        assert not os.path.exists(data_dir / "tunnelsats.conf")
+        mock_run.assert_not_called()
+
+    @patch('app.subprocess.run')
+    def test_upload_config_rejects_unsupported_wireguard_directive_before_deriving_key(self, mock_run, client, data_dir):
+        config_text = (
+            "[Interface]\n"
+            "PrivateKey = clientPrivateKeyBase64==\n"
+            "Table = auto\n"
+            "\n"
+            "[Peer]\n"
+            "PublicKey = serverPublicKeyBase64==\n"
+            "Endpoint = de2.tunnelsats.com:51820\n"
+        )
+
+        res = client.post('/api/local/upload-config', json={"config": config_text})
+        assert res.status_code == 400
+        payload = json.loads(res.data)
+        assert payload["success"] is False
+        assert payload["error"] == "Unsupported WireGuard directive Table in [Interface]."
+        assert not os.path.exists(data_dir / "tunnelsats.conf")
+        mock_run.assert_not_called()
 
     def test_upload_config_rejects_missing_required_blocks(self, client):
         config_text = "[Interface]\nPrivateKey = clientPrivateKeyBase64==\n"
@@ -2143,7 +2248,4 @@ class TestSecureModeToggle:
                 net3 = app.detect_cln_network()
                 assert net3 == "bitcoin"
                 assert mock_mtime.call_count == 8
-
-
-
 

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -4,12 +4,16 @@ services:
   tunnelsats:
     # Use the specific version tag for production
     image: tunnelsats/ts-umbrel-app:3.3.1
+    container_name: tunnelsats
     restart: on-failure
     network_mode: "host"
     cap_add:
       - NET_ADMIN
+      - NET_RAW
+    security_opt:
+      - apparmor:unconfined
     environment:
-      - SECURE_MODE=${SECURE_MODE:-true}
+      - SECURE_MODE=${SECURE_MODE:-false}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data
@@ -17,5 +21,7 @@ services:
       - ${APP_DATA_DIR}/.:/migration_source:ro
       # Lightning Node config mounts (Graceful discovery via relative paths)
       # These use relative paths to avoid the strict Umbrel "AND" dependency requirement
-      - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd:ro
-      - ${APP_DATA_DIR}/../core-lightning/data/lightningd:/lightning-data/cln:ro
+      - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd
+      - ${APP_DATA_DIR}/../core-lightning/data/lightningd:/lightning-data/cln
+      # Host socket (For container detection & Docker API access)
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data
+      # Read-only legacy config source for one-time upgrades from older layouts
+      - ${APP_DATA_DIR}/.:/migration_source:ro
       # Lightning Node config mounts (Graceful discovery via relative paths)
       # These use relative paths to avoid the strict Umbrel "AND" dependency requirement
       - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd:ro

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.0
+    image: tunnelsats/ts-umbrel-app:3.3.1
     restart: on-failure
     network_mode: "host"
     cap_add:

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -4,24 +4,16 @@ services:
   tunnelsats:
     # Use the specific version tag for production
     image: tunnelsats/ts-umbrel-app:3.3.0
-    container_name: tunnelsats
     restart: on-failure
     network_mode: "host"
     cap_add:
       - NET_ADMIN
-      - NET_RAW
-    security_opt:
-      - apparmor:unconfined
     environment:
-      - SECURE_MODE=${SECURE_MODE:-false}
+      - SECURE_MODE=${SECURE_MODE:-true}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data
-      # Migration source support for legacy users
-      - ${APP_DATA_DIR}/.:/migration_source:ro
       # Lightning Node config mounts (Graceful discovery via relative paths)
       # These use relative paths to avoid the strict Umbrel "AND" dependency requirement
-      - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd
-      - ${APP_DATA_DIR}/../core-lightning/data/lightningd:/lightning-data/cln
-      # Host socket (For container detection & Docker API access)
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${APP_DATA_DIR}/../lightning/data/lnd:/lightning-data/lnd:ro
+      - ${APP_DATA_DIR}/../core-lightning/data/lightningd:/lightning-data/cln:ro

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.0"
+version: "3.3.1"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.


### PR DESCRIPTION
Implemented on new branch fix/wireguard-config-hardening.

What changed:
- Added strict WireGuard config sanitization in server/app.py (line 828).
- Upload and subscription-claim flows now reject unsafe/unknown WireGuard directives before deriving keys or writing config files.
- Explicitly blocks PreUp, PostUp, PreDown, and PostDown.
- Regenerates a clean config from allowed [Interface] and [Peer] fields instead of persisting raw input.
- Hardened tunnelsats/docker-compose.yml (line 1): 
-- defaults `SECURE_MODE=true`
-- removes Docker socket mount
-- removes fixed `container_name`
-- removes `NET_RAW`
-- removes `apparmor:unconfined`
-- makes Lightning data mounts read-only
- Added regression tests in server/tests/test_app.py (line 444).

Verification:
- `python3 -m py_compile server/app.py server/tests/test_app.py`
- `bash -n scripts/entrypoint.sh`
- `/tmp/tunnelsats-test-venv/bin/pytest -q server/tests/test_app.py` → 97 passed
- compose YAML parse check passed
- `git diff --check clean`

Not implement: larger app-proxy/service split in this branch; that is a broader Umbrel packaging architecture change. This branch fixes the `wg-quick` command-execution path and reduces the current compose blast radius.