### PR TITLE
chore(release): bump version to v3.3.3

### DIFF
--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.3.2
+          image: tunnelsats/ts-umbrel-app:3.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/server/app.py
+++ b/server/app.py
@@ -27,7 +27,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.3.2"
+APP_VERSION = "v3.3.3"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.2
+    image: tunnelsats/ts-umbrel-app:3.3.3
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.2"
+version: "3.3.3"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.

--- a/web/index.html
+++ b/web/index.html
@@ -924,7 +924,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.2</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.3</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary of Changes
Bump version to `v3.3.3` across manifest, compose, backend, frontend, and deployment configurations to trigger GitHub Actions Docker release workflow for `tunnelsats/ts-umbrel-app:3.3.3` and GitHub Release `v3.3.3`.

Includes changes from:
- #110: Tailscale/Headscale CGNAT subnet (100.64.0.0/10) support.
- #106: Official Store promotion pipeline exclusion updates & standalone diagnostic script integration.

## Testing Strategy
- **Backend Tests**: 125/125 passing ✅
- **Frontend Tests**: 56/56 passing ✅