### PR TITLE
fix(k3s): enforce Lightning pod co-location

### DIFF
--- a/k3s/README.md
+++ b/k3s/README.md
@@ -82,14 +82,12 @@ This means TunnelSats and the LND/CLN pod **must run on the same node**:
 
 - **Single-node cluster** (the typical Umbrel / home-node setup): nothing to do
   — there is only one node, so they are always co-located.
-- **Multi-node cluster**: the scheduler may place the LND/CLN pod on a different
-  node than TunnelSats. DNAT then forwards to a pod on another node, but the
-  reply never passes through TunnelSats' fwmark rules — inbound connections
-  break and replies can leak outside the tunnel.
+- **Multi-node cluster**: the shipped Deployment uses required pod affinity to
+  schedule TunnelSats on the same node as the default LND target. A runtime
+  check independently compares both pods' `spec.nodeName` values before any
+  forwarding rules are installed.
 
-To enforce co-location on a multi-node cluster, uncomment the `podAffinity`
-block in `deployment.yaml` and set its `labelSelector` to match your Lightning
-pod (the same labels as `LND_K8S_POD_SELECTOR` / `CLN_K8S_POD_SELECTOR`):
+The default affinity selector matches the default `LND_K8S_POD_SELECTOR`:
 
 ```yaml
 affinity:
@@ -101,11 +99,74 @@ affinity:
         topologyKey: kubernetes.io/hostname
 ```
 
+Do not remove or weaken this required affinity. If scheduling configuration
+drifts or a target moves after scheduling, TunnelSats fails closed: it removes
+its forwarding rules, reports `rules_synced: false`, and places a
+`Pod co-location required` explanation in `last_error` at
+`/api/local/status`.
+
 Confirm both landed on the same node:
 
 ```sh
 kubectl get pods -n <ns> -o wide -l 'app in (tunnelsats,lnd)'   # same NODE column
 ```
+
+### Select exactly one Lightning implementation
+
+The manifest targets LND by default. TunnelSats forwards to exactly one
+Lightning implementation, and LND has priority if both service variables are
+enabled. On k3s, configure exactly one target so the scheduler affinity and
+runtime selection cannot disagree.
+
+For **LND**, keep these values aligned:
+
+```yaml
+affinity: ... matchLabels: {app: lnd}
+LND_K8S_SERVICE: lnd
+LND_K8S_NAMESPACE: <LND namespace, or omit for the TunnelSats namespace>
+LND_K8S_POD_SELECTOR: app=lnd
+```
+
+For **CLN**, disable/comment all three `LND_K8S_*` entries, enable the three
+`CLN_K8S_*` entries, and change the affinity selector:
+
+```yaml
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: cln
+        topologyKey: kubernetes.io/hostname
+# CLN_K8S_SERVICE: cln
+# CLN_K8S_NAMESPACE: <CLN namespace, or omit for the TunnelSats namespace>
+# CLN_K8S_POD_SELECTOR: app=cln
+```
+
+The affinity `matchLabels` must describe the same pods as the selected
+`*_K8S_POD_SELECTOR`. The environment selector accepts Kubernetes selector
+syntax such as `app=cln`; express the equivalent requirement under the
+affinity `labelSelector`.
+
+By default, a pod-affinity term searches only the namespace containing
+TunnelSats. If the selected Lightning pod is in another namespace, set the
+matching runtime namespace **and** add that namespace to the affinity term:
+
+```yaml
+- name: CLN_K8S_NAMESPACE
+  value: "bitcoin-lab"
+# ...
+requiredDuringSchedulingIgnoredDuringExecution:
+  - labelSelector:
+      matchLabels:
+        app: cln
+    namespaces:
+      - bitcoin-lab
+    topologyKey: kubernetes.io/hostname
+```
+
+The Role and RoleBinding instructions in the previous section still apply to
+cross-namespace targets.
 
 ## 3. PVC mount paths (do not move them)
 

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -27,17 +27,17 @@ spec:
       # straight to the Lightning pod IP and the reply path must traverse THIS
       # host's fwmark/WireGuard rules. That only holds if tunnelsats runs on the
       # SAME node as the LND/CLN pod. On a single-node cluster this is automatic.
