### PR TITLE
[Bug]: Allow Tailscale / CGNAT IPs (100.64.0.0/10) for local API

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -284,6 +284,7 @@ _metadata_lock = threading.Lock()
 ALLOWED_NETWORKS = (
     ip_network("127.0.0.0/8"),
     ip_network("10.0.0.0/8"),
+    ip_network("100.64.0.0/10"),  # RFC 6598 Shared Address Space (Tailscale/Headscale CGNAT)
     ip_network("172.16.0.0/12"),
     ip_network("192.168.0.0/16"),
     ip_network("::1/128"),

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -743,6 +743,26 @@ class TestDataplaneAndRegressionFixes:
         })
         assert res.status_code == 200
 
+    def test_local_api_allows_tailscale_cgnat_address(self, client):
+        for ip in ['100.64.0.1', '100.117.194.79', '100.127.255.254']:
+            res = client.get('/api/local/status', environ_base={
+                'REMOTE_ADDR': ip
+            })
+            assert res.status_code == 200, f"Expected 200 for Tailscale CGNAT IP {ip}"
+
+    def test_local_api_allows_ipv4_mapped_tailscale_address(self, client):
+        res = client.get('/api/local/status', environ_base={
+            'REMOTE_ADDR': '::ffff:100.64.1.2'
+        })
+        assert res.status_code == 200
+
+    def test_local_api_rejects_non_cgnat_100_address(self, client):
+        for ip in ['100.63.255.255', '100.128.0.1']:
+            res = client.get('/api/local/status', environ_base={
+                'REMOTE_ADDR': ip
+            })
+            assert res.status_code == 403, f"Expected 403 for non-CGNAT 100.x IP {ip}"
+
     @patch('app.requests.post', side_effect=requests.RequestException("No network in tests"))
     @patch('app.subprocess.run')
     def test_upload_config_saves_tunnelsats_conf_and_meta(self, mock_run, mock_post, client, data_dir):


### PR DESCRIPTION
# PR: [Bug]: Allow Tailscale / CGNAT IPs (100.64.0.0/10) for local API

## Summary of Changes
- Fixes #109 where users accessing the Tunnel⚡Sats Umbrel app UI remotely via Tailscale or other mesh VPN services (using the RFC 6598 CGNAT address space `100.64.0.0/10`) received a `403 Forbidden` error on local API endpoints.
- Added `ip_network("100.64.0.0/10")` to `ALLOWED_NETWORKS` in `server/app.py`.

## Detailed Changes
- `server/app.py`: Included `100.64.0.0/10` in `ALLOWED_NETWORKS` tuple.
- `server/tests/test_app.py`: Added unit tests for:
  - Allowing Tailscale CGNAT IPs (`100.64.0.1`, `100.117.194.79`, `100.127.255.254`).
  - Allowing IPv4-mapped IPv6 Tailscale CGNAT IPs (`::ffff:100.64.1.2`).
  - Rejecting non-CGNAT `100.x` addresses (`100.63.255.255`, `100.128.0.1`).

## Testing Strategy
- **Unit Tests**:
  - Python (`pytest`): 129/129 passed ✅
  - Jest (`npm test`): 56/56 passed ✅
- **Live Verification**:
  - Hot-patched on local Umbrel test node (`umbrel.lan`).
  - Verified `client_is_allowed('100.117.194.79')` resolves to `True` and `/api/local/status` returns HTTP `200 OK`.