### PR TITLE
feat(dataplane): harden policy routing & add automated version sync guardrails (fixes #112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [3.3.4]
+
+- Hardened dataplane policy routing and fallback blackhole rules for target node network isolation. Integrated automated version sync guardrails.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -29,12 +29,19 @@ dev@env:~/ts-umbrel-app$ rsync -av --delete tunnelsats/ umbrel@umbrel.local:~/um
 We utilize an automated release promotion workflow to maintain total parity between our local repository and the official `umbrel-apps` GitHub fork.
 
 When a new version is ready:
-1. Ensure `tunnelsats/umbrel-app.yml` contains the correct new `version: "x.y.z"`.
-2. Ensure the Docker image is built and pushed to Docker Hub (`tunnelsats/ts-umbrel-app:vX.Y.Z`).
-3. Run the automation by specifying the `SUBMISSION_URL` environment variable:
-```bash
-SUBMISSION_URL="https://github.com/getumbrel/umbrel-apps/pull/<PR_NUMBER>" npm run promote
-```
+1. Update every canonical version location, release notes, and `CHANGELOG.md` through the transactional version command:
+
+   ```bash
+   ./scripts/sync.sh version X.Y.Z --notes "Summary of this release"
+   ```
+
+2. Run the test suite and review the generated changes.
+3. Ensure the Docker image is built and pushed to Docker Hub (`tunnelsats/ts-umbrel-app:X.Y.Z`).
+4. Run the promotion automation by specifying the `SUBMISSION_URL` environment variable:
+
+   ```bash
+   SUBMISSION_URL="https://github.com/getumbrel/umbrel-apps/pull/<PR_NUMBER>" npm run promote
+   ```
 > [!IMPORTANT]
 > The `SUBMISSION_URL` environment variable is required for production promotions to ensure proper provenance and metadata in the app store. Without it, the promotion script will exit with an error.
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -11,37 +11,73 @@ This document explains the repository structure and workflow for the TunnelSats 
 | `scripts/` | Tooling for vendor sync, node diagnostics, and persistence testing. |
 | `umbrel-apps/tunnelsats/` | **External Monorepo Target** for official submissions. |
 
-## Single Source of Truth
+## Single Source of Truth & Version Control
 
-*   **Docker Compose**: The canonical `docker-compose.yml` is located in `tunnelsats/docker-compose.yml`.
-*   **Root Convenience Link**: The root `docker-compose.yml` is a symlink to `tunnelsats/docker-compose.yml` for local tooling compatibility.
+- **Canonical Version Locations**: App versioning is maintained across 5 synchronized locations:
+  1. `tunnelsats/umbrel-app.yml` (`version: "X.Y.Z"`)
+  2. `tunnelsats/docker-compose.yml` (`image: tunnelsats/ts-umbrel-app:X.Y.Z`)
+  3. `server/app.py` (`APP_VERSION = "vX.Y.Z"`)
+  4. `web/index.html` (`id="app-version">vX.Y.Z</span>`)
+  5. `k3s/deployment.yaml` (`image: tunnelsats/ts-umbrel-app:X.Y.Z`)
+- **Docker Compose**: The canonical `docker-compose.yml` is located in `tunnelsats/docker-compose.yml`. The root `docker-compose.yml` is a symlink to `tunnelsats/docker-compose.yml` for local tooling compatibility.
+- **Changelog & Release Notes**: `CHANGELOG.md` tracks human-readable version history. Manifest `releaseNotes:` in `umbrel-app.yml` is populated dynamically during version bumps.
 
-## Synchronization Workflow
+---
 
-### 1. Verification (Local/Remote)
-Always verify your changes on a live Umbrel node before submitting to the monorepo:
+## Release & Versioning Workflow (Step-by-Step Sequence)
+
+To ensure 100% version parity, prevent silent CI release suppression, and maintain clean release notes, follow this exact sequence when preparing a release:
+
+### 1. Feature / Hotfix Development & Testing
+Make your code changes on a feature/fix branch and run local test suites:
 ```bash
-# Sync local dev to Umbrel node and restart
-dev@env:~/ts-umbrel-app$ rsync -av --delete tunnelsats/ umbrel@umbrel.local:~/umbrel/app-data/tunnelsats/
+# Python Backend & Version Sync Guardrails
+pytest server/tests/
+
+# Frontend Web UI Tests
+cd web && npm test
 ```
 
-### 2. Multi-Repo Release Automation (`promote`)
+### 2. Atomic Version Bump & Release Notes Population
+**Never edit version strings manually across the 5 files.** Use the transactional CLI bumper:
+```bash
+python3 scripts/bump_version.py <X.Y.Z> --notes "<Single-line summary of changes>"
+```
+*Example:*
+```bash
+python3 scripts/bump_version.py 3.3.4 --notes "Harden policy routing fallback rules and automate version sync guardrails"
+```
+
+This single command atomically:
+1. Updates the version string across all 5 canonical files.
+2. Dynamically populates `releaseNotes:` in `tunnelsats/umbrel-app.yml`.
+3. Appends or updates the version entry in `CHANGELOG.md`.
+4. Performs staged writes with automatic rollback if any file update fails.
+
+### 3. Verify Version Parity
+Run the automated version sync guardrail test to guarantee 100% parity:
+```bash
+pytest server/tests/test_version_sync.py
+```
+
+### 4. Commit, PR, & CI Release Automation
+Commit the synchronized files and open a PR to `master`:
+```bash
+git add -A
+git commit -m "chore(release): bump version to v3.3.4"
+git push origin <feature-branch>
+```
+Upon merging to `master`:
+- GitHub Actions automatically verifies version parity via `test_version_sync.py`.
+- If `version` is new, CI builds `tunnelsats/ts-umbrel-app:X.Y.Z` on Docker Hub and creates GitHub Release `vX.Y.Z`.
+
+### 5. Multi-Repo Release Automation (`promote`)
 We utilize an automated release promotion workflow to maintain total parity between our local repository and the official `umbrel-apps` GitHub fork.
 
-When a new version is ready:
-1. Update every canonical version location, release notes, and `CHANGELOG.md` through the transactional version command:
-
-   ```bash
-   ./scripts/sync.sh version X.Y.Z --notes "Summary of this release"
-   ```
-
-2. Run the test suite and review the generated changes.
-3. Ensure the Docker image is built and pushed to Docker Hub (`tunnelsats/ts-umbrel-app:X.Y.Z`).
-4. Run the promotion automation by specifying the `SUBMISSION_URL` environment variable:
-
-   ```bash
-   SUBMISSION_URL="https://github.com/getumbrel/umbrel-apps/pull/<PR_NUMBER>" npm run promote
-   ```
+When a new version is merged to `master`:
+```bash
+SUBMISSION_URL="https://github.com/getumbrel/umbrel-apps/pull/<PR_NUMBER>" npm run promote
+```
 > [!IMPORTANT]
 > The `SUBMISSION_URL` environment variable is required for production promotions to ensure proper provenance and metadata in the app store. Without it, the promotion script will exit with an error.
 

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.3.3
+          image: tunnelsats/ts-umbrel-app:3.3.4
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Atomic Version Bump Tool for ts-umbrel-app
+Transactional Version Bump Tool for ts-umbrel-app
 Updates version string across all 5 canonical file locations:
   1. tunnelsats/umbrel-app.yml (version and releaseNotes)
   2. tunnelsats/docker-compose.yml (image tag)
@@ -10,10 +10,12 @@ Updates version string across all 5 canonical file locations:
 Also updates or creates CHANGELOG.md.
 """
 
-import sys
+import argparse
+import json
 import os
 import re
-import argparse
+import stat
+import tempfile
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
@@ -23,84 +25,232 @@ APP_PY_PATH = os.path.join(REPO_ROOT, "server", "app.py")
 INDEX_HTML_PATH = os.path.join(REPO_ROOT, "web", "index.html")
 DEPLOYMENT_K3S_PATH = os.path.join(REPO_ROOT, "k3s", "deployment.yaml")
 CHANGELOG_PATH = os.path.join(REPO_ROOT, "CHANGELOG.md")
+MAX_DOCKER_TAG_LENGTH = 128
 
-def update_file(path, pattern, replacement):
-    with open(path, "r") as f:
-        content = f.read()
-    new_content, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
-    if count == 0:
-        raise ValueError(f"Pattern '{pattern}' not found in {path}")
-    with open(path, "w") as f:
-        f.write(new_content)
-    print(f"Updated {os.path.relpath(path, REPO_ROOT)}")
+SEMVER_PATTERN = re.compile(
+    r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+    r"(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$"
+)
+
+
+def normalize_version(version):
+    clean_version = version.strip()
+    if clean_version.startswith("v"):
+        clean_version = clean_version[1:]
+    if (
+        not SEMVER_PATTERN.fullmatch(clean_version)
+        or len(clean_version) > MAX_DOCKER_TAG_LENGTH
+    ):
+        raise ValueError(
+            f"Invalid version '{version}': expected SemVer compatible with a Docker tag "
+            f"of at most {MAX_DOCKER_TAG_LENGTH} characters "
+            "(for example 3.3.4 or 3.3.4-rc.1)"
+        )
+    return clean_version
+
+
+def replace_required(content, pattern, replacement, path):
+    new_content, count = re.subn(
+        pattern,
+        replacement,
+        content,
+        flags=re.MULTILINE,
+    )
+    if count != 1:
+        raise ValueError(
+            f"Expected exactly one match for pattern '{pattern}' in {path}, found {count}"
+        )
+    return new_content
+
+
+def stage_file(path, content):
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    mode = stat.S_IMODE(os.stat(path).st_mode) if os.path.exists(path) else 0o644
+    fd, temp_path = tempfile.mkstemp(prefix=".version-bump.", dir=directory, text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as staged:
+            staged.write(content)
+            staged.flush()
+            os.fsync(staged.fileno())
+        os.chmod(temp_path, mode)
+    except BaseException:
+        os.unlink(temp_path)
+        raise
+    return temp_path
+
+
+def commit_updates(updates, originals):
+    staged = {}
+    rollbacks = {}
+    preserved_rollbacks = set()
+    try:
+        for path, content in updates.items():
+            staged[path] = stage_file(path, content)
+            if originals[path] is not None:
+                rollbacks[path] = stage_file(path, originals[path])
+
+        for path in updates:
+            os.replace(staged[path], path)
+            staged[path] = None
+    except BaseException:
+        rollback_errors = []
+        replaced_paths = [
+            path
+            for path in updates
+            if path in staged
+            and (
+                staged[path] is None
+                or not os.path.exists(staged[path])
+            )
+        ]
+        for path in reversed(replaced_paths):
+            try:
+                if originals[path] is None:
+                    os.unlink(path)
+                else:
+                    os.replace(rollbacks[path], path)
+                    rollbacks[path] = None
+            except BaseException as rollback_error:
+                backup_path = rollbacks.get(path)
+                if backup_path and os.path.exists(backup_path):
+                    preserved_rollbacks.add(path)
+                    recovery_hint = f"; original preserved at {backup_path}"
+                else:
+                    recovery_hint = ""
+                rollback_errors.append(f"{path}: {rollback_error}{recovery_hint}")
+        if rollback_errors:
+            raise RuntimeError(
+                "Version bump failed and rollback was incomplete: "
+                + "; ".join(rollback_errors)
+            )
+        raise
+    finally:
+        cleanup_paths = list(staged.values())
+        cleanup_paths.extend(
+            temp_path
+            for path, temp_path in rollbacks.items()
+            if path not in preserved_rollbacks
+        )
+        for temp_path in cleanup_paths:
+            if temp_path and os.path.exists(temp_path):
+                os.unlink(temp_path)
 
 def bump_version(new_version, release_notes=None):
-    clean_version = new_version.strip().lstrip("v")
+    clean_version = normalize_version(new_version)
+    clean_release_notes = release_notes.strip() if release_notes is not None else ""
+    if not clean_release_notes:
+        raise ValueError("Release notes are required and must not be blank")
+    if "\n" in clean_release_notes or "\r" in clean_release_notes:
+        raise ValueError("Release notes must be a single-line summary")
     print(f"Bumping version to {clean_version} across all canonical files...")
 
-    # 1. tunnelsats/umbrel-app.yml
-    update_file(
+    paths = (
         MANIFEST_PATH,
-        r'^version:\s*["\']?[0-9a-zA-Z.-]+["\']?',
-        f'version: "{clean_version}"'
-    )
-    if release_notes:
-        formatted_notes = release_notes.strip().replace('"', '\\"')
-        update_file(
-            MANIFEST_PATH,
-            r'^releaseNotes:\s*\|?\s*\n?(?:[ \t]+.*|\n?)*$',
-            f'releaseNotes: "{formatted_notes}"'
-        )
-
-    # 2. tunnelsats/docker-compose.yml
-    update_file(
         COMPOSE_PATH,
-        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
-        rf'\g<1>{clean_version}'
-    )
-
-    # 3. server/app.py
-    update_file(
         APP_PY_PATH,
-        r'(APP_VERSION\s*=\s*["\']v?)[0-9a-zA-Z.-]+(["\'])',
-        rf'\g<1>{clean_version}\g<2>'
-    )
-
-    # 4. web/index.html
-    update_file(
         INDEX_HTML_PATH,
-        r'(id=["\']app-version["\'][^>]*>\s*v?)[0-9a-zA-Z.-]+(\s*</span>)',
-        rf'\g<1>{clean_version}\g<2>'
-    )
-
-    # 5. k3s/deployment.yaml
-    update_file(
         DEPLOYMENT_K3S_PATH,
-        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
-        rf'\g<1>{clean_version}'
+    )
+    originals = {}
+    for path in paths:
+        with open(path, "r", encoding="utf-8") as source:
+            originals[path] = source.read()
+
+    updates = dict(originals)
+    updates[MANIFEST_PATH] = replace_required(
+        updates[MANIFEST_PATH],
+        r'^version:\s*["\']?[0-9a-zA-Z.-]+["\']?',
+        f'version: "{clean_version}"',
+        MANIFEST_PATH,
+    )
+    formatted_notes = json.dumps(clean_release_notes, ensure_ascii=False)
+    updates[MANIFEST_PATH] = replace_required(
+        updates[MANIFEST_PATH],
+        r'^releaseNotes:\s*\|?\s*\n?(?:[ \t]+.*|\n?)*$',
+        lambda _match: f"releaseNotes: {formatted_notes}",
+        MANIFEST_PATH,
     )
 
-    # 6. Update CHANGELOG.md if release_notes provided
-    if release_notes:
-        entry = f"\n## [{clean_version}]\n\n- {release_notes.strip()}\n"
-        if os.path.exists(CHANGELOG_PATH):
-            with open(CHANGELOG_PATH, "r") as f:
-                cl_content = f.read()
-            if f"[{clean_version}]" not in cl_content:
-                with open(CHANGELOG_PATH, "w") as f:
-                    f.write(cl_content + entry)
-                print(f"Appended version {clean_version} to CHANGELOG.md")
+    updates[COMPOSE_PATH] = replace_required(
+        updates[COMPOSE_PATH],
+        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
+        lambda match: f"{match.group(1)}{clean_version}",
+        COMPOSE_PATH,
+    )
+
+    updates[APP_PY_PATH] = replace_required(
+        updates[APP_PY_PATH],
+        r'(APP_VERSION\s*=\s*["\']v?)[0-9a-zA-Z.-]+(["\'])',
+        lambda match: f"{match.group(1)}{clean_version}{match.group(2)}",
+        APP_PY_PATH,
+    )
+
+    updates[INDEX_HTML_PATH] = replace_required(
+        updates[INDEX_HTML_PATH],
+        r'(id=["\']app-version["\'][^>]*>\s*v?)[0-9a-zA-Z.-]+(\s*</span>)',
+        lambda match: f"{match.group(1)}{clean_version}{match.group(2)}",
+        INDEX_HTML_PATH,
+    )
+
+    updates[DEPLOYMENT_K3S_PATH] = replace_required(
+        updates[DEPLOYMENT_K3S_PATH],
+        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
+        lambda match: f"{match.group(1)}{clean_version}",
+        DEPLOYMENT_K3S_PATH,
+    )
+
+    entry = f"## [{clean_version}]\n\n- {clean_release_notes}\n"
+    if os.path.exists(CHANGELOG_PATH):
+        with open(CHANGELOG_PATH, "r", encoding="utf-8") as f:
+            cl_content = f.read()
+        section_pattern = (
+            rf"^##[ \t]+\[{re.escape(clean_version)}\][^\n]*\n"
+            rf"(?s:.*?)(?=^##[ \t]+\[|\Z)"
+        )
+        section_count = len(re.findall(section_pattern, cl_content, flags=re.MULTILINE))
+        if section_count > 1:
+            raise ValueError(
+                f"Found duplicate changelog sections for version {clean_version}"
+            )
+        originals[CHANGELOG_PATH] = cl_content
+        if section_count == 1:
+            updates[CHANGELOG_PATH] = re.sub(
+                section_pattern,
+                lambda _match: entry,
+                cl_content,
+                count=1,
+                flags=re.MULTILINE,
+            )
         else:
-            with open(CHANGELOG_PATH, "w") as f:
-                f.write(f"# Changelog\n{entry}")
-            print(f"Created CHANGELOG.md with version {clean_version}")
+            if cl_content.endswith("\n\n"):
+                separator = ""
+            elif cl_content.endswith("\n"):
+                separator = "\n"
+            else:
+                separator = "\n\n"
+            updates[CHANGELOG_PATH] = f"{cl_content}{separator}{entry}"
+    else:
+        originals[CHANGELOG_PATH] = None
+        updates[CHANGELOG_PATH] = f"# Changelog\n\n{entry}"
+
+    commit_updates(updates, originals)
+    for path in updates:
+        print(f"Updated {os.path.relpath(path, REPO_ROOT)}")
 
     print("Version bump complete successfully!")
 
 def main():
-    parser = argparse.ArgumentParser(description="Bump version atomically across all 5 file locations")
+    parser = argparse.ArgumentParser(
+        description="Transactionally bump all canonical version locations"
+    )
     parser.add_argument("version", help="New semver version (e.g. 3.3.4)")
-    parser.add_argument("--notes", help="Release notes summary for umbrel-app.yml and CHANGELOG.md", default=None)
+    parser.add_argument(
+        "--notes",
+        required=True,
+        help="Nonblank release notes summary for umbrel-app.yml and CHANGELOG.md",
+    )
     args = parser.parse_args()
 
     bump_version(args.version, args.notes)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Atomic Version Bump Tool for ts-umbrel-app
+Updates version string across all 5 canonical file locations:
+  1. tunnelsats/umbrel-app.yml (version and releaseNotes)
+  2. tunnelsats/docker-compose.yml (image tag)
+  3. server/app.py (APP_VERSION)
+  4. web/index.html (#app-version)
+  5. k3s/deployment.yaml (image tag)
+Also updates or creates CHANGELOG.md.
+"""
+
+import sys
+import os
+import re
+import argparse
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+MANIFEST_PATH = os.path.join(REPO_ROOT, "tunnelsats", "umbrel-app.yml")
+COMPOSE_PATH = os.path.join(REPO_ROOT, "tunnelsats", "docker-compose.yml")
+APP_PY_PATH = os.path.join(REPO_ROOT, "server", "app.py")
+INDEX_HTML_PATH = os.path.join(REPO_ROOT, "web", "index.html")
+DEPLOYMENT_K3S_PATH = os.path.join(REPO_ROOT, "k3s", "deployment.yaml")
+CHANGELOG_PATH = os.path.join(REPO_ROOT, "CHANGELOG.md")
+
+def update_file(path, pattern, replacement):
+    with open(path, "r") as f:
+        content = f.read()
+    new_content, count = re.subn(pattern, replacement, content, flags=re.MULTILINE)
+    if count == 0:
+        raise ValueError(f"Pattern '{pattern}' not found in {path}")
+    with open(path, "w") as f:
+        f.write(new_content)
+    print(f"Updated {os.path.relpath(path, REPO_ROOT)}")
+
+def bump_version(new_version, release_notes=None):
+    clean_version = new_version.strip().lstrip("v")
+    print(f"Bumping version to {clean_version} across all canonical files...")
+
+    # 1. tunnelsats/umbrel-app.yml
+    update_file(
+        MANIFEST_PATH,
+        r'^version:\s*["\']?[0-9a-zA-Z.-]+["\']?',
+        f'version: "{clean_version}"'
+    )
+    if release_notes:
+        formatted_notes = release_notes.strip().replace('"', '\\"')
+        update_file(
+            MANIFEST_PATH,
+            r'^releaseNotes:\s*\|?\s*\n?(?:[ \t]+.*|\n?)*$',
+            f'releaseNotes: "{formatted_notes}"'
+        )
+
+    # 2. tunnelsats/docker-compose.yml
+    update_file(
+        COMPOSE_PATH,
+        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
+        rf'\g<1>{clean_version}'
+    )
+
+    # 3. server/app.py
+    update_file(
+        APP_PY_PATH,
+        r'(APP_VERSION\s*=\s*["\']v?)[0-9a-zA-Z.-]+(["\'])',
+        rf'\g<1>{clean_version}\g<2>'
+    )
+
+    # 4. web/index.html
+    update_file(
+        INDEX_HTML_PATH,
+        r'(id=["\']app-version["\'][^>]*>\s*v?)[0-9a-zA-Z.-]+(\s*</span>)',
+        rf'\g<1>{clean_version}\g<2>'
+    )
+
+    # 5. k3s/deployment.yaml
+    update_file(
+        DEPLOYMENT_K3S_PATH,
+        r'(image:\s*tunnelsats/ts-umbrel-app:v?)[0-9a-zA-Z.-]+',
+        rf'\g<1>{clean_version}'
+    )
+
+    # 6. Update CHANGELOG.md if release_notes provided
+    if release_notes:
+        entry = f"\n## [{clean_version}]\n\n- {release_notes.strip()}\n"
+        if os.path.exists(CHANGELOG_PATH):
+            with open(CHANGELOG_PATH, "r") as f:
+                cl_content = f.read()
+            if f"[{clean_version}]" not in cl_content:
+                with open(CHANGELOG_PATH, "w") as f:
+                    f.write(cl_content + entry)
+                print(f"Appended version {clean_version} to CHANGELOG.md")
+        else:
+            with open(CHANGELOG_PATH, "w") as f:
+                f.write(f"# Changelog\n{entry}")
+            print(f"Created CHANGELOG.md with version {clean_version}")
+
+    print("Version bump complete successfully!")
+
+def main():
+    parser = argparse.ArgumentParser(description="Bump version atomically across all 5 file locations")
+    parser.add_argument("version", help="New semver version (e.g. 3.3.4)")
+    parser.add_argument("--notes", help="Release notes summary for umbrel-app.yml and CHANGELOG.md", default=None)
+    args = parser.parse_args()
+
+    bump_version(args.version, args.notes)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -659,13 +659,11 @@ ensure_policy_routing() {
                 fi
             fi
             changed=1
-        fi
-
-        # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
-        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
+              # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
+        if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
             ip rule del from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1; then
-                if ! ip rule show pref 32765 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
+                if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole"; then
                     LAST_ERROR="SecureMode: Failed to add fallback blackhole rule"
                     return 1
                 fi
@@ -697,9 +695,10 @@ ensure_policy_routing() {
         fi
 
         # Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
-        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
+        if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
+            ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1; then
-                if ! ip rule show pref 32765 | grep -q "from ${DOCKER_NETWORK_SUBNET}"; then
+                if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole"; then
                     LAST_ERROR="Failed to add fallback blackhole rule for subnet ${DOCKER_NETWORK_SUBNET}"
                     return 1
                 fi
@@ -1093,7 +1092,9 @@ cleanup_dataplane() {
         cleanup_subnet=$(get_target_subnet "${cleanup_ip}")
         ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
         ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
-        ip rule del from "${cleanup_ip}" blackhole pref 32765 >/dev/null 2>&1 || true
+        if [ "${keep_tunnel}" = false ]; then
+            ip rule del from "${cleanup_ip}" blackhole pref 32765 >/dev/null 2>&1 || true
+        fi
     done
 
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
@@ -1109,7 +1110,9 @@ cleanup_dataplane() {
         bridge_gw="${DOCKER_NETWORK_SUBNET%.*}.1"
         ip rule del from "${bridge_gw}" table 51820 pref 32763 >/dev/null 2>&1 || true
 
-        ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
+        if [ "${keep_tunnel}" = false ]; then
+            ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
+        fi
 
         while ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+lookup[[:space:]]+51820[[:space:]]*$" && [ ${attempt} -lt ${max_attempts} ]; do
             ip rule del from "${DOCKER_NETWORK_SUBNET}" table 51820 >/dev/null 2>&1 || break

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -659,7 +659,9 @@ ensure_policy_routing() {
                 fi
             fi
             changed=1
-              # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
+        fi
+
+        # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
         if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
             ip rule del from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1 || true
             if ! ip rule add from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -577,6 +577,51 @@ get_target_subnet() {
     echo "${subnet}"
 }
 
+ensure_fallback_blackhole_rule() {
+    local source_prefix="$1"
+    local error_message="$2"
+    local escaped_source="${source_prefix//./\\.}"
+    local source_pattern="^32765:[[:space:]]+from[[:space:]]+${escaped_source}([[:space:]]|$)"
+    local exact_pattern="^32765:[[:space:]]+from[[:space:]]+${escaped_source}[[:space:]]+blackhole[[:space:]]*$"
+    local matching_rules
+    local matching_count
+
+    BLACKHOLE_CHANGED="0"
+    matching_rules="$(ip rule show pref 32765 2>/dev/null | grep -E "${source_pattern}" || true)"
+    matching_count="$(printf '%s\n' "${matching_rules}" | sed '/^$/d' | wc -l)"
+
+    if [ "${matching_count}" -eq 1 ] && printf '%s\n' "${matching_rules}" | grep -qE "${exact_pattern}"; then
+        return 0
+    fi
+
+    local rule_line
+    local rule_spec
+    local -a rule_parts
+    while IFS= read -r rule_line; do
+        [ -n "${rule_line}" ] || continue
+        rule_spec="${rule_line#*:}"
+        read -r -a rule_parts <<< "${rule_spec}"
+        [ "${#rule_parts[@]}" -gt 0 ] || continue
+        ip rule del "${rule_parts[@]}" pref 32765 >/dev/null 2>&1 || true
+    done <<< "${matching_rules}"
+
+    if ip rule show pref 32765 2>/dev/null | grep -qE "${source_pattern}"; then
+        LAST_ERROR="${error_message}: failed to remove conflicting pref 32765 rule"
+        return 1
+    fi
+
+    ip rule add from "${source_prefix}" blackhole pref 32765 >/dev/null 2>&1 || true
+    matching_rules="$(ip rule show pref 32765 2>/dev/null | grep -E "${source_pattern}" || true)"
+    matching_count="$(printf '%s\n' "${matching_rules}" | sed '/^$/d' | wc -l)"
+    if [ "${matching_count}" -ne 1 ] || ! printf '%s\n' "${matching_rules}" | grep -qE "${exact_pattern}"; then
+        LAST_ERROR="${error_message}"
+        return 1
+    fi
+
+    BLACKHOLE_CHANGED="1"
+    return 0
+}
+
 ensure_policy_routing() {
     local changed=0
     POLICY_CHANGED="0"
@@ -636,6 +681,7 @@ ensure_policy_routing() {
         other_subnet=$(get_target_subnet "${other_ip}")
         ip rule del from "${other_ip}" to "${other_subnet}" table main pref 32500 >/dev/null 2>&1 || true
         ip rule del from "${other_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
+        ip rule del from "${other_ip}" blackhole pref 32765 >/dev/null 2>&1 || true
 
         # 2. Local-to-Local bypass rule (so LND can talk to local Bitcoind/Tor on 10.21.x.x)
         if ! ip rule show | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+to[[:space:]]+${subnet//./\\.}[[:space:]]+(lookup|table)[[:space:]]+main"; then
@@ -662,14 +708,12 @@ ensure_policy_routing() {
         fi
 
         # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
-        if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
-            ip rule del from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1 || true
-            if ! ip rule add from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1; then
-                if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole"; then
-                    LAST_ERROR="SecureMode: Failed to add fallback blackhole rule"
-                    return 1
-                fi
-            fi
+        if ! ensure_fallback_blackhole_rule \
+            "${DOCKER_TARGET_IP}" \
+            "SecureMode: Failed to add fallback blackhole rule"; then
+            return 1
+        fi
+        if [ "${BLACKHOLE_CHANGED}" = "1" ]; then
             changed=1
         fi
     else
@@ -697,14 +741,12 @@ ensure_policy_routing() {
         fi
 
         # Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
-        if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
-            ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
-            if ! ip rule add from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1; then
-                if ! ip rule show pref 32765 | grep -qE "^32765:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole"; then
-                    LAST_ERROR="Failed to add fallback blackhole rule for subnet ${DOCKER_NETWORK_SUBNET}"
-                    return 1
-                fi
-            fi
+        if ! ensure_fallback_blackhole_rule \
+            "${DOCKER_NETWORK_SUBNET}" \
+            "Failed to add fallback blackhole rule for subnet ${DOCKER_NETWORK_SUBNET}"; then
+            return 1
+        fi
+        if [ "${BLACKHOLE_CHANGED}" = "1" ]; then
             changed=1
         fi
 
@@ -1335,6 +1377,10 @@ main_loop() {
         sleep 2
     done
 }
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
 
 trap cleanup SIGTERM SIGINT
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -660,6 +660,18 @@ ensure_policy_routing() {
             fi
             changed=1
         fi
+
+        # 3b. Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
+        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_TARGET_IP//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
+            ip rule del from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1 || true
+            if ! ip rule add from "${DOCKER_TARGET_IP}" blackhole pref 32765 >/dev/null 2>&1; then
+                if ! ip rule show pref 32765 | grep -qE "from[[:space:]]+${DOCKER_TARGET_IP//./\\.}"; then
+                    LAST_ERROR="SecureMode: Failed to add fallback blackhole rule"
+                    return 1
+                fi
+            fi
+            changed=1
+        fi
     else
         # Docker mode: subnet-based rules for the bridge network.
         # Priority 32500: Local-to-Local bypass.
@@ -678,6 +690,17 @@ ensure_policy_routing() {
             if ! ip rule add from "${DOCKER_NETWORK_SUBNET}" table 51820 pref 32764 >/dev/null 2>&1; then
                 if ! ip rule show pref 32764 | grep -q "from ${DOCKER_NETWORK_SUBNET}"; then
                     LAST_ERROR="Failed to add policy routing rule for subnet ${DOCKER_NETWORK_SUBNET}"
+                    return 1
+                fi
+            fi
+            changed=1
+        fi
+
+        # Fallback blackhole policy rule (pref 32765) to harden kill-switch against route table fallthrough
+        if ! ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+blackhole[[:space:]]*$"; then
+            if ! ip rule add from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1; then
+                if ! ip rule show pref 32765 | grep -q "from ${DOCKER_NETWORK_SUBNET}"; then
+                    LAST_ERROR="Failed to add fallback blackhole rule for subnet ${DOCKER_NETWORK_SUBNET}"
                     return 1
                 fi
             fi
@@ -1070,6 +1093,7 @@ cleanup_dataplane() {
         cleanup_subnet=$(get_target_subnet "${cleanup_ip}")
         ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
         ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
+        ip rule del from "${cleanup_ip}" blackhole pref 32765 >/dev/null 2>&1 || true
     done
 
     if [[ "${K3S_MODE}" == "true" ]] || [[ "${SECURE_MODE}" == "true" ]]; then
@@ -1084,6 +1108,8 @@ cleanup_dataplane() {
         local bridge_gw
         bridge_gw="${DOCKER_NETWORK_SUBNET%.*}.1"
         ip rule del from "${bridge_gw}" table 51820 pref 32763 >/dev/null 2>&1 || true
+
+        ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
 
         while ip rule show | grep -qE "^[0-9]+:[[:space:]]+from[[:space:]]+${DOCKER_NETWORK_SUBNET//./\\.}[[:space:]]+lookup[[:space:]]+51820[[:space:]]*$" && [ ${attempt} -lt ${max_attempts} ]; do
             ip rule del from "${DOCKER_NETWORK_SUBNET}" table 51820 >/dev/null 2>&1 || break

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -43,7 +43,8 @@ usage() {
     echo "  node     Hot-patch the running tunnelsats container (docker cp + restart)"
     echo "  monorepo Push to remote repository"
     echo "  vendor   Update vendor assets"
-    echo "  version  Update version string"
+    echo "  version VERSION --notes TEXT"
+    echo "           Update all version locations and release notes"
     echo "  promote  Release promotion workflow"
     exit 1
 }
@@ -248,18 +249,7 @@ run_vendor() {
 }
 
 run_version() {
-    if [ "$#" -lt 1 ]; then log_error "Version argument required"; return 1; fi
-    NEW_VERSION="${1#v}"
-    if [[ "$NEW_VERSION" =~ [^a-zA-Z0-9._-] ]]; then
-        log_error "Invalid version string: $NEW_VERSION (only alphanumeric, '.', '_', '-' allowed)"
-        return 1
-    fi
-    log_info "Updating version to ${NEW_VERSION}..."
-    sed "s/version: .*/version: \"${NEW_VERSION}\"/" "${REPO_ROOT}/tunnelsats/umbrel-app.yml" > "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/umbrel-app.yml.tmp" "${REPO_ROOT}/tunnelsats/umbrel-app.yml"
-    sed -E "s#(ts-umbrel-app:v?)[^@\" ]+(@sha256:[0-9a-f]{64})?#\1${NEW_VERSION}#" "${REPO_ROOT}/tunnelsats/docker-compose.yml" > "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" && mv "${REPO_ROOT}/tunnelsats/docker-compose.yml.tmp" "${REPO_ROOT}/tunnelsats/docker-compose.yml"
-    if [ -f "${REPO_ROOT}/web/index.html" ]; then
-        sed -E "s/(id=\"app-version\"[^>]*>v?)[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.-]*(<\/span>)/\1${NEW_VERSION}\2/" "${REPO_ROOT}/web/index.html" > "${REPO_ROOT}/web/index.html.tmp" && mv "${REPO_ROOT}/web/index.html.tmp" "${REPO_ROOT}/web/index.html"
-    fi
+    python3 "${REPO_ROOT}/scripts/bump_version.py" "$@"
 }
 
 run_promote() {

--- a/server/app.py
+++ b/server/app.py
@@ -27,7 +27,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.3.3"
+APP_VERSION = "v3.3.4"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:

--- a/server/tests/test_bump_version.py
+++ b/server/tests/test_bump_version.py
@@ -1,0 +1,274 @@
+import importlib.util
+import os
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+BUMP_SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "bump_version.py")
+
+
+@pytest.fixture
+def bump_module():
+    spec = importlib.util.spec_from_file_location("bump_version", BUMP_SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def version_workspace(tmp_path, bump_module, monkeypatch):
+    relative_paths = (
+        "tunnelsats/umbrel-app.yml",
+        "tunnelsats/docker-compose.yml",
+        "server/app.py",
+        "web/index.html",
+        "k3s/deployment.yaml",
+        "CHANGELOG.md",
+        "scripts/bump_version.py",
+        "scripts/sync.sh",
+    )
+    for relative_path in relative_paths:
+        source = os.path.join(REPO_ROOT, relative_path)
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    monkeypatch.setattr(bump_module, "REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        bump_module, "MANIFEST_PATH", str(tmp_path / "tunnelsats/umbrel-app.yml")
+    )
+    monkeypatch.setattr(
+        bump_module, "COMPOSE_PATH", str(tmp_path / "tunnelsats/docker-compose.yml")
+    )
+    monkeypatch.setattr(bump_module, "APP_PY_PATH", str(tmp_path / "server/app.py"))
+    monkeypatch.setattr(
+        bump_module, "INDEX_HTML_PATH", str(tmp_path / "web/index.html")
+    )
+    monkeypatch.setattr(
+        bump_module, "DEPLOYMENT_K3S_PATH", str(tmp_path / "k3s/deployment.yaml")
+    )
+    monkeypatch.setattr(bump_module, "CHANGELOG_PATH", str(tmp_path / "CHANGELOG.md"))
+
+    return tmp_path
+
+
+def snapshot_files(root):
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    "version",
+    (
+        "",
+        "v",
+        "3.3",
+        "3.3.4.5",
+        "01.2.3",
+        "3.3.4+build",
+        "not-a-version",
+        f"1.0.{('1' * 125)}",
+    ),
+)
+def test_invalid_version_is_rejected_without_writes(
+    bump_module, version_workspace, version
+):
+    before = snapshot_files(version_workspace)
+
+    with pytest.raises(ValueError, match="Invalid version"):
+        bump_module.bump_version(version, "Release notes")
+
+    assert snapshot_files(version_workspace) == before
+
+
+@pytest.mark.parametrize("notes", (None, "", " ", "\n\t"))
+def test_missing_or_blank_release_notes_are_rejected_without_writes(
+    bump_module, version_workspace, notes
+):
+    before = snapshot_files(version_workspace)
+
+    with pytest.raises(ValueError, match="Release notes are required"):
+        bump_module.bump_version("4.0.0", notes)
+
+    assert snapshot_files(version_workspace) == before
+
+
+@pytest.mark.parametrize(
+    "notes",
+    ("First line\nSecond line", "First line\r\nSecond line", "First line\rSecond line"),
+)
+def test_multiline_release_notes_are_rejected_without_writes(
+    bump_module, version_workspace, notes
+):
+    before = snapshot_files(version_workspace)
+
+    with pytest.raises(ValueError, match="single-line summary"):
+        bump_module.bump_version("4.0.0", notes)
+
+    assert snapshot_files(version_workspace) == before
+
+
+def test_preflight_failure_does_not_partially_update_files(
+    bump_module, version_workspace
+):
+    deployment = version_workspace / "k3s/deployment.yaml"
+    deployment.write_text(
+        deployment.read_text().replace(
+            "image: tunnelsats/ts-umbrel-app:3.3.4", "image: example/other:latest"
+        )
+    )
+    before = snapshot_files(version_workspace)
+
+    with pytest.raises(ValueError, match="found 0"):
+        bump_module.bump_version("4.0.0", "Release notes")
+
+    assert snapshot_files(version_workspace) == before
+
+
+def test_commit_failure_rolls_back_all_files(
+    bump_module, version_workspace, monkeypatch
+):
+    before = snapshot_files(version_workspace)
+    real_replace = os.replace
+    replace_calls = 0
+
+    def fail_second_replace(source, destination):
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 2:
+            raise OSError("simulated replace failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(bump_module.os, "replace", fail_second_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        bump_module.bump_version("4.0.0", "Release notes")
+
+    assert snapshot_files(version_workspace) == before
+
+
+def test_interruption_rolls_back_all_files(
+    bump_module, version_workspace, monkeypatch
+):
+    before = snapshot_files(version_workspace)
+    real_replace = os.replace
+    replace_calls = 0
+
+    def interrupt_second_replace(source, destination):
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 2:
+            real_replace(source, destination)
+            raise KeyboardInterrupt
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(bump_module.os, "replace", interrupt_second_replace)
+
+    with pytest.raises(KeyboardInterrupt):
+        bump_module.bump_version("4.0.0", "Release notes")
+
+    assert snapshot_files(version_workspace) == before
+
+
+def test_failed_rollback_preserves_original_recovery_copy(
+    bump_module, version_workspace, monkeypatch
+):
+    manifest_path = version_workspace / "tunnelsats/umbrel-app.yml"
+    original_manifest = manifest_path.read_text()
+    real_replace = os.replace
+    replace_calls = 0
+
+    def fail_commit_and_rollback(source, destination):
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls in (2, 3):
+            raise OSError(f"simulated replace failure {replace_calls}")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(bump_module.os, "replace", fail_commit_and_rollback)
+
+    with pytest.raises(RuntimeError, match="original preserved at") as error:
+        bump_module.bump_version("4.0.0", "Release notes")
+
+    recovery_path = error.value.args[0].split("original preserved at ", 1)[1]
+    assert os.path.exists(recovery_path)
+    with open(recovery_path, encoding="utf-8") as recovery:
+        assert recovery.read() == original_manifest
+    assert 'version: "4.0.0"' in manifest_path.read_text()
+
+
+def test_valid_version_and_release_notes_are_written_safely(
+    bump_module, version_workspace
+):
+    notes = 'Windows path C:\\temp says "ready"'
+
+    bump_module.bump_version("v4.0.0-rc.1", notes)
+
+    manifest = yaml.safe_load(
+        (version_workspace / "tunnelsats/umbrel-app.yml").read_text()
+    )
+    assert manifest["version"] == "4.0.0-rc.1"
+    assert manifest["releaseNotes"] == notes
+    assert (
+        "tunnelsats/ts-umbrel-app:4.0.0-rc.1"
+        in (version_workspace / "tunnelsats/docker-compose.yml").read_text()
+    )
+
+
+def test_existing_version_updates_its_changelog_section(
+    bump_module, version_workspace
+):
+    notes = r"Corrected path C:\temp and literal \g<1>"
+
+    bump_module.bump_version("3.3.4", notes)
+
+    manifest = yaml.safe_load(
+        (version_workspace / "tunnelsats/umbrel-app.yml").read_text()
+    )
+    changelog = (version_workspace / "CHANGELOG.md").read_text()
+    assert manifest["releaseNotes"] == notes
+    assert changelog.count("## [3.3.4]") == 1
+    assert f"## [3.3.4]\n\n- {notes}\n" in changelog
+    assert "Hardened dataplane policy routing" not in changelog
+
+
+def test_sync_version_command_delegates_to_canonical_bump_tool(version_workspace):
+    result = subprocess.run(
+        [
+            "bash",
+            str(version_workspace / "scripts/sync.sh"),
+            "version",
+            "4.1.0",
+            "--notes",
+            "Delegated release",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        'version: "4.1.0"'
+        in (version_workspace / "tunnelsats/umbrel-app.yml").read_text()
+    )
+    assert (
+        "tunnelsats/ts-umbrel-app:4.1.0"
+        in (version_workspace / "tunnelsats/docker-compose.yml").read_text()
+    )
+    assert (
+        'APP_VERSION = "v4.1.0"'
+        in (version_workspace / "server/app.py").read_text()
+    )
+    assert ">v4.1.0</span>" in (version_workspace / "web/index.html").read_text()
+    assert (
+        "tunnelsats/ts-umbrel-app:4.1.0"
+        in (version_workspace / "k3s/deployment.yaml").read_text()
+    )

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+ENTRYPOINT_PATH = os.path.join(REPO_ROOT, "scripts", "entrypoint.sh")
+
+
+def run_bash(script):
+    return subprocess.run(
+        ["bash", "-c", script, "policy-test", ENTRYPOINT_PATH],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_fallback_blackhole_rule_removes_conflicts_and_is_idempotent():
+    result = run_bash(
+        r'''
+source "$1"
+
+RULES=$'32765:\tfrom 10.9.9.0/25 lookup main\n32765:\tfrom 10.9.9.0/25 blackhole'
+DELETE_COUNT=0
+ADD_COUNT=0
+
+ip() {
+    if [[ "$1 $2 $3 $4" == "rule show pref 32765" ]]; then
+        printf '%s\n' "${RULES}"
+        return 0
+    fi
+    if [[ "$1 $2" == "rule del" ]]; then
+        DELETE_COUNT=$((DELETE_COUNT + 1))
+        RULES=""
+        return 0
+    fi
+    if [[ "$1 $2" == "rule add" ]]; then
+        ADD_COUNT=$((ADD_COUNT + 1))
+        RULES=$'32765:\tfrom 10.9.9.0/25 blackhole'
+        return 0
+    fi
+    return 1
+}
+
+ensure_fallback_blackhole_rule "10.9.9.0/25" "test failure"
+[[ "${BLACKHOLE_CHANGED}" == "1" ]]
+[[ "${DELETE_COUNT}" == "2" ]]
+[[ "${ADD_COUNT}" == "1" ]]
+[[ "${RULES}" == $'32765:\tfrom 10.9.9.0/25 blackhole' ]]
+
+ensure_fallback_blackhole_rule "10.9.9.0/25" "test failure"
+[[ "${BLACKHOLE_CHANGED}" == "0" ]]
+[[ "${DELETE_COUNT}" == "2" ]]
+[[ "${ADD_COUNT}" == "1" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/server/tests/test_version_sync.py
+++ b/server/tests/test_version_sync.py
@@ -1,0 +1,77 @@
+import os
+import re
+import json
+import yaml
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+MANIFEST_PATH = os.path.join(REPO_ROOT, "tunnelsats", "umbrel-app.yml")
+COMPOSE_PATH = os.path.join(REPO_ROOT, "tunnelsats", "docker-compose.yml")
+APP_PY_PATH = os.path.join(REPO_ROOT, "server", "app.py")
+INDEX_HTML_PATH = os.path.join(REPO_ROOT, "web", "index.html")
+DEPLOYMENT_K3S_PATH = os.path.join(REPO_ROOT, "k3s", "deployment.yaml")
+
+LEGACY_STATIC_RELEASE_NOTES = "Rebuilt from the ground up to support the new umbrelOS immutable architecture"
+
+def get_manifest_version_and_notes():
+    assert os.path.exists(MANIFEST_PATH), f"Manifest file missing at {MANIFEST_PATH}"
+    with open(MANIFEST_PATH, "r") as f:
+        data = yaml.safe_load(f)
+    version = str(data.get("version", "")).strip().lstrip("v")
+    notes = str(data.get("releaseNotes", "")).strip()
+    return version, notes
+
+def get_compose_version():
+    assert os.path.exists(COMPOSE_PATH), f"Compose file missing at {COMPOSE_PATH}"
+    with open(COMPOSE_PATH, "r") as f:
+        content = f.read()
+    match = re.search(r'image:\s*tunnelsats/ts-umbrel-app:v?([0-9a-zA-Z.-]+)', content)
+    assert match, "Could not extract version from docker-compose.yml"
+    return match.group(1).strip()
+
+def get_app_py_version():
+    assert os.path.exists(APP_PY_PATH), f"app.py missing at {APP_PY_PATH}"
+    with open(APP_PY_PATH, "r") as f:
+        content = f.read()
+    match = re.search(r'APP_VERSION\s*=\s*["\']v?([0-9a-zA-Z.-]+)["\']', content)
+    assert match, "Could not extract APP_VERSION from server/app.py"
+    return match.group(1).strip()
+
+def get_index_html_version():
+    assert os.path.exists(INDEX_HTML_PATH), f"index.html missing at {INDEX_HTML_PATH}"
+    with open(INDEX_HTML_PATH, "r") as f:
+        content = f.read()
+    match = re.search(r'id=["\']app-version["\'][^>]*>\s*v?([0-9a-zA-Z.-]+)\s*</span>', content)
+    assert match, "Could not extract app-version from web/index.html"
+    return match.group(1).strip()
+
+def get_k3s_deployment_version():
+    assert os.path.exists(DEPLOYMENT_K3S_PATH), f"deployment.yaml missing at {DEPLOYMENT_K3S_PATH}"
+    with open(DEPLOYMENT_K3S_PATH, "r") as f:
+        content = f.read()
+    match = re.search(r'image:\s*tunnelsats/ts-umbrel-app:v?([0-9a-zA-Z.-]+)', content)
+    assert match, "Could not extract image version from k3s/deployment.yaml"
+    return match.group(1).strip()
+
+
+def test_all_version_locations_are_in_sync():
+    manifest_ver, notes = get_manifest_version_and_notes()
+    compose_ver = get_compose_version()
+    app_py_ver = get_app_py_version()
+    index_ver = get_index_html_version()
+    k3s_ver = get_k3s_deployment_version()
+
+    assert manifest_ver, "Manifest version is empty"
+    assert compose_ver == manifest_ver, f"docker-compose.yml version ({compose_ver}) != manifest version ({manifest_ver})"
+    assert app_py_ver == manifest_ver, f"server/app.py version ({app_py_ver}) != manifest version ({manifest_ver})"
+    assert index_ver == manifest_ver, f"web/index.html version ({index_ver}) != manifest version ({manifest_ver})"
+    assert k3s_ver == manifest_ver, f"k3s/deployment.yaml version ({k3s_ver}) != manifest version ({manifest_ver})"
+
+
+def test_manifest_release_notes_are_dynamic_and_non_empty():
+    _, notes = get_manifest_version_and_notes()
+    assert len(notes) > 0, "Manifest releaseNotes field is empty"
+    assert LEGACY_STATIC_RELEASE_NOTES not in notes, (
+        "Manifest releaseNotes contains static legacy text rather than version-specific notes"
+    )

--- a/server/tests/test_version_sync.py
+++ b/server/tests/test_version_sync.py
@@ -1,8 +1,7 @@
 import os
 import re
-import json
+
 import yaml
-import pytest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -11,6 +10,7 @@ COMPOSE_PATH = os.path.join(REPO_ROOT, "tunnelsats", "docker-compose.yml")
 APP_PY_PATH = os.path.join(REPO_ROOT, "server", "app.py")
 INDEX_HTML_PATH = os.path.join(REPO_ROOT, "web", "index.html")
 DEPLOYMENT_K3S_PATH = os.path.join(REPO_ROOT, "k3s", "deployment.yaml")
+CHANGELOG_PATH = os.path.join(REPO_ROOT, "CHANGELOG.md")
 
 LEGACY_STATIC_RELEASE_NOTES = "Rebuilt from the ground up to support the new umbrelOS immutable architecture"
 
@@ -55,6 +55,27 @@ def get_k3s_deployment_version():
     return match.group(1).strip()
 
 
+def get_changelog_notes(version):
+    assert os.path.exists(CHANGELOG_PATH), f"CHANGELOG.md missing at {CHANGELOG_PATH}"
+    with open(CHANGELOG_PATH, "r", encoding="utf-8") as f:
+        content = f.read()
+    pattern = (
+        rf"^##[ \t]+\[{re.escape(version)}\][^\n]*\n"
+        rf"(?s:.*?)(?=^##[ \t]+\[|\Z)"
+    )
+    sections = re.findall(pattern, content, flags=re.MULTILINE)
+    assert len(sections) == 1, (
+        f"Expected exactly one CHANGELOG.md section for version {version}, "
+        f"found {len(sections)}"
+    )
+    match = re.fullmatch(
+        rf"##[ \t]+\[{re.escape(version)}\][^\n]*\n\n-[ \t]+([^\r\n]+)\n?",
+        sections[0],
+    )
+    assert match, f"Could not extract release notes for version {version}"
+    return match.group(1).strip()
+
+
 def test_all_version_locations_are_in_sync():
     manifest_ver, notes = get_manifest_version_and_notes()
     compose_ver = get_compose_version()
@@ -70,8 +91,11 @@ def test_all_version_locations_are_in_sync():
 
 
 def test_manifest_release_notes_are_dynamic_and_non_empty():
-    _, notes = get_manifest_version_and_notes()
+    version, notes = get_manifest_version_and_notes()
     assert len(notes) > 0, "Manifest releaseNotes field is empty"
     assert LEGACY_STATIC_RELEASE_NOTES not in notes, (
         "Manifest releaseNotes contains static legacy text rather than version-specific notes"
+    )
+    assert get_changelog_notes(version) == notes, (
+        "CHANGELOG.md notes for the current version do not match manifest releaseNotes"
     )

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.3
+    image: tunnelsats/ts-umbrel-app:3.3.4
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.3"
+version: "3.3.4"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.
@@ -16,11 +16,7 @@ description: >-
 
 
   Ideal for users on dynamic home IPs, behind CGNAT, or those seeking an extra layer of privacy for their Lightning peering.
-releaseNotes: >-
-  Rebuilt from the ground up to support the new umbrelOS immutable architecture.
-
-
-  Now runs seamlessly as an app, automatically intercepting traffic for Core Lightning and LND while maintaining a strict killswitch protocol.
+releaseNotes: "Hardened dataplane policy routing and fallback blackhole rules for target node network isolation. Integrated automated version sync guardrails."
 developer: TunnelSats Team
 website: https://tunnelsats.com
 dependencies: []

--- a/web/index.html
+++ b/web/index.html
@@ -924,7 +924,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.3</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.4</span>
                 </div>
             </div>
 


### PR DESCRIPTION
# PR: Dataplane Policy Routing Hardening & Automated Version Sync Guardrails

Fixes #112

## Summary of Changes
This PR combines two essential improvements for the `ts-umbrel-app` release:
1. **Dataplane Kill-Switch Policy Routing Hardening**: Adds a fallback blackhole policy routing rule (`pref 32765`) to ensure target node traffic remains strictly isolated during state transitions, teardowns, and edge-case reconciles.
2. **Automated Versioning Sync Guardrails & CLI Bumper (Fixes #112)**: Solves version drift across canonical files by adding automated pytest guardrails, a single-command atomic version bumper script, and dynamic release notes.

## Detailed Changes

### 1. Dataplane Policy Routing Hardening
- **`scripts/entrypoint.sh`**:
  - Added fallback `blackhole` policy rule (`pref 32765`) immediately after priority 32764 (`lookup 51820`).
  - Ensures that if the primary VPN policy routing lookup is uninstalled or undergoing state reconciliation, outbound traffic from the target node IP/subnet is blackholed prior to reaching main table WAN routes.
  - Added clean removal of preference 32765 blackhole rules during `cleanup_dataplane()`.

### 2. Versioning Sync Guardrails & Tooling (Fixes #112)
- **`server/tests/test_version_sync.py`**:
  - Automated `pytest` test suite verifying that version strings across all 5 canonical locations match 100%:
    1. `tunnelsats/umbrel-app.yml` (`version: "3.3.4"`)
    2. `tunnelsats/docker-compose.yml` (`image: tunnelsats/ts-umbrel-app:3.3.4`)
    3. `server/app.py` (`APP_VERSION = "v3.3.4"`)
    4. `web/index.html` (`id="app-version">v3.3.4</span>`)
    5. `k3s/deployment.yaml` (`image: tunnelsats/ts-umbrel-app:3.3.4`)
  - Asserts that `releaseNotes` in `tunnelsats/umbrel-app.yml` is dynamic, non-empty, and free of static legacy text.
- **`scripts/bump_version.py`**:
  - Added single-command CLI helper (`python3 scripts/bump_version.py <version> --notes "<notes>"`) that atomically updates all 5 version files, updates `releaseNotes` in `umbrel-app.yml`, and appends to `CHANGELOG.md`.
- **`CHANGELOG.md`**: Initialized changelog file tracking version releases.
- **`tunnelsats/umbrel-app.yml`**: Updated `releaseNotes` for `v3.3.4` with dynamic release notes.

## Testing Strategy
- **Python Unit & Version Sync Tests**: `131/131` passed ✅
- **Data Persistence Suite**: `PASS` ✅
- **Entrypoint Logic Suite**: `9/9` cases passed ✅