-      # On a multi-node cluster you MUST pin them together — uncomment the
-      # podAffinity below and set the labelSelector to match your Lightning pod
-      # (the same labels as LND_K8S_POD_SELECTOR / CLN_K8S_POD_SELECTOR). See
-      # k3s/README.md → "Multi-node clusters".
-      # affinity:
-      #   podAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       - labelSelector:
-      #           matchLabels:
-      #             app: lnd
-      #         topologyKey: kubernetes.io/hostname
+      # Required affinity makes that privacy invariant the safe default. This
+      # selector matches the default LND_K8S_POD_SELECTOR below. If using CLN,
+      # or a Lightning pod in another namespace, update BOTH this affinity term
+      # and the corresponding *_K8S_* environment variables. See k3s/README.md.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: lnd
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
@@ -55,6 +55,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Runtime backstop for the required affinity above. The dataplane
+            # refuses to activate unless the selected Lightning pod reports
+            # this same node name.
+            - name: TUNNELSATS_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             # Set to your LND Service name (used for routing + config injection)
             - name: LND_K8S_SERVICE
               value: "lnd"

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  app: lnd
+                  app: lnd # Change to app: cln if targeting Core-Lightning
               topologyKey: kubernetes.io/hostname
       containers:
         - name: tunnelsats

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -31,6 +31,7 @@ export LND_K8S_NAMESPACE="${LND_K8S_NAMESPACE:-${K8S_NAMESPACE}}"
 export CLN_K8S_NAMESPACE="${CLN_K8S_NAMESPACE:-${K8S_NAMESPACE}}"
 export LND_K8S_POD_SELECTOR="${LND_K8S_POD_SELECTOR:-app=lnd}"
 export CLN_K8S_POD_SELECTOR="${CLN_K8S_POD_SELECTOR:-app=cln}"
+export TUNNELSATS_K8S_NODE_NAME="${TUNNELSATS_K8S_NODE_NAME:-}"
 K8S_SA_TOKEN_PATH="/var/run/secrets/kubernetes.io/serviceaccount/token"
 K8S_SA_CA_PATH="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 K8S_API_URL="https://kubernetes.default.svc"
@@ -239,10 +240,59 @@ resolve_svc_ip() {
     return 1
 }
 
