### PR TITLE
fix(dataplane): keep startup and reconciliation fail-closed

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -614,6 +614,49 @@ read_wg_config_path() {
     echo "${files[0]:-}"
 }
 
+ensure_runtime_wireguard_keepalive() {
+    local config_path="$1"
+    local config_tmp
+
+    [ -f "${config_path}" ] || return 1
+    config_tmp="$(mktemp "${config_path}.tmp.XXXXXX")" || return 1
+
+    if ! awk '
+        function add_keepalive_if_missing() {
+            if (in_peer && !peer_has_keepalive) {
+                print "PersistentKeepalive = 25"
+            }
+        }
+        {
+            normalized = tolower($0)
+            gsub(/[[:space:]]/, "", normalized)
+            if (normalized ~ /^\[[^]]+\]$/) {
+                add_keepalive_if_missing()
+                in_peer = (normalized == "[peer]")
+                peer_has_keepalive = 0
+                print
+                next
+            }
+            directive = tolower($0)
+            if (in_peer && directive ~ /^[[:space:]]*persistentkeepalive[[:space:]]*=/) {
+                peer_has_keepalive = 1
+            }
+            print
+        }
+        END {
+            add_keepalive_if_missing()
+        }
+    ' "${config_path}" > "${config_tmp}"; then
+        rm -f "${config_tmp}"
+        return 1
+    fi
+
+    if ! mv -f "${config_tmp}" "${config_path}"; then
+        rm -f "${config_tmp}"
+        return 1
+    fi
+}
+
 extract_forwarding_port() {
     local cfg="$1"
     if [ -z "${cfg}" ] || [ ! -f "${cfg}" ]; then
@@ -998,6 +1041,10 @@ ensure_wg_up() {
 
     mkdir -p /etc/wireguard
     cp "${source_cfg}" "${WG_CONF_PATH}"
+    if ! ensure_runtime_wireguard_keepalive "${WG_CONF_PATH}"; then
+        LAST_ERROR="Failed to ensure PersistentKeepalive in runtime WireGuard config"
+        return 1
+    fi
 
     # Ensure WireGuard doesn't aggressively hijack the host routing table via AllowedIPs=0.0.0.0/0
     sed -i '/^\s*Table\s*=/Id' "${WG_CONF_PATH}"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -16,6 +16,8 @@ DOCKER_NETWORK_SUBNET="10.9.9.0/25"
 DOCKER_TARGET_IP="10.9.9.9"
 LN_TARGET_PORT="9735" # Default to LND, will be updated in detect_lightning_container
 RECONCILE_INTERVAL=30
+KILL_SWITCH_PREF=32762
+WG_HANDSHAKE_MAX_AGE=180
 
 # k3s mode: set K3S_MODE=true to bypass Docker networking and use Kubernetes Services instead.
 # These are explicitly exported so the Python dashboard (launched as a child process below)
@@ -1313,6 +1315,116 @@ get_target_subnet() {
     echo "${subnet}"
 }
 
+ensure_source_blackhole_rule() {
+    local source_prefix="$1"
+    local preference="$2"
+    local error_message="$3"
+    local escaped_source="${source_prefix//./\\.}"
+    local displayed_source="${escaped_source}"
+    local source_pattern
+    local exact_pattern
+    local matching_rules
+    local matching_count
+
+    [[ "${source_prefix}" == */* ]] || displayed_source+="(/32)?"
+    source_pattern="^${preference}:[[:space:]]+from[[:space:]]+${displayed_source}([[:space:]]|$)"
+    exact_pattern="^${preference}:[[:space:]]+from[[:space:]]+${displayed_source}[[:space:]]+blackhole[[:space:]]*$"
+    SOURCE_BLACKHOLE_CHANGED="0"
+
+    matching_rules="$(ip rule show pref "${preference}" 2>/dev/null | grep -E "${source_pattern}" || true)"
+    matching_count="$(printf '%s\n' "${matching_rules}" | sed '/^$/d' | wc -l)"
+    if [ "${matching_count}" -eq 1 ] && printf '%s\n' "${matching_rules}" | grep -qE "${exact_pattern}"; then
+        return 0
+    fi
+
+    local rule_line
+    while IFS= read -r rule_line; do
+        [ -n "${rule_line}" ] || continue
+        delete_policy_rule_line "${rule_line}" || true
+    done <<< "${matching_rules}"
+
+    if ip rule show pref "${preference}" 2>/dev/null | grep -qE "${source_pattern}"; then
+        LAST_ERROR="${error_message}: failed to remove conflicting pref ${preference} rule"
+        return 1
+    fi
+
+    ip rule add from "${source_prefix}" blackhole pref "${preference}" >/dev/null 2>&1 || true
+    matching_rules="$(ip rule show pref "${preference}" 2>/dev/null | grep -E "${source_pattern}" || true)"
+    matching_count="$(printf '%s\n' "${matching_rules}" | sed '/^$/d' | wc -l)"
+    if [ "${matching_count}" -ne 1 ] || ! printf '%s\n' "${matching_rules}" | grep -qE "${exact_pattern}"; then
+        LAST_ERROR="${error_message}"
+        return 1
+    fi
+
+    SOURCE_BLACKHOLE_CHANGED="1"
+}
+
+ensure_reconcile_kill_switch() {
+    [[ "${K3S_MODE}" == "true" ]] && return 0
+
+    if [[ "${SECURE_MODE}" == "true" ]]; then
+        ensure_source_blackhole_rule \
+            "10.21.21.9" "${KILL_SWITCH_PREF}" \
+            "SecureMode: Failed to install LND reconciliation kill switch" || return 1
+        ensure_source_blackhole_rule \
+            "10.21.21.96" "${KILL_SWITCH_PREF}" \
+            "SecureMode: Failed to install CLN reconciliation kill switch" || return 1
+        return 0
+    fi
+
+    ensure_source_blackhole_rule \
+        "${DOCKER_NETWORK_SUBNET}" "${KILL_SWITCH_PREF}" \
+        "Failed to install reconciliation kill switch for ${DOCKER_NETWORK_SUBNET}"
+}
+
+remove_source_blackhole_rule() {
+    local source_prefix="$1"
+    local preference="$2"
+    local escaped_source="${source_prefix//./\\.}"
+    local displayed_source="${escaped_source}"
+    local exact_pattern
+
+    [[ "${source_prefix}" == */* ]] || displayed_source+="(/32)?"
+    exact_pattern="^${preference}:[[:space:]]+from[[:space:]]+${displayed_source}[[:space:]]+blackhole[[:space:]]*$"
+    ip rule del from "${source_prefix}" blackhole pref "${preference}" >/dev/null 2>&1 || true
+    if ip rule show pref "${preference}" 2>/dev/null | grep -qE "${exact_pattern}"; then
+        LAST_ERROR="Failed to release reconciliation kill switch for ${source_prefix}"
+        return 1
+    fi
+}
+
+remove_reconcile_kill_switch() {
+    [[ "${K3S_MODE}" == "true" ]] && return 0
+
+    if [[ "${SECURE_MODE}" == "true" ]]; then
+        [ -n "${DOCKER_TARGET_IP:-}" ] || return 0
+        remove_source_blackhole_rule "${DOCKER_TARGET_IP}" "${KILL_SWITCH_PREF}"
+        return
+    fi
+
+    remove_source_blackhole_rule "${DOCKER_NETWORK_SUBNET}" "${KILL_SWITCH_PREF}"
+}
+
+wireguard_handshake_is_fresh() {
+    local latest_handshake
+    local now
+    local age
+
+    latest_handshake="$(wg show "${WG_IFACE}" latest-handshakes 2>/dev/null \
+        | awk 'BEGIN { newest = 0 } $2 > newest { newest = $2 } END { print newest }' || true)"
+    if [[ ! "${latest_handshake}" =~ ^[0-9]+$ ]] || [ "${latest_handshake}" -eq 0 ]; then
+        LAST_ERROR="WireGuard has no completed handshake"
+        return 1
+    fi
+
+    now="$(date +%s)"
+    age=$((now - latest_handshake))
+    if [ "${age}" -lt 0 ] || [ "${age}" -gt "${WG_HANDSHAKE_MAX_AGE}" ]; then
+        LAST_ERROR="WireGuard handshake is stale (${age}s; maximum ${WG_HANDSHAKE_MAX_AGE}s)"
+        return 1
+    fi
+}
+
 ensure_fallback_blackhole_rule() {
     local source_prefix="$1"
     local error_message="$2"
@@ -2028,7 +2140,43 @@ ensure_nat_forward_rules() {
     return 0
 }
 
+fail_closed_policy_prerequisites_are_synced() {
+    [[ "${K3S_MODE}" == "true" ]] && return 0
+
+    local source_prefix
+    if [[ "${SECURE_MODE}" == "true" ]]; then
+        source_prefix="${DOCKER_TARGET_IP}"
+    else
+        source_prefix="${DOCKER_NETWORK_SUBNET}"
+    fi
+
+    local escaped_source="${source_prefix//./\\.}"
+    local displayed_source="${escaped_source}"
+    [[ "${source_prefix}" == */* ]] || displayed_source+="(/32)?"
+    if ! ip rule show pref "${K3S_BLACKHOLE_RULE_PREF}" 2>/dev/null \
+        | grep -qE "^${K3S_BLACKHOLE_RULE_PREF}:[[:space:]]+from[[:space:]]+${displayed_source}[[:space:]]+blackhole[[:space:]]*$"; then
+        log WARN "rules_are_synced: source fallback blackhole FAIL"
+        return 1
+    fi
+
+    local table_routes
+    table_routes="$(ip route show table 51820 2>/dev/null || true)"
+    if ! printf '%s\n' "${table_routes}" \
+        | grep -qE "^default([[:space:]].*)?[[:space:]]dev[[:space:]]+${WG_IFACE}([[:space:]]|$)"; then
+        log WARN "rules_are_synced: WireGuard table default route FAIL"
+        return 1
+    fi
+    if ! printf '%s\n' "${table_routes}" | grep -qE '^blackhole[[:space:]]+default([[:space:]]|$)'; then
+        log WARN "rules_are_synced: policy table blackhole FAIL"
+        return 1
+    fi
+}
+
 rules_are_synced() {
+    if ! fail_closed_policy_prerequisites_are_synced; then
+        return 1
+    fi
+
     # We match the config-defined VPNPort on the tunnel interface to catch these packets.
     local internal_match_port="${FORWARDING_PORT}"
 
@@ -2321,6 +2469,7 @@ cleanup_dataplane() {
             ip rule del from "${cleanup_ip}" to "${cleanup_subnet}" table main pref 32500 >/dev/null 2>&1 || true
             ip rule del from "${cleanup_ip}" table 51820 pref 32764 >/dev/null 2>&1 || true
             if [ "${keep_tunnel}" = false ]; then
+                ip rule del from "${cleanup_ip}" blackhole pref "${KILL_SWITCH_PREF}" >/dev/null 2>&1 || true
                 ip rule del from "${cleanup_ip}" blackhole pref 32765 >/dev/null 2>&1 || true
             fi
         done
@@ -2335,6 +2484,7 @@ cleanup_dataplane() {
             ip rule del from "${bridge_gw}" table 51820 pref 32763 >/dev/null 2>&1 || true
 
             if [ "${keep_tunnel}" = false ]; then
+                ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref "${KILL_SWITCH_PREF}" >/dev/null 2>&1 || true
                 ip rule del from "${DOCKER_NETWORK_SUBNET}" blackhole pref 32765 >/dev/null 2>&1 || true
             fi
 
@@ -2390,6 +2540,47 @@ write_reconcile_result() {
     cp -f "${result_path}" "${RECONCILE_RESULT_LEGACY}" || true
 }
 
+fail_reconcile_closed() {
+    local request_id="${1:-}"
+    local failure_error="${LAST_ERROR:-Reconciliation failed}"
+    local pre_cleanup_guard_error=""
+
+    # k3s owns a separate layered isolation and recovery lifecycle. Preserve
+    # that state instead of applying the Docker/Secure Mode cleanup below.
+    if [[ "${K3S_MODE}" == "true" ]]; then
+        RULES_SYNCED="false"
+        write_state
+        if [ -n "${request_id}" ]; then
+            write_reconcile_result "${request_id}" false
+        fi
+        return 1
+    fi
+
+    # Try to isolate first, but always clear partially staged NAT/FORWARD and
+    # source-routing state even when this attempt fails. The post-cleanup retry
+    # then verifies that the dataplane is left fail-closed.
+    if ! ensure_reconcile_kill_switch; then
+        pre_cleanup_guard_error="${LAST_ERROR}"
+    fi
+
+    cleanup_dataplane "--keep-tunnel"
+
+    if ! ensure_reconcile_kill_switch; then
+        LAST_ERROR="${failure_error}; additionally failed to restore kill switch: ${LAST_ERROR}"
+    elif [ -n "${pre_cleanup_guard_error}" ]; then
+        LAST_ERROR="${failure_error}; pre-cleanup kill switch warning: ${pre_cleanup_guard_error}"
+    else
+        LAST_ERROR="${failure_error}"
+    fi
+
+    RULES_SYNCED="false"
+    write_state
+    if [ -n "${request_id}" ]; then
+        write_reconcile_result "${request_id}" false
+    fi
+    return 1
+}
+
 reconcile_once() {
     local reason="$1"
     local request_id="${2:-}"
@@ -2403,8 +2594,8 @@ reconcile_once() {
 
     log INFO "reconcile_start reason=${reason}"
 
-    if [[ "${K3S_MODE}" != "true" ]] && [[ "${SECURE_MODE}" != "true" ]] && [ ! -S "${DOCKER_SOCK}" ]; then
-        LAST_ERROR="Docker socket unavailable"
+    if ! ensure_reconcile_kill_switch; then
+        LAST_ERROR="${LAST_ERROR:-Failed to install reconciliation kill switch}"
         write_state
         if [ -n "${request_id}" ]; then
             write_reconcile_result "${request_id}" false
@@ -2412,12 +2603,22 @@ reconcile_once() {
         return 1
     fi
 
+    if [[ "${K3S_MODE}" != "true" ]] && [[ "${SECURE_MODE}" != "true" ]] && [ ! -S "${DOCKER_SOCK}" ]; then
+        LAST_ERROR="Docker socket unavailable"
+        fail_reconcile_closed "${request_id}"
+        return 1
+    fi
+
     if ! detect_lightning_container; then
         LAST_ERROR="${LAST_ERROR:-No running LND/CLN container detected}"
-        cleanup_dataplane "--keep-tunnel"
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
+        if [[ "${K3S_MODE}" == "true" ]]; then
+            cleanup_dataplane "--keep-tunnel"
+            write_state
+            if [ -n "${request_id}" ]; then
+                write_reconcile_result "${request_id}" false
+            fi
+        else
+            fail_reconcile_closed "${request_id}"
         fi
         return 1
     fi
@@ -2467,43 +2668,33 @@ reconcile_once() {
     fi
 
     if ! ensure_docker_network; then
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
 
     if ! ensure_container_attached; then
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
 
     if ! resolve_bridge_name; then
         LAST_ERROR="Failed to resolve docker bridge interface"
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
 
     if ! ensure_wg_up; then
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
+        return 1
+    fi
+
+    if [[ "${K3S_MODE}" != "true" ]] && ! wireguard_handshake_is_fresh; then
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
 
     if ! ensure_policy_routing; then
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
     policy_changed="${POLICY_CHANGED}"
@@ -2513,10 +2704,7 @@ reconcile_once() {
     fi
 
     if ! ensure_nat_forward_rules; then
-        write_state
-        if [ -n "${request_id}" ]; then
-            write_reconcile_result "${request_id}" false
-        fi
+        fail_reconcile_closed "${request_id}"
         return 1
     fi
     nat_changed="${NAT_CHANGED}"
@@ -2525,14 +2713,40 @@ reconcile_once() {
         changed=1
     fi
 
-    if rules_are_synced; then
-        if [[ "${K3S_MODE}" == "true" ]] && ! release_k3s_reconcile_guards; then
-            RULES_SYNCED="false"
-        else
-            RULES_SYNCED="true"
+    if [[ "${K3S_MODE}" == "true" ]]; then
+        if ! rules_are_synced; then
+            LAST_ERROR="Dataplane rules are not fully synced"
+            fail_reconcile_closed "${request_id}"
+            return 1
         fi
-    else
+        if ! release_k3s_reconcile_guards; then
+            RULES_SYNCED="false"
+            fail_reconcile_closed "${request_id}"
+            return 1
+        fi
+        RULES_SYNCED="true"
+    elif ! rules_are_synced; then
         LAST_ERROR="Dataplane rules are not fully synced"
+        fail_reconcile_closed "${request_id}"
+        return 1
+    else
+        # The emergency guard remains active while the complete dataplane and
+        # handshake are verified. Only then can target traffic use table 51820.
+        if ! wireguard_handshake_is_fresh; then
+            fail_reconcile_closed "${request_id}"
+            return 1
+        fi
+        if ! remove_reconcile_kill_switch; then
+            fail_reconcile_closed "${request_id}"
+            return 1
+        fi
+        # Defense in depth against route-table drift during activation.
+        if ! rules_are_synced; then
+            LAST_ERROR="Dataplane rules failed verification after kill-switch release"
+            fail_reconcile_closed "${request_id}"
+            return 1
+        fi
+        RULES_SYNCED="true"
     fi
 
     write_state
@@ -2570,7 +2784,12 @@ main_loop() {
             if [ -n "${API_PID}" ]; then
                 kill "${API_PID}" >/dev/null 2>&1 || true
             fi
-            cleanup_dataplane
+            if [[ "${K3S_MODE}" == "true" ]]; then
+                cleanup_dataplane
+            else
+                LAST_ERROR="Restart requested; dataplane remains fail-closed"
+                fail_reconcile_closed || true
+            fi
             exit 1
         fi
 
@@ -2613,6 +2832,11 @@ if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
 fi
 
 trap cleanup SIGTERM SIGINT
+
+if ! ensure_reconcile_kill_switch; then
+    log ERROR "Startup aborted because the Lightning kill switch could not be installed: ${LAST_ERROR}"
+    exit 1
+fi
 
 echo "Starting Tunnelsats v3 (mode: $([[ "${K3S_MODE}" == "true" ]] && echo "k3s" || echo "umbrel"))..."
 log INFO "Starting internal dashboard server on port 9739"

--- a/server/app.py
+++ b/server/app.py
@@ -1863,7 +1863,7 @@ def claim_subscription():
             if sanitize_error:
                 app.logger.error(f"Upstream claim returned unsafe WireGuard config: {sanitize_error}")
                 return jsonify({"success": False, "error": "Invalid upstream payload: Unsafe WireGuard configuration"}), 400
-            full_config = sanitized_full_config or ""
+            full_config = _ensure_peer_persistent_keepalive(sanitized_full_config or "", keepalive=25)
 
             sub = data.get("subscription")
             subscription_data = sub if isinstance(sub, dict) else {}

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -350,6 +350,34 @@ class TestClaimSavesConfig:
         conf_files = [f for f in os.listdir(data_dir) if f.endswith('.conf')]
         assert len(conf_files) == 1
 
+    @patch('app.requests.post')
+    def test_claim_adds_missing_persistent_keepalive(self, mock_post, client, data_dir):
+        """Claimed peers must keep handshakes fresh while source traffic is quarantined."""
+        claim_response = MOCK_CLAIM_RESPONSE.copy()
+        claim_response["config"] = claim_response["config"].replace(
+            "PersistentKeepalive = 25\n", ""
+        )
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = claim_response
+        mock_resp.content = json.dumps(claim_response).encode()
+        mock_resp.headers = {"Content-Type": "application/json"}
+        mock_post.return_value = mock_resp
+
+        res = client.post(
+            '/api/subscription/claim',
+            json={"paymentHash": "test-hash-123", "referralCode": None},
+            content_type='application/json',
+        )
+
+        assert res.status_code == 200
+        conf_files = [f for f in os.listdir(data_dir) if f.endswith('.conf')]
+        assert len(conf_files) == 1
+        with open(os.path.join(data_dir, conf_files[0])) as config_file:
+            saved_config = config_file.read()
+        assert saved_config.count("PersistentKeepalive = 25") == 1
+
     @patch('app.requests.post', side_effect=_mock_claim_post)
     def test_claim_saves_metadata_json(self, mock_post, client, data_dir):
         """A metadata file must be created with fields from the response."""

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import tempfile
 
+import pytest
+
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 ENTRYPOINT_PATH = os.path.join(REPO_ROOT, "scripts", "entrypoint.sh")
@@ -58,6 +60,284 @@ ensure_fallback_blackhole_rule "10.9.9.0/25" "test failure"
 [[ "${BLACKHOLE_CHANGED}" == "0" ]]
 [[ "${DELETE_COUNT}" == "2" ]]
 [[ "${ADD_COUNT}" == "1" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_startup_kill_switch_covers_docker_subnet_and_secure_candidates():
+    result = run_bash(
+        r'''
+source "$1"
+
+GUARDS=""
+ensure_source_blackhole_rule() { GUARDS+="$1:$2"$'\n'; }
+
+K3S_MODE="false"
+SECURE_MODE="false"
+ensure_reconcile_kill_switch
+[[ "${GUARDS}" == $'10.9.9.0/25:32762\n' ]]
+
+GUARDS=""
+SECURE_MODE="true"
+ensure_reconcile_kill_switch
+[[ "${GUARDS}" == $'10.21.21.9:32762\n10.21.21.96:32762\n' ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_detection_failure_is_guarded_before_discovery_and_stays_fail_closed():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+EVENTS=""
+
+ensure_source_blackhole_rule() { EVENTS+="guard:$1"$'\n'; }
+detect_lightning_container() { EVENTS+="detect"$'\n'; return 1; }
+cleanup_dataplane() { EVENTS+="cleanup:$1"$'\n'; }
+write_state() { EVENTS+="state:${RULES_SYNCED}"$'\n'; }
+
+if reconcile_once "test"; then exit 1; fi
+
+[[ "${EVENTS}" == $'guard:10.21.21.9\nguard:10.21.21.96\ndetect\nguard:10.21.21.9\nguard:10.21.21.96\ncleanup:--keep-tunnel\nguard:10.21.21.9\nguard:10.21.21.96\nstate:false\n' ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "failed_stage",
+    ["docker_network", "container_attach", "bridge", "wireguard", "policy", "nat"],
+)
+def test_each_reconciliation_failure_restores_the_kill_switch(failed_stage):
+    result = run_bash(
+        rf'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+FAILED_STAGE="{failed_stage}"
+GUARD_COUNT=0
+CLEANUP_COUNT=0
+
+ensure_source_blackhole_rule() {{ GUARD_COUNT=$((GUARD_COUNT + 1)); }}
+detect_lightning_container() {{ DOCKER_TARGET_IP="10.21.21.9"; TARGET_CONTAINER_NAME="lnd"; return 0; }}
+stage() {{ [[ "${{FAILED_STAGE}}" != "$1" ]]; }}
+ensure_docker_network() {{ stage docker_network; }}
+ensure_container_attached() {{ stage container_attach; }}
+resolve_bridge_name() {{ stage bridge; }}
+ensure_wg_up() {{ stage wireguard; }}
+wireguard_handshake_is_fresh() {{ return 0; }}
+ensure_policy_routing() {{ POLICY_CHANGED=0; stage policy; }}
+ensure_nat_forward_rules() {{ NAT_CHANGED=0; stage nat; }}
+rules_are_synced() {{ return 0; }}
+cleanup_dataplane() {{ [[ "$1" == "--keep-tunnel" ]]; CLEANUP_COUNT=$((CLEANUP_COUNT + 1)); }}
+write_state() {{ :; }}
+
+if reconcile_once "test"; then exit 1; fi
+[[ "${{CLEANUP_COUNT}}" == "1" ]]
+[[ "${{GUARD_COUNT}}" == "6" ]]
+[[ "${{RULES_SYNCED}}" == "false" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_failed_precleanup_guard_still_cleans_partial_dataplane_and_retries_guard():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+GUARD_COUNT=0
+CLEANUP_COUNT=0
+STATE_ERROR=""
+
+ensure_reconcile_kill_switch() {
+    GUARD_COUNT=$((GUARD_COUNT + 1))
+    if [ "${GUARD_COUNT}" = "1" ]; then
+        LAST_ERROR="pre-cleanup guard failed"
+        return 1
+    fi
+    return 0
+}
+cleanup_dataplane() {
+    [[ "$1" == "--keep-tunnel" ]]
+    CLEANUP_COUNT=$((CLEANUP_COUNT + 1))
+}
+write_state() { STATE_ERROR="${LAST_ERROR}"; }
+
+LAST_ERROR="NAT staging failed"
+if fail_reconcile_closed; then exit 1; fi
+
+[[ "${CLEANUP_COUNT}" == "1" ]]
+[[ "${GUARD_COUNT}" == "2" ]]
+[[ "${STATE_ERROR}" == *"NAT staging failed"* ]]
+[[ "${STATE_ERROR}" == *"pre-cleanup kill switch warning: pre-cleanup guard failed"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_stale_wireguard_handshake_never_activates_policy_routing():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+POLICY_COUNT=0
+CLEANUP_COUNT=0
+
+ensure_source_blackhole_rule() { :; }
+detect_lightning_container() { DOCKER_TARGET_IP="10.21.21.9"; return 0; }
+ensure_docker_network() { return 0; }
+ensure_container_attached() { return 0; }
+resolve_bridge_name() { return 0; }
+ensure_wg_up() { return 0; }
+wireguard_handshake_is_fresh() { LAST_ERROR="WireGuard handshake is stale"; return 1; }
+ensure_policy_routing() { POLICY_COUNT=$((POLICY_COUNT + 1)); return 0; }
+cleanup_dataplane() { CLEANUP_COUNT=$((CLEANUP_COUNT + 1)); }
+write_state() { :; }
+
+if reconcile_once "test"; then exit 1; fi
+[[ "${POLICY_COUNT}" == "0" ]]
+[[ "${CLEANUP_COUNT}" == "1" ]]
+[[ "${LAST_ERROR}" == *"handshake is stale"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_unsynced_dataplane_is_requarantined_and_reported_as_failure():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+CLEANUP_COUNT=0
+RELEASE_COUNT=0
+
+ensure_source_blackhole_rule() { :; }
+detect_lightning_container() { DOCKER_TARGET_IP="10.21.21.9"; return 0; }
+ensure_docker_network() { return 0; }
+ensure_container_attached() { return 0; }
+resolve_bridge_name() { return 0; }
+ensure_wg_up() { return 0; }
+wireguard_handshake_is_fresh() { return 0; }
+ensure_policy_routing() { POLICY_CHANGED=0; return 0; }
+ensure_nat_forward_rules() { NAT_CHANGED=0; return 0; }
+rules_are_synced() { return 1; }
+remove_reconcile_kill_switch() { RELEASE_COUNT=$((RELEASE_COUNT + 1)); }
+cleanup_dataplane() { CLEANUP_COUNT=$((CLEANUP_COUNT + 1)); }
+write_state() { :; }
+
+if reconcile_once "test"; then exit 1; fi
+[[ "${RELEASE_COUNT}" == "0" ]]
+[[ "${CLEANUP_COUNT}" == "1" ]]
+[[ "${RULES_SYNCED}" == "false" ]]
+[[ "${LAST_ERROR}" == "Dataplane rules are not fully synced" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_guard_is_released_only_after_staged_and_active_verification():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+VERIFY_COUNT=0
+RELEASE_COUNT=0
+CLEANUP_COUNT=0
+
+ensure_source_blackhole_rule() { :; }
+detect_lightning_container() { DOCKER_TARGET_IP="10.21.21.9"; TARGET_CONTAINER_NAME="lnd"; return 0; }
+ensure_docker_network() { return 0; }
+ensure_container_attached() { return 0; }
+resolve_bridge_name() { return 0; }
+ensure_wg_up() { return 0; }
+wireguard_handshake_is_fresh() { return 0; }
+ensure_policy_routing() { POLICY_CHANGED=1; return 0; }
+ensure_nat_forward_rules() { NAT_CHANGED=1; return 0; }
+rules_are_synced() { VERIFY_COUNT=$((VERIFY_COUNT + 1)); return 0; }
+remove_reconcile_kill_switch() { RELEASE_COUNT=$((RELEASE_COUNT + 1)); return 0; }
+cleanup_dataplane() { CLEANUP_COUNT=$((CLEANUP_COUNT + 1)); }
+write_state() { :; }
+
+reconcile_once "test"
+[[ "${VERIFY_COUNT}" == "2" ]]
+[[ "${RELEASE_COUNT}" == "1" ]]
+[[ "${CLEANUP_COUNT}" == "0" ]]
+[[ "${RULES_SYNCED}" == "true" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_wireguard_handshake_freshness_rejects_missing_and_stale_values():
+    result = run_bash(
+        r'''
+source "$1"
+
+HANDSHAKE=0
+wg() { printf 'peer-key\t%s\n' "${HANDSHAKE}"; }
+date() { printf '%s\n' 1000; }
+
+if wireguard_handshake_is_fresh; then exit 1; fi
+[[ "${LAST_ERROR}" == *"no completed handshake"* ]]
+HANDSHAKE=819
+if wireguard_handshake_is_fresh; then exit 1; fi
+[[ "${LAST_ERROR}" == *"handshake is stale"* ]]
+HANDSHAKE=820
+wireguard_handshake_is_fresh
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_fail_closed_policy_prerequisites_require_both_blackholes_and_wg_default():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="true"
+DOCKER_TARGET_IP="10.21.21.9"
+RULES=$'32765:\tfrom 10.21.21.9 blackhole\n'
+ROUTES=$'default dev tunnelsatsv2 metric 2\nblackhole default metric 3\n'
+
+ip() {
+    if [[ "$*" == "rule show pref 32765" ]]; then printf '%s' "${RULES}"; return 0; fi
+    if [[ "$*" == "route show table 51820" ]]; then printf '%s' "${ROUTES}"; return 0; fi
+    return 1
+}
+
+fail_closed_policy_prerequisites_are_synced
+RULES=""
+if fail_closed_policy_prerequisites_are_synced; then exit 1; fi
+RULES=$'32765:\tfrom 10.21.21.9 blackhole\n'
+ROUTES=$'default dev tunnelsatsv2 metric 2\n'
+if fail_closed_policy_prerequisites_are_synced; then exit 1; fi
+ROUTES=$'blackhole default metric 3\n'
+if fail_closed_policy_prerequisites_are_synced; then exit 1; fi
 '''
     )
 

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -313,6 +313,33 @@ wireguard_handshake_is_fresh
     assert result.returncode == 0, result.stderr
 
 
+def test_runtime_wireguard_config_adds_keepalive_for_legacy_peer_idempotently():
+    result = run_bash(
+        r'''
+source "$1"
+
+CONFIG_FILE="${POLICY_TEST_STATE_FILE}.conf"
+cat > "${CONFIG_FILE}" <<'EOF_CONFIG'
+[Interface]
+PrivateKey = client-key
+
+[Peer]
+PublicKey = server-key
+AllowedIPs = 0.0.0.0/0
+Endpoint = vpn.example.test:51820
+EOF_CONFIG
+
+ensure_runtime_wireguard_keepalive "${CONFIG_FILE}"
+[[ "$(grep -c '^PersistentKeepalive = 25$' "${CONFIG_FILE}")" == "1" ]]
+
+ensure_runtime_wireguard_keepalive "${CONFIG_FILE}"
+[[ "$(grep -c '^PersistentKeepalive = 25$' "${CONFIG_FILE}")" == "1" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_fail_closed_policy_prerequisites_require_both_blackholes_and_wg_default():
     result = run_bash(
         r'''


### PR DESCRIPTION
## Summary

- install a high-priority source blackhole before dashboard startup and target discovery in Docker and Secure Mode
- stage WireGuard, policy routing, NAT, and forwarding while guarded; release only after a fresh handshake and complete verification
- reassert isolation before cleanup on every failure and preserve it across internal restarts
- require source and policy-table blackhole fallbacks before publishing rules_synced=true

## TDD coverage

- cold-start guards for Docker subnet and both Secure Mode target addresses
- failed target discovery
- missing/broken configuration and container/network preparation failures
- failed WireGuard setup and stale or absent handshake
- partial policy-routing/NAT setup and failed final verification
- guard release only after staged and active verification

## Validation

- .venv-tests/bin/pytest -q server/tests/ (167 passed)
- npm test -- --runInBand in web/ (56 passed)
- bash scripts/test.sh entrypoint (9 cases passed)
- bash -n scripts/entrypoint.sh
- shellcheck -e SC2010,SC2086,SC2001,SC2034 scripts/entrypoint.sh
- git diff --check

Scope note: k3s full-outbound routing and pod-CIDR quarantine are handled separately by PR #119, avoiding conflicting implementations.

Fixes #115