+resolve_k3s_target_pod() {
+    local impl="$1"
+    local namespace="$2"
+    local selector="$3"
+    local encoded_selector pod_list pod
+    local pod_name pod_ip pod_node
+
+    encoded_selector=$(urlencode "${selector}")
+    if ! pod_list=$(k8s_api "/api/v1/namespaces/${namespace}/pods?labelSelector=${encoded_selector}"); then
+        LAST_ERROR="k3s: Failed to query ${impl^^} pods (namespace=${namespace}, selector=${selector})"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    if ! pod=$(printf '%s' "${pod_list}" | jq -ce \
+        '[.items[]? | select(.status.phase == "Running")] | first // empty' 2>/dev/null); then
+        LAST_ERROR="k3s: No Running ${impl^^} pod found (namespace=${namespace}, selector=${selector})"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    pod_name=$(printf '%s' "${pod}" | jq -r '.metadata.name // empty')
+    pod_ip=$(printf '%s' "${pod}" | jq -r '.status.podIP // empty')
+    pod_node=$(printf '%s' "${pod}" | jq -r '.spec.nodeName // empty')
+
+    if [ -z "${pod_name}" ] || [ -z "${pod_ip}" ] || [ -z "${pod_node}" ]; then
+        LAST_ERROR="k3s: ${impl^^} pod metadata incomplete (namespace=${namespace}, pod=${pod_name:-unknown}, pod_ip=${pod_ip:-missing}, node=${pod_node:-missing})"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    if [ -z "${TUNNELSATS_K8S_NODE_NAME}" ]; then
+        LAST_ERROR="k3s: TunnelSats node name is unavailable; refusing to activate dataplane"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    if [ "${pod_node}" != "${TUNNELSATS_K8S_NODE_NAME}" ]; then
+        LAST_ERROR="k3s: Pod co-location required; TunnelSats node=${TUNNELSATS_K8S_NODE_NAME}, ${impl^^} pod=${namespace}/${pod_name} node=${pod_node}"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    DOCKER_TARGET_IP="${pod_ip}"
+    log INFO "k3s: Using co-located ${impl^^} pod ${namespace}/${pod_name} on node ${pod_node} at ${pod_ip}"
+    return 0
+}
+
 detect_k3s_target() {
     TARGET_CONTAINER_ID=""
     TARGET_CONTAINER_NAME=""
     TARGET_IMPL=""
+    DOCKER_TARGET_IP=""
 
     local svc_name svc_fqdn svc_ip
 
@@ -257,17 +307,7 @@ detect_k3s_target() {
             log INFO "k3s: Detected LND service ${svc_fqdn} at ClusterIP ${svc_ip}"
             # Use the actual pod IP for DNAT and policy routing to avoid asymmetric
             # routing caused by kube-proxy's double NAT through the ClusterIP.
-            local pod_ip encoded_selector
-            encoded_selector=$(urlencode "${LND_K8S_POD_SELECTOR}")
-            pod_ip=$(k8s_api "/api/v1/namespaces/${LND_K8S_NAMESPACE}/pods?labelSelector=${encoded_selector}" 2>/dev/null \
-                | jq -r '.items[] | select(.status.phase == "Running") | .status.podIP' 2>/dev/null \
-                | head -n1 || true)
-            if [ -n "${pod_ip}" ]; then
-                DOCKER_TARGET_IP="${pod_ip}"
-                log INFO "k3s: Using LND pod IP ${pod_ip} for direct routing (bypasses kube-proxy)"
-            else
-                LAST_ERROR="k3s: Could not resolve LND pod IP"
-                log ERROR "k3s: Could not resolve LND pod IP, direct routing is required for WireGuard CONNMARK"
+            if ! resolve_k3s_target_pod "lnd" "${LND_K8S_NAMESPACE}" "${LND_K8S_POD_SELECTOR}"; then
                 return 1
             fi
             return 0
@@ -284,17 +324,7 @@ detect_k3s_target() {
             TARGET_CONTAINER_NAME="${svc_name}"
             LN_TARGET_PORT="9736"
             log INFO "k3s: Detected CLN service ${svc_fqdn} at ClusterIP ${svc_ip}"
-            local pod_ip encoded_selector
-            encoded_selector=$(urlencode "${CLN_K8S_POD_SELECTOR}")
-            pod_ip=$(k8s_api "/api/v1/namespaces/${CLN_K8S_NAMESPACE}/pods?labelSelector=${encoded_selector}" 2>/dev/null \
-                | jq -r '.items[] | select(.status.phase == "Running") | .status.podIP' 2>/dev/null \
-                | head -n1 || true)
-            if [ -n "${pod_ip}" ]; then
-                DOCKER_TARGET_IP="${pod_ip}"
-                log INFO "k3s: Using CLN pod IP ${pod_ip} for direct routing (bypasses kube-proxy)"
-            else
-                LAST_ERROR="k3s: Could not resolve CLN pod IP"
-                log ERROR "k3s: Could not resolve CLN pod IP, direct routing is required for WireGuard CONNMARK"
+            if ! resolve_k3s_target_pod "cln" "${CLN_K8S_NAMESPACE}" "${CLN_K8S_POD_SELECTOR}"; then
                 return 1
             fi
             return 0

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -244,7 +244,7 @@ resolve_k3s_target_pod() {
     local impl="$1"
     local namespace="$2"
     local selector="$3"
-    local encoded_selector pod_list pod
+    local encoded_selector pod_list running_pods pod
     local pod_name pod_ip pod_node
 
     encoded_selector=$(urlencode "${selector}")
@@ -254,8 +254,32 @@ resolve_k3s_target_pod() {
         return 1
     fi
 
-    if ! pod=$(printf '%s' "${pod_list}" | jq -ce \
-        '[.items[]? | select(.status.phase == "Running")] | first // empty' 2>/dev/null); then
+    if ! running_pods=$(printf '%s' "${pod_list}" | jq -ce \
+        '[.items[]? | select(.status.phase == "Running")]' 2>/dev/null); then
+        LAST_ERROR="k3s: No Running ${impl^^} pod found (namespace=${namespace}, selector=${selector})"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    if [ -z "${TUNNELSATS_K8S_NODE_NAME}" ]; then
+        LAST_ERROR="k3s: TunnelSats node name is unavailable; refusing to activate dataplane"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    # During a rollout the selector can temporarily match multiple Running pods.
+    # Prefer a complete pod on this node instead of trusting Kubernetes API order;
+    # otherwise a remote old/new replica could falsely trip the co-location guard.
+    if ! pod=$(printf '%s' "${running_pods}" | jq -ce --arg node "${TUNNELSATS_K8S_NODE_NAME}" \
+        '. as $pods
+         | ([$pods[]
+             | select(
+                 .spec.nodeName == $node
+                 and (.metadata.name // "") != ""
+                 and (.status.podIP // "") != ""
+             )] | first)
+           // $pods[0]
+           // empty' 2>/dev/null); then
         LAST_ERROR="k3s: No Running ${impl^^} pod found (namespace=${namespace}, selector=${selector})"
         log ERROR "${LAST_ERROR}"
         return 1
@@ -267,12 +291,6 @@ resolve_k3s_target_pod() {
 
     if [ -z "${pod_name}" ] || [ -z "${pod_ip}" ] || [ -z "${pod_node}" ]; then
         LAST_ERROR="k3s: ${impl^^} pod metadata incomplete (namespace=${namespace}, pod=${pod_name:-unknown}, pod_ip=${pod_ip:-missing}, node=${pod_node:-missing})"
-        log ERROR "${LAST_ERROR}"
-        return 1
-    fi
-
-    if [ -z "${TUNNELSATS_K8S_NODE_NAME}" ]; then
-        LAST_ERROR="k3s: TunnelSats node name is unavailable; refusing to activate dataplane"
         log ERROR "${LAST_ERROR}"
         return 1
     fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -326,7 +326,7 @@ resolve_k3s_target_pod() {
     fi
 
     if [ "${pod_node}" != "${TUNNELSATS_K8S_NODE_NAME}" ]; then
-        LAST_ERROR="k3s: Pod co-location required; TunnelSats node=${TUNNELSATS_K8S_NODE_NAME}, ${impl^^} pod=${namespace}/${pod_name} node=${pod_node}"
+        LAST_ERROR="k3s: Pod co-location required; TunnelSats node=${TUNNELSATS_K8S_NODE_NAME}, ${impl^^} pod=${namespace}/${pod_name} node=${pod_node}. Check podAffinity in k3s/deployment.yaml or node scheduling labels."
         log ERROR "${LAST_ERROR}"
         return 1
     fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -268,18 +268,48 @@ resolve_k3s_target_pod() {
     fi
 
     # During a rollout the selector can temporarily match multiple Running pods.
-    # Prefer a complete pod on this node instead of trusting Kubernetes API order;
-    # otherwise a remote old/new replica could falsely trip the co-location guard.
-    if ! pod=$(printf '%s' "${running_pods}" | jq -ce --arg node "${TUNNELSATS_K8S_NODE_NAME}" \
-        '. as $pods
-         | ([$pods[]
-             | select(
-                 .spec.nodeName == $node
-                 and (.metadata.name // "") != ""
-                 and (.status.podIP // "") != ""
-             )] | first)
-           // $pods[0]
-           // empty' 2>/dev/null); then
+    # Prefer a complete, Ready, non-terminating pod on this node instead of
+    # trusting Kubernetes API order.
+    pod=$(printf '%s' "${running_pods}" | jq -ce --arg node "${TUNNELSATS_K8S_NODE_NAME}" \
+        '[.[]
+          | select(
+              .spec.nodeName == $node
+              and (.metadata.deletionTimestamp // null) == null
+              and any(.status.conditions[]?; .type == "Ready" and .status == "True")
+              and (.metadata.name // "") != ""
+              and (.status.podIP // "") != ""
+          )]
+         | first
+         // empty' 2>/dev/null || true)
+
+    # Preserve the detailed incomplete-metadata error when the only otherwise
+    # usable local candidate lacks a name or pod IP.
+    if [ -z "${pod}" ]; then
+        pod=$(printf '%s' "${running_pods}" | jq -ce --arg node "${TUNNELSATS_K8S_NODE_NAME}" \
+            '[.[]
+              | select(
+                  .spec.nodeName == $node
+                  and (.metadata.deletionTimestamp // null) == null
+                  and any(.status.conditions[]?; .type == "Ready" and .status == "True")
+              )]
+             | first
+             // empty' 2>/dev/null || true)
+    fi
+
+    if [ -z "${pod}" ] && printf '%s' "${running_pods}" | jq -e --arg node "${TUNNELSATS_K8S_NODE_NAME}" \
+        'any(.[]; .spec.nodeName == $node)' >/dev/null 2>&1; then
+        LAST_ERROR="k3s: No Ready non-terminating ${impl^^} pod is co-located on TunnelSats node=${TUNNELSATS_K8S_NODE_NAME} (namespace=${namespace}, selector=${selector})"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+
+    # No local candidate exists. Keep one remote candidate so the normal
+    # co-location error below can report its pod and node.
+    if [ -z "${pod}" ]; then
+        pod=$(printf '%s' "${running_pods}" | jq -ce 'first // empty' 2>/dev/null || true)
+    fi
+
+    if [ -z "${pod}" ]; then
         LAST_ERROR="k3s: No Running ${impl^^} pod found (namespace=${namespace}, selector=${selector})"
         log ERROR "${LAST_ERROR}"
         return 1

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -74,7 +74,7 @@ resolve_svc_ip() {
     printf '%s\n' "10.43.0.10"
 }
 k8s_api() {
-    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-remote"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.9"}},{"metadata":{"name":"lnd-local"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-remote"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.9","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-unready"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.5","conditions":[{"type":"Ready","status":"False"}]}},{"metadata":{"name":"lnd-terminating","deletionTimestamp":"2026-07-31T08:00:00Z"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.6","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-local"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7","conditions":[{"type":"Ready","status":"True"}]}}]}'
 }
 
 detect_k3s_target
@@ -105,7 +105,7 @@ resolve_svc_ip() {
     printf '%s\n' "10.43.0.11"
 }
 k8s_api() {
-    printf '%s\n' '{"items":[{"metadata":{"name":"cln-0"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.8"}}]}'
+    printf '%s\n' '{"items":[{"metadata":{"name":"cln-0"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.8","conditions":[{"type":"Ready","status":"True"}]}}]}'
 }
 
 detect_k3s_target
@@ -229,6 +229,27 @@ if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
     exit 1
 fi
 [[ "${LAST_ERROR}" == *"No Running LND pod found"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_k3s_target_resolution_rejects_unready_or_terminating_local_pods():
+    result = run_bash(
+        r'''
+source "$1"
+
+TUNNELSATS_K8S_NODE_NAME="worker-a"
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-unready"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.5","conditions":[{"type":"Ready","status":"False"}]}},{"metadata":{"name":"lnd-terminating","deletionTimestamp":"2026-07-31T08:00:00Z"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.6","conditions":[{"type":"Ready","status":"True"}]}}]}'
+}
+
+if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
+    exit 1
+fi
+[[ "${LAST_ERROR}" == *"No Ready non-terminating LND pod is co-located"* ]]
+[[ "${LAST_ERROR}" == *"TunnelSats node=worker-a"* ]]
 '''
     )
 

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -56,3 +56,180 @@ ensure_fallback_blackhole_rule "10.9.9.0/25" "test failure"
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_k3s_lnd_target_must_be_colocated():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="true"
+TUNNELSATS_K8S_NODE_NAME="worker-a"
+LND_K8S_SERVICE="lnd"
+LND_K8S_NAMESPACE="lightning"
+LND_K8S_POD_SELECTOR="app=lnd"
+CLN_K8S_SERVICE=""
+
+resolve_svc_ip() {
+    printf '%s\n' "10.43.0.10"
+}
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-0"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
+}
+
+detect_k3s_target
+[[ "${TARGET_IMPL}" == "lnd" ]]
+[[ "${TARGET_CONTAINER_NAME}" == "lnd" ]]
+[[ "${DOCKER_TARGET_IP}" == "10.42.1.7" ]]
+[[ "${LN_TARGET_PORT}" == "9735" ]]
+[[ -z "${LAST_ERROR}" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_k3s_cln_target_must_be_colocated():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="true"
+TUNNELSATS_K8S_NODE_NAME="worker-b"
+LND_K8S_SERVICE=""
+CLN_K8S_SERVICE="cln"
+CLN_K8S_NAMESPACE="lightning"
+CLN_K8S_POD_SELECTOR="app=cln"
+
+resolve_svc_ip() {
+    printf '%s\n' "10.43.0.11"
+}
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"cln-0"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.8"}}]}'
+}
+
+detect_k3s_target
+[[ "${TARGET_IMPL}" == "cln" ]]
+[[ "${TARGET_CONTAINER_NAME}" == "cln" ]]
+[[ "${DOCKER_TARGET_IP}" == "10.42.2.8" ]]
+[[ "${LN_TARGET_PORT}" == "9736" ]]
+[[ -z "${LAST_ERROR}" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_k3s_cross_node_target_fails_closed_before_dataplane_activation():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="true"
+TUNNELSATS_K8S_NODE_NAME="worker-a"
+LND_K8S_SERVICE="lnd"
+LND_K8S_NAMESPACE="lightning"
+LND_K8S_POD_SELECTOR="app=lnd"
+CLN_K8S_SERVICE=""
+CLEANUP_COUNT=0
+WG_UP_COUNT=0
+STATE_ERROR=""
+STATE_SYNCED=""
+STATE_TARGET_IP=""
+
+resolve_svc_ip() {
+    printf '%s\n' "10.43.0.10"
+}
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-0"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.7"}}]}'
+}
+cleanup_dataplane() {
+    [[ "${1:-}" == "--keep-tunnel" ]]
+    CLEANUP_COUNT=$((CLEANUP_COUNT + 1))
+}
+ensure_wg_up() {
+    WG_UP_COUNT=$((WG_UP_COUNT + 1))
+}
+write_state() {
+    STATE_ERROR="${LAST_ERROR}"
+    STATE_SYNCED="${RULES_SYNCED}"
+    STATE_TARGET_IP="${DOCKER_TARGET_IP}"
+}
+
+if reconcile_once "test"; then
+    exit 1
+fi
+
+[[ "${CLEANUP_COUNT}" == "1" ]]
+[[ "${WG_UP_COUNT}" == "0" ]]
+[[ "${STATE_SYNCED}" == "false" ]]
+[[ -z "${STATE_TARGET_IP}" ]]
+[[ "${STATE_ERROR}" == *"Pod co-location required"* ]]
+[[ "${STATE_ERROR}" == *"TunnelSats node=worker-a"* ]]
+[[ "${STATE_ERROR}" == *"LND pod=lightning/lnd-0 node=worker-b"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_k3s_target_resolution_fails_when_node_metadata_is_unavailable():
+    result = run_bash(
+        r'''
+source "$1"
+
+TUNNELSATS_K8S_NODE_NAME="worker-a"
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-0"},"spec":{},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
+}
+
+if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
+    exit 1
+fi
+[[ "${LAST_ERROR}" == *"pod metadata incomplete"* ]]
+[[ "${LAST_ERROR}" == *"node=missing"* ]]
+
+TUNNELSATS_K8S_NODE_NAME=""
+k8s_api() {
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-0"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
+}
+
+if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
+    exit 1
+fi
+[[ "${LAST_ERROR}" == *"TunnelSats node name is unavailable"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_k3s_target_resolution_reports_api_and_selector_failures():
+    result = run_bash(
+        r'''
+source "$1"
+
+TUNNELSATS_K8S_NODE_NAME="worker-a"
+k8s_api() {
+    return 1
+}
+
+if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
+    exit 1
+fi
+[[ "${LAST_ERROR}" == *"Failed to query LND pods"* ]]
+[[ "${LAST_ERROR}" == *"namespace=lightning"* ]]
+[[ "${LAST_ERROR}" == *"selector=app=lnd"* ]]
+
+k8s_api() {
+    printf '%s\n' '{"items":[]}'
+}
+
+if resolve_k3s_target_pod "lnd" "lightning" "app=lnd"; then
+    exit 1
+fi
+[[ "${LAST_ERROR}" == *"No Running LND pod found"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -167,6 +167,7 @@ fi
 [[ "${STATE_ERROR}" == *"Pod co-location required"* ]]
 [[ "${STATE_ERROR}" == *"TunnelSats node=worker-a"* ]]
 [[ "${STATE_ERROR}" == *"LND pod=lightning/lnd-0 node=worker-b"* ]]
+[[ "${STATE_ERROR}" == *"Check podAffinity in k3s/deployment.yaml or node scheduling labels."* ]]
 '''
     )
 

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -74,7 +74,7 @@ resolve_svc_ip() {
     printf '%s\n' "10.43.0.10"
 }
 k8s_api() {
-    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-0"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-remote"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.9"}},{"metadata":{"name":"lnd-local"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7"}}]}'
 }
 
 detect_k3s_target

--- a/server/tests/test_k3s_manifest.py
+++ b/server/tests/test_k3s_manifest.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOYMENT_PATH = REPO_ROOT / "k3s" / "deployment.yaml"
+
+
+def load_deployment():
+    with DEPLOYMENT_PATH.open(encoding="utf-8") as manifest:
+        return yaml.safe_load(manifest)
+
+
+def test_k3s_manifest_requires_lnd_colocation_by_default():
+    deployment = load_deployment()
+    pod_spec = deployment["spec"]["template"]["spec"]
+    required_terms = pod_spec["affinity"]["podAffinity"][
+        "requiredDuringSchedulingIgnoredDuringExecution"
+    ]
+
+    assert len(required_terms) == 1
+    term = required_terms[0]
+    assert term["labelSelector"]["matchLabels"] == {"app": "lnd"}
+    assert term["topologyKey"] == "kubernetes.io/hostname"
+    # Omitting namespaces makes affinity use the Deployment's own namespace,
+    # matching the default LND_K8S_NAMESPACE=K8S_NAMESPACE configuration.
+    assert "namespaces" not in term
+    assert "namespaceSelector" not in term
+
+
+def test_k3s_manifest_exposes_tunnelsats_node_name_to_runtime():
+    deployment = load_deployment()
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env = {entry["name"]: entry for entry in container["env"]}
+
+    assert env["TUNNELSATS_K8S_NODE_NAME"]["valueFrom"]["fieldRef"] == {
+        "fieldPath": "spec.nodeName"
+    }
+    assert env["LND_K8S_POD_SELECTOR"]["value"] == "app=lnd"

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -103,7 +103,9 @@ describe('UI Routing and Initialization', () => {
                     target_impl: 'lnd',
                     target_container: 'lightning_lnd_1',
                     configs_found: [],
-                    version: 'v3.0.0'
+                    version: 'v3.0.0',
+                    rules_synced: true,
+                    last_error: null
                 }),
                 ok: true
             })
@@ -263,6 +265,36 @@ describe('UI Routing and Initialization', () => {
 
         expect(document.getElementById('statusBadge').textContent).toBe('Connected');
         expect(document.getElementById('txt-routing-status').textContent).toBe('No Nodes Detected');
+    });
+
+    test('fetchStatus reports a fail-closed dataplane error instead of Protected', async () => {
+        const error = 'k3s: Pod co-location required; TunnelSats node=worker-a, LND pod=lightning/lnd-0 node=worker-b';
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    vpn_active: true,
+                    lnd_detected: true,
+                    cln_detected: false,
+                    lnd_routing_active: true,
+                    cln_routing_active: false,
+                    wg_status: 'Connected',
+                    target_impl: 'lnd',
+                    rules_synced: false,
+                    last_error: error
+                }),
+                ok: true
+            })
+        );
+
+        await window.fetchStatus();
+
+        expect(document.getElementById('statusBadge').textContent).toBe('Connected');
+        expect(document.getElementById('txt-routing-status').textContent).toBe('Dataplane Blocked');
+        expect(document.getElementById('badge-routing').textContent).toBe('Offline');
+        expect(document.getElementById('txt-routing-error').textContent).toBe(error);
+        expect(document.getElementById('txt-routing-error').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('dashboard-banner-title').textContent).toBe('Hybrid Lightning Connectivity');
+        expect(document.getElementById('btn-dash-disable-routing').classList.contains('hidden')).toBe(true);
     });
 
     test('fetchStatus adjusts UI for secure_mode: true', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -114,6 +114,9 @@
                         <div id="txt-routing-status" class="text-xl font-bold text-white mt-4">
                             <span class="skeleton w-48 h-6"></span>
                         </div>
+                        <p id="txt-routing-error"
+                            class="hidden mt-3 rounded-lg border border-red-800/70 bg-red-950/40 p-3 font-mono text-xs text-red-300 break-words">
+                        </p>
                         <div id="routing-actions" class="mt-6 space-x-3 hidden">
                             <button id="btn-dash-enable-routing"
                                 class="flex-1 bg-tsyellow hover:bg-yellow-500 text-black font-bold py-2.5 px-4 rounded-xl transition shadow-lg hidden">Enable

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -82,6 +82,7 @@ async function mockFetch(url) {
                 expires_at: '2027-03-10T12:00:00Z',
                 forwarding_port: '35825',
                 last_reconcile_at: new Date().toISOString(),
+                rules_synced: true,
                 last_error: null
             }
         };
@@ -724,13 +725,16 @@ async function fetchStatus() {
         const clnDetected = data.cln_detected === true;
         const lndRouting = data.lnd_routing_active === true;
         const clnRouting = data.cln_routing_active === true;
+        const dataplaneError = typeof data.last_error === 'string' && data.last_error.trim() !== ''
+            ? data.last_error.trim()
+            : '';
 
         const hasNode = lndDetected || clnDetected;
         const routingActive = lndRouting || clnRouting;
 
         // Update Header Badge
         const badge = document.getElementById('statusBadge');
-        if (vpnActive && hasNode && routingActive) {
+        if (vpnActive && hasNode && routingActive && !dataplaneError) {
             badge.className = "px-4 py-2 rounded-full font-bold text-sm bg-green-900/50 text-tsgreen border border-green-700";
             badge.textContent = "Protected";
             const pingDot = document.getElementById('ping-tunnel');
@@ -849,6 +853,7 @@ async function fetchStatus() {
         // Node Routing explicit UI states
         const badgeRouting = document.getElementById('badge-routing');
         const txtRoutingStatus = document.getElementById('txt-routing-status');
+        const txtRoutingError = document.getElementById('txt-routing-error');
         const routingActions = document.getElementById('routing-actions');
         const btnDashEnable = document.getElementById('btn-dash-enable-routing');
         const btnDashDisable = document.getElementById('btn-dash-disable-routing');
@@ -859,9 +864,16 @@ async function fetchStatus() {
         }
         if (btnDashEnable) btnDashEnable.classList.add('hidden');
         if (btnDashDisable) btnDashDisable.classList.add('hidden');
+        if (txtRoutingError) {
+            txtRoutingError.textContent = dataplaneError;
+            txtRoutingError.classList.toggle('hidden', !dataplaneError);
+        }
 
         let badgeState;
-        if (!hasNode) {
+        if (dataplaneError) {
+            badgeState = BADGE_STATES.offline;
+            if (txtRoutingStatus) txtRoutingStatus.textContent = "Dataplane Blocked";
+        } else if (!hasNode) {
             badgeState = BADGE_STATES.notFound;
             if (txtRoutingStatus) txtRoutingStatus.textContent = "No Nodes Detected";
         } else if (!vpnActive) {
@@ -887,7 +899,7 @@ async function fetchStatus() {
         const bannerText = document.getElementById('dashboard-banner-text');
         const bannerDots = document.getElementById('dashboard-banner-dots');
 
-        if (vpnActive) {
+        if (vpnActive && !dataplaneError) {
             if (bannerTitle) bannerTitle.textContent = "Network Layer Active";
             if (bannerText) bannerText.textContent = "Secure WireGuard tunneling provided by Tunnelsats. Your Lightning P2P traffic is now encrypted and routed through our private global exit nodes.";
             if (bannerDots) {
@@ -1927,7 +1939,12 @@ async function pollUntilConnected(options = {}) {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         const status = await fetchStatus();
-        if (status && status.vpn_active === true) {
+        if (
+            status
+            && status.vpn_active === true
+            && status.rules_synced !== false
+            && !status.last_error
+        ) {
             if (onConnected) onConnected(status);
             return true;
         }


### PR DESCRIPTION
## Summary

- enforce required pod affinity for the default LND k3s deployment
- compare the TunnelSats and selected Lightning pod node names before activating routing
- fail closed, clear stale target state, and surface co-location errors in the dashboard
- document aligned LND/CLN selectors and cross-namespace affinity
- add manifest, dataplane, and UI regression coverage

## Validation

- `.venv-tests/bin/pytest -q server/tests/` (161 passed)
- `npm test -- --runInBand` in `web/` (57 passed)
- `bash scripts/test.sh entrypoint` (9 cases passed)
- `bash -n scripts/entrypoint.sh`
- `shellcheck -e SC2010,SC2086,SC2001,SC2034 scripts/entrypoint.sh`
- `git diff --check`

Fixes #117