### PR TITLE
fix(dataplane): fail closed on IPv6 egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ tunnel route is unavailable.
 
 Because Umbrel is immutable, host-level WireGuard services and persistent host networking rules are not reliable across upgrades/reboots. This app keeps the full dataplane inside the app container and reconciles drift continuously.
 
+### IPv6 policy: fail-closed denial
+
+TunnelSats VPN servers currently provide IPv4 transit only. TunnelSats therefore
+does **not** route IPv6 over WireGuard: it discovers non-link-local IPv6 addresses
+on the selected Lightning workload and blocks their egress with both IPv6 policy
+blackholes and tagged `ip6tables` rules. Loopback remains internal to the
+workload and link-local traffic remains available for neighbor discovery; global
+and unique-local IPv6 egress is denied.
+
+The local status API reports `ipv4_rules_synced` and `ipv6_rules_synced`
+independently, with `rules_synced` remaining the aggregate compatibility field.
+`ipv6_policy` is `deny`; `target_ipv6_addresses` and
+`target_ipv6_default_route` expose the detected IPv6 context. TunnelSats never
+reports aggregate protection when IPv6 is present but containment cannot be
+installed and verified.
+
 ### Secure Mode dataplane
 1. The container runs with `network_mode: "host"` and `NET_ADMIN` to manage WireGuard, routing, and firewall state.
 2. Runtime detects active Lightning nodes through TCP probes on Umbrel's default service IPs and read-only config path checks.
@@ -155,7 +171,8 @@ Target: us3.tunnelsats.com (178.156.167.202) : 12345
 ----------------------------------------------------------------
 ```
 - Check `GET /api/local/status` first to view the current `dataplane_mode` and `wg_status`.
-- If `rules_synced` is `false`, inspect `last_error` in the JSON response.
+- If `rules_synced` is `false`, inspect `ipv4_rules_synced`,
+  `ipv6_rules_synced`, and `last_error` in the JSON response.
 - **Trigger immediate Dataplane repair:**
   ```bash
   curl -X POST http://127.0.0.1:9739/api/local/reconcile

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,69 @@
+# Issue #127 implementation plan: fail-closed IPv6 denial
+
+## Decision
+
+Implement Option B from issue #127. The deployed TunnelSats WireGuard fleet
+assigns only IPv4 client addresses and provides only IPv4 transit, so advertising
+IPv6 tunnel support would require new customer configurations and a coordinated
+backend/server rollout. Until that exists, the selected Lightning workload must
+not have non-local IPv6 egress.
+
+## Security invariants
+
+- Keep the existing IPv4 policy-routing and WireGuard behavior unchanged.
+- Treat IPv6 as a separately verified dataplane family with policy `deny`.
+- Discover every non-link-local IPv6 address assigned to the selected Docker
+  container or Kubernetes pod before reporting protection.
+- Install two independent IPv6 controls for each discovered source: a policy
+  rule into a table whose default is blackholed, followed by a source blackhole
+  fallback, and a tagged `ip6tables` FORWARD drop for non-local egress.
+- Preserve IPv6 loopback inside the workload and link-local traffic required for
+  neighbor discovery; do not add any global/ULA bypass.
+- Never set aggregate `rules_synced` to true unless both IPv4 routing and IPv6
+  containment verify successfully. A global/ULA target address whose rules
+  cannot be installed or verified remains unprotected and reports an error.
+
+## Implementation
+
+1. Extend target discovery in `scripts/entrypoint.sh`.
+   - Parse IPv6 endpoint addresses and IPv6 gateways from Docker inspect data.
+   - Parse the complete Kubernetes `status.podIPs` array while retaining the
+     IPv4 pod IP for the existing dataplane.
+   - Normalize and deduplicate non-loopback, non-link-local IPv6 addresses.
+2. Add an idempotent IPv6 containment reconciler.
+   - Seed a dedicated IPv6 policy table with a blackhole default.
+   - Install per-source lookup and fallback-blackhole rules before the packet
+     filter is considered ready.
+   - Maintain a tagged `ip6tables` chain that returns link-local/ND traffic and
+     drops all other forwarded IPv6 from current target addresses.
+   - Remove stale rules only when they are provably owned by TunnelSats.
+3. Split validation and status by address family.
+   - Preserve `rules_synced` as the aggregate compatibility field.
+   - Add `ipv4_rules_synced`, `ipv6_rules_synced`, `ipv6_policy`,
+     `target_ipv6_addresses`, and `target_ipv6_default_route` to state and the
+     local status API.
+   - Require aggregate `rules_synced: true` before the dashboard renders the
+     workload as Protected, even when no detailed error string is available.
+   - Reconciliation evaluates both validators independently so diagnostics do
+     not hide the state of one family behind a failure in the other.
+4. Keep cleanup fail-closed during ordinary reconciliation failures and remove
+   owned IPv6 state only during a full shutdown cleanup.
+5. Add tests.
+   - Unit-test Docker and k3s IPv6 discovery, idempotent containment, stale rule
+     cleanup, independent status fields, and verification failure behavior.
+   - Extend the root-only namespace integration test with a dual-stack pod and
+     clear-net observer. Prove IPv4 traverses the VPN observer, IPv6 is denied,
+     and removing a containment route cannot fall through to the ordinary IPv6
+     default route.
+   - Run shell syntax checks, backend tests, frontend tests, and the available
+     root-only integration tests.
+6. Document the explicit IPv6 product policy in `README.md` and `k3s/README.md`.
+
+## Review gates
+
+1. Local review/fix cycle: inspect the complete branch diff for security,
+   ownership, cleanup, race, compatibility, and test gaps; fix every finding and
+   rerun the relevant checks until clean.
+2. Greptile review/fix cycle: push the branch, open a pull request, request a
+   Greptile review, resolve every actionable finding, and repeat review/checks
+   until Greptile has no findings left.

--- a/k3s/README.md
+++ b/k3s/README.md
@@ -180,6 +180,14 @@ new connections initiated by LND or CLN. If WireGuard routing becomes
 unavailable, a source-specific blackhole prevents the traffic from falling
 through to the node's ordinary default route.
 
+IPv6 is intentionally deny-only because the TunnelSats server fleet does not
+currently assign client IPv6 addresses or provide IPv6 transit. On a dual-stack
+pod, the reconciler reads every address in Kubernetes `status.podIPs`, installs
+per-source IPv6 policy and fallback blackholes, and adds a tagged `ip6tables`
+drop for non-link-local egress. IPv6 cluster/ULA ranges are not bypassed by
+`K3S_BYPASS_CIDRS`; that setting remains IPv4-only. A missing IPv6 control sets
+`ipv6_rules_synced: false` and prevents aggregate `rules_synced` protection.
+
 Cluster-internal destinations must be listed explicitly in
 `K3S_BYPASS_CIDRS`. The shipped Deployment uses the standard k3s ranges:
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -17,6 +17,12 @@ DOCKER_TARGET_IP="10.9.9.9"
 DOCKER_MIN_GW_PRIORITY=100
 DOCKER_ROUTE_PROBE_DESTINATIONS=("1.1.1.1" "8.8.8.8")
 DOCKER_POLICY_STATE_FILE="${DOCKER_POLICY_STATE_FILE:-/data/tunnelsats-docker-policy-sources.json}"
+IPV6_POLICY_STATE_FILE="${IPV6_POLICY_STATE_FILE:-/data/tunnelsats-ipv6-policy-sources.json}"
+IPV6_POLICY_TABLE="${IPV6_POLICY_TABLE:-51821}"
+IPV6_TUNNEL_RULE_PREF="${IPV6_TUNNEL_RULE_PREF:-32764}"
+IPV6_BLACKHOLE_RULE_PREF="${IPV6_BLACKHOLE_RULE_PREF:-32765}"
+IPV6_BLACKHOLE_METRIC="${IPV6_BLACKHOLE_METRIC:-42760}"
+IPV6_RULE_MARKER="tunnelsats-ipv6-deny"
 LN_TARGET_PORT="9735" # Default to LND, will be updated in detect_lightning_container
 RECONCILE_INTERVAL=30
 KILL_SWITCH_PREF=32762
@@ -190,6 +196,12 @@ TARGET_CONTAINER_NAME=""
 TARGET_IMPL=""
 TARGET_IPV4_ENDPOINTS=()
 MANAGED_DOCKER_IPV4_ENDPOINTS=()
+TARGET_IPV6_ADDRESSES=()
+TARGET_IPV6_MACS=()
+MANAGED_TARGET_IPV6_ADDRESSES=()
+IPV6_POLICY_STATE_LOADED="false"
+IPV6_POLICY_TABLE_MANAGED="false"
+TARGET_HAS_IPV6_DEFAULT_ROUTE="false"
 DOCKER_GW_PRIORITY_SUPPORTED="unknown"
 DOCKER_POLICY_STATE_LOADED="false"
 FORWARDING_PORT=""
@@ -198,6 +210,8 @@ K3S_TARGET_POD_NAME=""
 K3S_TARGET_POD_NAMESPACE=""
 K3S_TARGET_POD_SELECTOR=""
 RULES_SYNCED="false"
+IPV4_RULES_SYNCED="false"
+IPV6_RULES_SYNCED="false"
 LAST_ERROR=""
 POLICY_CHANGED="0"
 NAT_CHANGED="0"
@@ -241,6 +255,13 @@ write_state() {
         dataplane_mode="docker-full-parity"
     fi
 
+    local target_ipv6_addresses_json
+    target_ipv6_addresses_json=$(printf '%s\n' "${TARGET_IPV6_ADDRESSES[@]}" \
+        | jq -Rsc 'split("\n") | map(select(length > 0))') || {
+        rm -f "${tmp}"
+        return 1
+    }
+
     if jq -n \
         --arg dataplane_mode "${dataplane_mode}" \
         --arg target_container "${TARGET_CONTAINER_NAME:-}" \
@@ -248,6 +269,11 @@ write_state() {
         --arg target_impl "${TARGET_IMPL:-}" \
         --arg forwarding_port "${FORWARDING_PORT:-}" \
         --argjson rules_synced "${RULES_SYNCED}" \
+        --argjson ipv4_rules_synced "${IPV4_RULES_SYNCED}" \
+        --argjson ipv6_rules_synced "${IPV6_RULES_SYNCED}" \
+        --arg ipv6_policy "deny" \
+        --argjson target_ipv6_addresses "${target_ipv6_addresses_json}" \
+        --argjson target_ipv6_default_route "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" \
         --arg last_error "${LAST_ERROR:-}" \
         --arg docker_network_name "${DOCKER_NETWORK_NAME}" \
         --arg docker_network_subnet "${DOCKER_NETWORK_SUBNET}" \
@@ -261,6 +287,11 @@ write_state() {
             target_impl: $target_impl,
             forwarding_port: $forwarding_port,
             rules_synced: $rules_synced,
+            ipv4_rules_synced: $ipv4_rules_synced,
+            ipv6_rules_synced: $ipv6_rules_synced,
+            ipv6_policy: $ipv6_policy,
+            target_ipv6_addresses: $target_ipv6_addresses,
+            target_ipv6_default_route: $target_ipv6_default_route,
             k3s_bypass_cidrs: (
                 if $k3s_bypass_cidrs == ""
                 then []
@@ -465,6 +496,136 @@ persist_managed_docker_policy_state() {
     fi
 }
 
+load_managed_ipv6_policy_state() {
+    [ "${IPV6_POLICY_STATE_LOADED}" = "false" ] || return 0
+
+    local current_boot state saved_boot parsed address
+    current_boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null) || {
+        LAST_ERROR="Unable to identify the current boot for IPv6 policy ownership"
+        return 1
+    }
+    [ -n "${current_boot}" ] || {
+        LAST_ERROR="Current boot ID is empty; refusing to load IPv6 policy ownership"
+        return 1
+    }
+    if [ ! -e "${IPV6_POLICY_STATE_FILE}" ]; then
+        IPV6_POLICY_STATE_LOADED="true"
+        return 0
+    fi
+
+    state=$(cat "${IPV6_POLICY_STATE_FILE}" 2>/dev/null) || {
+        LAST_ERROR="Failed to read IPv6 policy ownership state"
+        return 1
+    }
+    if ! printf '%s' "${state}" | jq -e '
+        .version == 1 and
+        (.boot_id | type == "string") and
+        (.table_managed | type == "boolean") and
+        (.addresses | type == "array") and
+        all(.addresses[]; type == "string")
+    ' >/dev/null 2>&1; then
+        LAST_ERROR="IPv6 policy ownership state is malformed"
+        return 1
+    fi
+    saved_boot=$(printf '%s' "${state}" | jq -r '.boot_id')
+    if [ "${saved_boot}" != "${current_boot}" ]; then
+        MANAGED_TARGET_IPV6_ADDRESSES=()
+        IPV6_POLICY_TABLE_MANAGED="false"
+        IPV6_POLICY_STATE_LOADED="true"
+        return 0
+    fi
+    IPV6_POLICY_TABLE_MANAGED=$(printf '%s' "${state}" | jq -r '.table_managed')
+    if ! parsed=$(printf '%s' "${state}" | jq -r '.addresses[]' | python3 -c '
+import ipaddress
+import sys
+
+for raw in sys.stdin:
+    address = ipaddress.IPv6Address(raw.strip())
+    if address.is_unspecified or address.is_loopback or address.is_link_local or address.is_multicast:
+        raise SystemExit("non-routable address in state")
+    print(address)
+'); then
+        LAST_ERROR="IPv6 policy ownership addresses are malformed"
+        return 1
+    fi
+
+    MANAGED_TARGET_IPV6_ADDRESSES=()
+    while IFS= read -r address; do
+        [ -n "${address}" ] || continue
+        MANAGED_TARGET_IPV6_ADDRESSES+=("${address}")
+    done <<< "${parsed}"
+    IPV6_POLICY_STATE_LOADED="true"
+}
+
+persist_managed_ipv6_policy_state() {
+    local current_boot state_dir state_tmp addresses_json
+    current_boot=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null) || {
+        LAST_ERROR="Unable to identify the current boot for IPv6 policy ownership"
+        return 1
+    }
+    [ -n "${current_boot}" ] || {
+        LAST_ERROR="Current boot ID is empty; refusing to persist IPv6 policy ownership"
+        return 1
+    }
+    state_dir="${IPV6_POLICY_STATE_FILE%/*}"
+    [ "${state_dir}" != "${IPV6_POLICY_STATE_FILE}" ] || state_dir="."
+    mkdir -p "${state_dir}" || {
+        LAST_ERROR="Failed to create IPv6 policy ownership directory"
+        return 1
+    }
+    state_tmp=$(mktemp "${IPV6_POLICY_STATE_FILE}.tmp.XXXXXX") || {
+        LAST_ERROR="Failed to create temporary IPv6 policy ownership state"
+        return 1
+    }
+    addresses_json=$(printf '%s\n' "${MANAGED_TARGET_IPV6_ADDRESSES[@]}" \
+        | jq -Rsc 'split("\n") | map(select(length > 0))') || {
+        rm -f "${state_tmp}"
+        LAST_ERROR="Failed to encode IPv6 policy ownership addresses"
+        return 1
+    }
+    if ! jq -n \
+        --arg boot_id "${current_boot}" \
+        --argjson table_managed "${IPV6_POLICY_TABLE_MANAGED}" \
+        --argjson addresses "${addresses_json}" \
+        '{version:1, boot_id:$boot_id, table_managed:$table_managed, addresses:$addresses}' > "${state_tmp}" || \
+       ! chmod 600 "${state_tmp}" || \
+       ! mv -f "${state_tmp}" "${IPV6_POLICY_STATE_FILE}"; then
+        rm -f "${state_tmp}"
+        LAST_ERROR="Failed to persist IPv6 policy ownership state"
+        return 1
+    fi
+}
+
+normalize_target_ipv6_addresses() {
+    local normalized address
+    if ! normalized=$(printf '%s\n' "${TARGET_IPV6_ADDRESSES[@]}" | python3 -c '
+import ipaddress
+import sys
+
+addresses = set()
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    address = ipaddress.ip_address(raw.split("%", 1)[0])
+    if address.version != 6:
+        raise SystemExit(f"{raw!r} is not an IPv6 address")
+    if address.is_unspecified or address.is_loopback or address.is_link_local or address.is_multicast:
+        continue
+    addresses.add(address)
+for address in sorted(addresses, key=int):
+    print(address)
+'); then
+        LAST_ERROR="Failed to normalize target IPv6 addresses: ${normalized//$'\n'/ }"
+        return 1
+    fi
+    TARGET_IPV6_ADDRESSES=()
+    while IFS= read -r address; do
+        [ -n "${address}" ] || continue
+        TARGET_IPV6_ADDRESSES+=("${address}")
+    done <<< "${normalized}"
+}
+
 refresh_docker_target_endpoints() {
     [[ "${K3S_MODE}" == "true" ]] && return 0
     [[ "${SECURE_MODE}" == "true" ]] && return 0
@@ -478,7 +639,11 @@ refresh_docker_target_endpoints() {
 
     local inspect
     local parsed
+    local ipv6_parsed
     local entry
+    local address
+    local gateway
+    local mac
     local managed_entry
     local already_managed
     inspect=$(docker_api "GET" "/containers/${TARGET_CONTAINER_ID}/json") || {
@@ -524,6 +689,36 @@ if not found:
         return 1
     fi
 
+    if ! ipv6_parsed=$(printf '%s' "${inspect}" | python3 -c '
+import ipaddress
+import json
+import sys
+
+data = json.load(sys.stdin)
+networks = data.get("NetworkSettings", {}).get("Networks", {})
+if not isinstance(networks, dict):
+    raise SystemExit("NetworkSettings.Networks is unavailable")
+
+for name in sorted(networks):
+    endpoint = networks[name]
+    if not isinstance(endpoint, dict):
+        continue
+    raw_address = endpoint.get("GlobalIPv6Address") or ""
+    raw_gateway = endpoint.get("IPv6Gateway") or ""
+    mac = str(endpoint.get("MacAddress") or "").lower()
+    address = ""
+    gateway = ""
+    if raw_address:
+        address = str(ipaddress.IPv6Address(raw_address))
+    if raw_gateway:
+        gateway = str(ipaddress.IPv6Address(raw_gateway))
+    if address or gateway:
+        print(f"{address}|{gateway}|{mac}")
+'); then
+        LAST_ERROR="Failed to parse IPv6 endpoints for ${TARGET_CONTAINER_NAME:-Docker target}: ${ipv6_parsed//$'\n'/ }"
+        return 1
+    fi
+
     TARGET_IPV4_ENDPOINTS=()
     while IFS= read -r entry; do
         [ -n "${entry}" ] || continue
@@ -544,6 +739,23 @@ if not found:
         LAST_ERROR="Docker target has no assigned IPv4 endpoints"
         return 1
     }
+    TARGET_IPV6_ADDRESSES=()
+    TARGET_IPV6_MACS=()
+    TARGET_HAS_IPV6_DEFAULT_ROUTE="false"
+    while IFS='|' read -r address gateway mac; do
+        if [ -n "${address}" ]; then
+            TARGET_IPV6_ADDRESSES+=("${address}")
+        fi
+        if [ -n "${gateway}" ]; then
+            TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+        fi
+        if [ -n "${mac}" ]; then
+            TARGET_IPV6_MACS+=("${mac}")
+        fi
+    done <<< "${ipv6_parsed}"
+    if ! normalize_target_ipv6_addresses; then
+        return 1
+    fi
     persist_managed_docker_policy_state
 }
 
@@ -1046,7 +1258,7 @@ resolve_k3s_target_pod() {
     local namespace="$2"
     local selector="$3"
     local encoded_selector pod_list running_pods pod
-    local pod_name pod_ip pod_node
+    local pod_name pod_ip pod_node pod_addresses parsed_pod_addresses family address
 
     encoded_selector=$(urlencode "${selector}")
     if ! pod_list=$(k8s_api "/api/v1/namespaces/${namespace}/pods?labelSelector=${encoded_selector}"); then
@@ -1117,8 +1329,48 @@ resolve_k3s_target_pod() {
     fi
 
     pod_name=$(printf '%s' "${pod}" | jq -r '.metadata.name // empty')
-    pod_ip=$(printf '%s' "${pod}" | jq -r '.status.podIP // empty')
     pod_node=$(printf '%s' "${pod}" | jq -r '.spec.nodeName // empty')
+
+    pod_addresses=$(printf '%s' "${pod}" | jq -r '
+        [(.status.podIPs[]?.ip // empty), (.status.podIP // empty)]
+        | unique[]
+    ' 2>/dev/null || true)
+    if ! parsed_pod_addresses=$(printf '%s\n' "${pod_addresses}" | python3 -c '
+import ipaddress
+import sys
+
+seen = set()
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    address = ipaddress.ip_address(raw)
+    if address in seen:
+        continue
+    seen.add(address)
+    print(f"{address.version}|{address}")
+'); then
+        LAST_ERROR="k3s: ${impl^^} pod contains an invalid pod IP"
+        log ERROR "${LAST_ERROR}"
+        return 1
+    fi
+    pod_ip=""
+    TARGET_IPV6_ADDRESSES=()
+    TARGET_IPV6_MACS=()
+    TARGET_HAS_IPV6_DEFAULT_ROUTE="false"
+    while IFS='|' read -r family address; do
+        [ -n "${address}" ] || continue
+        if [ "${family}" = "4" ] && [ -z "${pod_ip}" ]; then
+            pod_ip="${address}"
+        elif [ "${family}" = "6" ]; then
+            TARGET_IPV6_ADDRESSES+=("${address}")
+            TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+        fi
+    done <<< "${parsed_pod_addresses}"
+    if ! normalize_target_ipv6_addresses; then
+        LAST_ERROR="k3s: ${LAST_ERROR}"
+        return 1
+    fi
 
     if [ -z "${pod_name}" ] || [ -z "${pod_ip}" ] || [ -z "${pod_node}" ]; then
         LAST_ERROR="k3s: ${impl^^} pod metadata incomplete (namespace=${namespace}, pod=${pod_name:-unknown}, pod_ip=${pod_ip:-missing}, node=${pod_node:-missing})"
@@ -1145,6 +1397,9 @@ detect_k3s_target() {
     TARGET_CONTAINER_NAME=""
     TARGET_IMPL=""
     DOCKER_TARGET_IP=""
+    TARGET_IPV6_ADDRESSES=()
+    TARGET_IPV6_MACS=()
+    TARGET_HAS_IPV6_DEFAULT_ROUTE="false"
     K3S_TARGET_POD_NAME=""
     K3S_TARGET_POD_NAMESPACE=""
     K3S_TARGET_POD_SELECTOR=""
@@ -1195,6 +1450,9 @@ detect_lightning_container() {
     TARGET_CONTAINER_ID=""
     TARGET_CONTAINER_NAME=""
     TARGET_IMPL=""
+    TARGET_IPV6_ADDRESSES=()
+    TARGET_IPV6_MACS=()
+    TARGET_HAS_IPV6_DEFAULT_ROUTE="false"
 
     if [[ "${K3S_MODE}" == "true" ]]; then
         detect_k3s_target || return 1
@@ -1234,6 +1492,7 @@ detect_lightning_container() {
             LN_TARGET_PORT="9735"
             DOCKER_TARGET_IP="10.21.21.9"
             log INFO "SecureMode: Detected LND node at ${DOCKER_TARGET_IP}"
+            discover_secure_ipv6_target || return 1
             return 0
         elif [ "${cln_ok}" -eq 1 ]; then
             TARGET_IMPL="cln"
@@ -1241,6 +1500,7 @@ detect_lightning_container() {
             LN_TARGET_PORT="9736"
             DOCKER_TARGET_IP="10.21.21.96"
             log INFO "SecureMode: Detected CLN node at ${DOCKER_TARGET_IP}"
+            discover_secure_ipv6_target || return 1
             return 0
         fi
         LAST_ERROR="SecureMode: No Lightning node detected (probed 10.21.21.9 and 10.21.21.96)"
@@ -1742,6 +2002,58 @@ release_k3s_reconcile_guards() {
         sleep "${K3S_ISOLATION_RETRY_INTERVAL}"
     done
     return 0
+}
+
+discover_secure_ipv6_target() {
+    [[ "${SECURE_MODE}" == "true" ]] || return 0
+    [ -n "${DOCKER_TARGET_IP:-}" ] || {
+        LAST_ERROR="SecureMode: Cannot inspect IPv6 without a selected target"
+        return 1
+    }
+
+    local route_info target_dev target_mac ipv6_context neighbor_line neighbor_address
+    route_info=$(ip -4 route get "${DOCKER_TARGET_IP}" 2>/dev/null || true)
+    target_dev=$(printf '%s\n' "${route_info}" | awk '
+        NR == 1 { for (i = 1; i < NF; i++) if ($i == "dev") { print $(i + 1); exit } }
+    ')
+    [ -n "${target_dev}" ] || {
+        LAST_ERROR="SecureMode: Cannot resolve target interface for IPv6 containment"
+        return 1
+    }
+
+    ipv6_context="$({
+        ip -6 -o addr show dev "${target_dev}" scope global 2>/dev/null || true
+        ip -6 route show default dev "${target_dev}" 2>/dev/null || true
+    } | sed '/^[[:space:]]*$/d')"
+    if [ -z "${ipv6_context}" ]; then
+        return 0
+    fi
+    if printf '%s\n' "${route_info}" | grep -qE '(^|[[:space:]])via([[:space:]]|$)'; then
+        LAST_ERROR="SecureMode: IPv6-capable target is routed through a gateway and cannot be isolated by MAC"
+        return 1
+    fi
+
+    # Secure Mode deliberately has no Docker socket. Match the selected
+    # container by the link-layer identity learned for its fixed IPv4 address;
+    # this blocks even temporary/privacy IPv6 addresses that are not yet in the
+    # neighbor cache.
+    target_mac=$(ip neigh show to "${DOCKER_TARGET_IP}" dev "${target_dev}" 2>/dev/null \
+        | awk '{for (i = 1; i < NF; i++) if ($i == "lladdr") {print tolower($(i + 1)); exit}}')
+    if [[ ! "${target_mac}" =~ ^([0-9a-f]{2}:){5}[0-9a-f]{2}$ ]]; then
+        LAST_ERROR="SecureMode: IPv6-capable target network detected but target MAC is unavailable"
+        return 1
+    fi
+
+    TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+    TARGET_IPV6_MACS=("${target_mac}")
+    while IFS= read -r neighbor_line; do
+        [ -n "${neighbor_line}" ] || continue
+        [[ "${neighbor_line,,}" == *"lladdr ${target_mac}"* ]] || continue
+        neighbor_address="${neighbor_line%% *}"
+        [[ "${neighbor_address}" == *:* ]] || continue
+        TARGET_IPV6_ADDRESSES+=("${neighbor_address%%\%*}")
+    done < <(ip -6 neigh show dev "${target_dev}" 2>/dev/null || true)
+    normalize_target_ipv6_addresses
 }
 
 get_target_subnet() {
@@ -2401,6 +2713,353 @@ remove_stale_docker_source_policy_rules() {
     fi
 }
 
+ipv6_rules_for_source_pref() {
+    local source="$1"
+    local preference="$2"
+    ip -6 rule show pref "${preference}" 2>/dev/null | awk -v source="${source}" '
+        {
+            for (i = 1; i < NF; i++) {
+                if ($i == "from" && ($(i + 1) == source || $(i + 1) == source "/128")) {
+                    print
+                    break
+                }
+            }
+        }
+    '
+}
+
+ipv6_address_is_managed() {
+    local source="$1"
+    local managed_source
+    for managed_source in "${MANAGED_TARGET_IPV6_ADDRESSES[@]}"; do
+        [ "${managed_source}" = "${source}" ] && return 0
+    done
+    return 1
+}
+
+ensure_ipv6_source_blackhole_rule() {
+    local source="$1"
+    local rules rule_count exact_pattern
+    exact_pattern="^${IPV6_BLACKHOLE_RULE_PREF}:[[:space:]]+from[[:space:]]+${source}(/128)?[[:space:]]+blackhole[[:space:]]*$"
+    rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_BLACKHOLE_RULE_PREF}" || true)
+    rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+    if [ "${rule_count}" -gt 0 ] && ! ipv6_address_is_managed "${source}"; then
+        LAST_ERROR="IPv6 blackhole preference is occupied by an unowned rule for ${source}"
+        return 1
+    fi
+    if [ "${rule_count}" -eq 1 ] && printf '%s\n' "${rules}" | grep -qE "${exact_pattern}"; then
+        return 0
+    fi
+    if ipv6_address_is_managed "${source}"; then
+        for _delete_attempt in 1 2 3 4; do
+            ip -6 rule del from "${source}" blackhole pref "${IPV6_BLACKHOLE_RULE_PREF}" >/dev/null 2>&1 || break
+        done
+    fi
+    if [ -n "$(ipv6_rules_for_source_pref "${source}" "${IPV6_BLACKHOLE_RULE_PREF}" || true)" ]; then
+        LAST_ERROR="Failed to clear conflicting IPv6 blackhole rules for ${source}"
+        return 1
+    fi
+    if ! ip -6 rule add from "${source}" blackhole pref "${IPV6_BLACKHOLE_RULE_PREF}" >/dev/null 2>&1; then
+        LAST_ERROR="Failed to install IPv6 fallback blackhole for ${source}"
+        return 1
+    fi
+    rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_BLACKHOLE_RULE_PREF}" || true)
+    rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+    if [ "${rule_count}" -ne 1 ] || ! printf '%s\n' "${rules}" | grep -qE "${exact_pattern}"; then
+        LAST_ERROR="IPv6 fallback blackhole verification failed for ${source}"
+        return 1
+    fi
+}
+
+ensure_ipv6_policy_table() {
+    local routes expected_count unexpected_count
+    routes=$(ip -6 route show table "${IPV6_POLICY_TABLE}" 2>/dev/null || true)
+    expected_count=$(printf '%s\n' "${routes}" | grep -cE \
+        "^blackhole[[:space:]]+default([[:space:]].*)metric[[:space:]]+${IPV6_BLACKHOLE_METRIC}([[:space:]]|$)" || true)
+    unexpected_count=$(printf '%s\n' "${routes}" | grep -cvE \
+        "^$|^blackhole[[:space:]]+default([[:space:]].*)metric[[:space:]]+${IPV6_BLACKHOLE_METRIC}([[:space:]]|$)" || true)
+    if [ "${unexpected_count}" -ne 0 ] || [ "${expected_count}" -gt 1 ]; then
+        LAST_ERROR="IPv6 policy table ${IPV6_POLICY_TABLE} contains unowned routes"
+        return 1
+    fi
+    if [ "${expected_count}" -eq 1 ] && [ "${IPV6_POLICY_TABLE_MANAGED}" != "true" ]; then
+        LAST_ERROR="IPv6 policy table ${IPV6_POLICY_TABLE} contains an unowned blackhole"
+        return 1
+    fi
+    if [ "${expected_count}" -eq 0 ]; then
+        if ! ip -6 route replace blackhole default metric "${IPV6_BLACKHOLE_METRIC}" table "${IPV6_POLICY_TABLE}" >/dev/null 2>&1; then
+            LAST_ERROR="Failed to install IPv6 policy-table blackhole"
+            return 1
+        fi
+        IPV6_POLICY_TABLE_MANAGED="true"
+        if ! persist_managed_ipv6_policy_state; then
+            ip -6 route del blackhole default metric "${IPV6_BLACKHOLE_METRIC}" table "${IPV6_POLICY_TABLE}" >/dev/null 2>&1 || true
+            IPV6_POLICY_TABLE_MANAGED="false"
+            return 1
+        fi
+    fi
+    routes=$(ip -6 route show table "${IPV6_POLICY_TABLE}" 2>/dev/null || true)
+    if [ "$(printf '%s\n' "${routes}" | sed '/^$/d' | wc -l)" -ne 1 ] || \
+       ! printf '%s\n' "${routes}" | grep -qE \
+        "^blackhole[[:space:]]+default([[:space:]].*)metric[[:space:]]+${IPV6_BLACKHOLE_METRIC}([[:space:]]|$)"; then
+        LAST_ERROR="IPv6 policy-table blackhole verification failed"
+        return 1
+    fi
+}
+
+ensure_ipv6_source_policy_rule() {
+    local source="$1"
+    local rules rule_count exact_pattern
+    exact_pattern="^${IPV6_TUNNEL_RULE_PREF}:[[:space:]]+from[[:space:]]+${source}(/128)?[[:space:]]+(lookup|table)[[:space:]]+${IPV6_POLICY_TABLE}[[:space:]]*$"
+    rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_TUNNEL_RULE_PREF}" || true)
+    rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+    if [ "${rule_count}" -gt 0 ] && ! ipv6_address_is_managed "${source}"; then
+        LAST_ERROR="IPv6 policy preference is occupied by an unowned rule for ${source}"
+        return 1
+    fi
+    if [ "${rule_count}" -eq 1 ] && printf '%s\n' "${rules}" | grep -qE "${exact_pattern}"; then
+        return 0
+    fi
+    if ipv6_address_is_managed "${source}"; then
+        for _delete_attempt in 1 2 3 4; do
+            ip -6 rule del from "${source}" table "${IPV6_POLICY_TABLE}" pref "${IPV6_TUNNEL_RULE_PREF}" >/dev/null 2>&1 || break
+        done
+    fi
+    if [ -n "$(ipv6_rules_for_source_pref "${source}" "${IPV6_TUNNEL_RULE_PREF}" || true)" ]; then
+        LAST_ERROR="Failed to clear conflicting IPv6 policy rules for ${source}"
+        return 1
+    fi
+    if ! ip -6 rule add from "${source}" table "${IPV6_POLICY_TABLE}" pref "${IPV6_TUNNEL_RULE_PREF}" >/dev/null 2>&1; then
+        LAST_ERROR="Failed to install IPv6 policy rule for ${source}"
+        return 1
+    fi
+    rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_TUNNEL_RULE_PREF}" || true)
+    rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+    if [ "${rule_count}" -ne 1 ] || ! printf '%s\n' "${rules}" | grep -qE "${exact_pattern}"; then
+        LAST_ERROR="IPv6 policy-rule verification failed for ${source}"
+        return 1
+    fi
+}
+
+ipv6_filter_rule_is_current() {
+    local rule="$1"
+    local source mac
+    for source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+        if [[ "${rule}" == *" -s ${source}/128 "* ]] || [[ "${rule}" == *" -s ${source} "* ]]; then
+            return 0
+        fi
+    done
+    for mac in "${TARGET_IPV6_MACS[@]}"; do
+        [[ "${rule,,}" == *" --mac-source ${mac,,} "* ]] && return 0
+    done
+    return 1
+}
+
+remove_stale_ipv6_filter_rules() {
+    local rules rule
+    local -a parts
+    rules=$(ip6tables -S FORWARD 2>/dev/null | grep -F -- "--comment ${IPV6_RULE_MARKER}" || true)
+    while IFS= read -r rule; do
+        [ -n "${rule}" ] || continue
+        ipv6_filter_rule_is_current "${rule}" && continue
+        read -r -a parts <<< "${rule}"
+        parts[0]="-D"
+        ip6tables "${parts[@]}" >/dev/null 2>&1 || {
+            LAST_ERROR="Failed to remove stale owned IPv6 filter rule"
+            return 1
+        }
+    done <<< "${rules}"
+}
+
+ensure_ipv6_containment() {
+    local source mac managed_source current_source already_current was_managed
+    local filter_ok=true
+    local routing_ok=true
+    local ip6tables_available=true
+    local containment_errors=""
+    local -a next_managed=()
+    if ! load_managed_ipv6_policy_state; then
+        return 1
+    fi
+    if [ "${#TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && \
+       [ "${#TARGET_IPV6_MACS[@]}" -eq 0 ] && \
+       [ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" != "true" ] && \
+       [ "${#MANAGED_TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && \
+       [ "${IPV6_POLICY_TABLE_MANAGED}" != "true" ]; then
+        return 0
+    fi
+    if [ "${#TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && \
+       [ "${#TARGET_IPV6_MACS[@]}" -eq 0 ] && \
+       [ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" = "true" ]; then
+        LAST_ERROR="IPv6-capable target network detected without a safe workload selector"
+        return 1
+    fi
+    # Install the packet-filter control first so a later policy-routing failure
+    # cannot leave the workload on its ordinary IPv6 default route.
+    if ! command -v ip6tables >/dev/null 2>&1; then
+        filter_ok=false
+        ip6tables_available=false
+        containment_errors="ip6tables is unavailable for IPv6 fail-closed containment"
+    fi
+    for source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+        if [ "${ip6tables_available}" = true ] && ! ip6tables -C FORWARD -s "${source}" ! -d fe80::/10 \
+            -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+            if ! ip6tables -I FORWARD 1 -s "${source}" ! -d fe80::/10 \
+                -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+                filter_ok=false
+                containment_errors="${containment_errors:+${containment_errors}; }failed to install IPv6 egress filter for ${source}"
+            fi
+        fi
+    done
+    for mac in "${TARGET_IPV6_MACS[@]}"; do
+        if [ "${ip6tables_available}" = true ] && ! ip6tables -C FORWARD -m mac --mac-source "${mac}" ! -d fe80::/10 \
+            -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+            if ! ip6tables -I FORWARD 1 -m mac --mac-source "${mac}" ! -d fe80::/10 \
+                -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+                filter_ok=false
+                containment_errors="${containment_errors:+${containment_errors}; }failed to install IPv6 egress filter for target MAC ${mac}"
+            fi
+        fi
+    done
+
+    # The direct source blackhole is installed first. It remains effective if
+    # the dedicated policy table is later flushed or otherwise loses its route.
+    for source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+        was_managed=false
+        ipv6_address_is_managed "${source}" && was_managed=true
+        if ! ensure_ipv6_source_blackhole_rule "${source}"; then
+            routing_ok=false
+            containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+            continue
+        fi
+        if [ "${was_managed}" = false ]; then
+            MANAGED_TARGET_IPV6_ADDRESSES+=("${source}")
+            if ! persist_managed_ipv6_policy_state; then
+                ip -6 rule del from "${source}" blackhole pref "${IPV6_BLACKHOLE_RULE_PREF}" >/dev/null 2>&1 || true
+                MANAGED_TARGET_IPV6_ADDRESSES=("${MANAGED_TARGET_IPV6_ADDRESSES[@]:0:${#MANAGED_TARGET_IPV6_ADDRESSES[@]}-1}")
+                routing_ok=false
+                containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+            fi
+        fi
+    done
+    if ! ensure_ipv6_policy_table; then
+        routing_ok=false
+        containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+    fi
+    if [ "${IPV6_POLICY_TABLE_MANAGED}" = true ]; then
+        for source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+            ipv6_address_is_managed "${source}" || continue
+            if ! ensure_ipv6_source_policy_rule "${source}"; then
+                routing_ok=false
+                containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+            fi
+        done
+    fi
+    if [ "${filter_ok}" = true ]; then
+        if ! remove_stale_ipv6_filter_rules; then
+            filter_ok=false
+            containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+        fi
+    fi
+
+    # Retire stale routing rules only after every current selector is guarded.
+    next_managed=()
+    for managed_source in "${MANAGED_TARGET_IPV6_ADDRESSES[@]}"; do
+        already_current=false
+        for current_source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+            [ "${managed_source}" = "${current_source}" ] && already_current=true
+        done
+        if [ "${already_current}" = true ]; then
+            next_managed+=("${managed_source}")
+            continue
+        fi
+        for _delete_attempt in 1 2 3 4; do
+            ip -6 rule del from "${managed_source}" table "${IPV6_POLICY_TABLE}" pref "${IPV6_TUNNEL_RULE_PREF}" >/dev/null 2>&1 || break
+        done
+        for _delete_attempt in 1 2 3 4; do
+            ip -6 rule del from "${managed_source}" blackhole pref "${IPV6_BLACKHOLE_RULE_PREF}" >/dev/null 2>&1 || break
+        done
+    done
+    MANAGED_TARGET_IPV6_ADDRESSES=("${next_managed[@]}")
+    if [ "${#TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && \
+       [ "${#TARGET_IPV6_MACS[@]}" -eq 0 ] && \
+       [ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" != "true" ] && \
+       [ "${IPV6_POLICY_TABLE_MANAGED}" = "true" ]; then
+        ip -6 route del blackhole default metric "${IPV6_BLACKHOLE_METRIC}" table "${IPV6_POLICY_TABLE}" >/dev/null 2>&1 || true
+        if ip -6 route show table "${IPV6_POLICY_TABLE}" 2>/dev/null | grep -qE \
+            "^blackhole[[:space:]]+default([[:space:]].*)metric[[:space:]]+${IPV6_BLACKHOLE_METRIC}([[:space:]]|$)"; then
+            routing_ok=false
+            containment_errors="${containment_errors:+${containment_errors}; }failed to retire the owned IPv6 policy table"
+        else
+            IPV6_POLICY_TABLE_MANAGED="false"
+        fi
+    fi
+    if ! persist_managed_ipv6_policy_state; then
+        routing_ok=false
+        containment_errors="${containment_errors:+${containment_errors}; }${LAST_ERROR}"
+    fi
+    if [ "${filter_ok}" != true ] || [ "${routing_ok}" != true ]; then
+        LAST_ERROR="${containment_errors:-IPv6 containment reconciliation failed}"
+        return 1
+    fi
+}
+
+ipv6_containment_is_synced() {
+    local source mac rules rule_count routes exact_blackhole_pattern exact_policy_pattern
+    if [ "${#TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && \
+       [ "${#TARGET_IPV6_MACS[@]}" -eq 0 ] && \
+       [ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" != "true" ]; then
+        return 0
+    fi
+    if [ "${#TARGET_IPV6_ADDRESSES[@]}" -eq 0 ] && [ "${#TARGET_IPV6_MACS[@]}" -eq 0 ]; then
+        log WARN "ipv6_rules_are_synced: IPv6-capable target has no safe selector"
+        return 1
+    fi
+    if [ "${IPV6_POLICY_TABLE_MANAGED}" != "true" ]; then
+        log WARN "ipv6_rules_are_synced: policy table is not owned"
+        return 1
+    fi
+    routes=$(ip -6 route show table "${IPV6_POLICY_TABLE}" 2>/dev/null || true)
+    if [ "$(printf '%s\n' "${routes}" | sed '/^$/d' | wc -l)" -ne 1 ] || \
+       ! printf '%s\n' "${routes}" | grep -qE \
+        "^blackhole[[:space:]]+default([[:space:]].*)metric[[:space:]]+${IPV6_BLACKHOLE_METRIC}([[:space:]]|$)"; then
+        log WARN "ipv6_rules_are_synced: policy-table blackhole FAIL"
+        return 1
+    fi
+    for source in "${TARGET_IPV6_ADDRESSES[@]}"; do
+        if ! ipv6_address_is_managed "${source}"; then
+            log WARN "ipv6_rules_are_synced: source ${source} is not owned"
+            return 1
+        fi
+        exact_blackhole_pattern="^${IPV6_BLACKHOLE_RULE_PREF}:[[:space:]]+from[[:space:]]+${source}(/128)?[[:space:]]+blackhole[[:space:]]*$"
+        exact_policy_pattern="^${IPV6_TUNNEL_RULE_PREF}:[[:space:]]+from[[:space:]]+${source}(/128)?[[:space:]]+(lookup|table)[[:space:]]+${IPV6_POLICY_TABLE}[[:space:]]*$"
+        rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_BLACKHOLE_RULE_PREF}" || true)
+        rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+        if [ "${rule_count}" -ne 1 ] || ! printf '%s\n' "${rules}" | grep -qE "${exact_blackhole_pattern}"; then
+            log WARN "ipv6_rules_are_synced: source blackhole for ${source} FAIL"
+            return 1
+        fi
+        rules=$(ipv6_rules_for_source_pref "${source}" "${IPV6_TUNNEL_RULE_PREF}" || true)
+        rule_count=$(printf '%s\n' "${rules}" | sed '/^$/d' | wc -l)
+        if [ "${rule_count}" -ne 1 ] || ! printf '%s\n' "${rules}" | grep -qE "${exact_policy_pattern}"; then
+            log WARN "ipv6_rules_are_synced: source policy for ${source} FAIL"
+            return 1
+        fi
+        if ! ip6tables -C FORWARD -s "${source}" ! -d fe80::/10 \
+            -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+            log WARN "ipv6_rules_are_synced: filter for ${source} FAIL"
+            return 1
+        fi
+    done
+    for mac in "${TARGET_IPV6_MACS[@]}"; do
+        if ! ip6tables -C FORWARD -m mac --mac-source "${mac}" ! -d fe80::/10 \
+            -m comment --comment "${IPV6_RULE_MARKER}" -j DROP >/dev/null 2>&1; then
+            log WARN "ipv6_rules_are_synced: filter for target MAC ${mac} FAIL"
+            return 1
+        fi
+    done
+}
+
 ensure_policy_routing() {
     local changed=0
     local installed_rule
@@ -2832,7 +3491,7 @@ fail_closed_policy_prerequisites_are_synced() {
     fi
 }
 
-rules_are_synced() {
+ipv4_rules_are_synced() {
     if ! fail_closed_policy_prerequisites_are_synced; then
         return 1
     fi
@@ -3061,6 +3720,22 @@ rules_are_synced() {
     return 0
 }
 
+rules_are_synced() {
+    local ipv4_ok=true
+    local ipv6_ok=true
+
+    if ! ipv4_rules_are_synced; then
+        ipv4_ok=false
+    fi
+    if ! ipv6_containment_is_synced; then
+        ipv6_ok=false
+    fi
+
+    IPV4_RULES_SYNCED="${ipv4_ok}"
+    IPV6_RULES_SYNCED="${ipv6_ok}"
+    [ "${ipv4_ok}" = true ] && [ "${ipv6_ok}" = true ]
+}
+
 cleanup_k3s_policy_rules() {
     local keep_blackholes="$1"
     local pref
@@ -3101,6 +3776,34 @@ cleanup_k3s_policy_rules() {
             delete_policy_rule_line "${rule_line}"
         done < <(ip rule show pref "${pref}" 2>/dev/null || true)
     done
+}
+
+cleanup_ipv6_containment() {
+    local rules rule managed_source
+    local -a parts
+
+    rules=$(ip6tables -S FORWARD 2>/dev/null | grep -F -- "--comment ${IPV6_RULE_MARKER}" || true)
+    while IFS= read -r rule; do
+        [ -n "${rule}" ] || continue
+        read -r -a parts <<< "${rule}"
+        parts[0]="-D"
+        ip6tables "${parts[@]}" >/dev/null 2>&1 || true
+    done <<< "${rules}"
+
+    if load_managed_ipv6_policy_state; then
+        for managed_source in "${MANAGED_TARGET_IPV6_ADDRESSES[@]}"; do
+            ip -6 rule del from "${managed_source}" table "${IPV6_POLICY_TABLE}" pref "${IPV6_TUNNEL_RULE_PREF}" >/dev/null 2>&1 || true
+            ip -6 rule del from "${managed_source}" blackhole pref "${IPV6_BLACKHOLE_RULE_PREF}" >/dev/null 2>&1 || true
+        done
+        MANAGED_TARGET_IPV6_ADDRESSES=()
+        if [ "${IPV6_POLICY_TABLE_MANAGED}" = "true" ]; then
+            ip -6 route del blackhole default metric "${IPV6_BLACKHOLE_METRIC}" table "${IPV6_POLICY_TABLE}" >/dev/null 2>&1 || true
+            IPV6_POLICY_TABLE_MANAGED="false"
+        fi
+        persist_managed_ipv6_policy_state || log WARN "${LAST_ERROR}"
+    else
+        log WARN "${LAST_ERROR}"
+    fi
 }
 
 cleanup_dataplane() {
@@ -3182,6 +3885,7 @@ cleanup_dataplane() {
     fi
 
     if [ "${keep_tunnel}" = false ]; then
+        cleanup_ipv6_containment
         ip route flush table 51820 >/dev/null 2>&1 || true
 
         if wg show "${WG_IFACE}" >/dev/null 2>&1; then
@@ -3277,6 +3981,8 @@ reconcile_once() {
 
     LAST_ERROR=""
     RULES_SYNCED="false"
+    IPV4_RULES_SYNCED="false"
+    IPV6_RULES_SYNCED="false"
 
     log INFO "reconcile_start reason=${reason}"
 
@@ -3317,6 +4023,20 @@ reconcile_once() {
             return 1
         fi
     fi
+
+    # IPv6 is an explicit deny-only family. Establish containment immediately
+    # after target discovery and before the IPv4 dataplane can be considered
+    # healthy.
+    if ! ensure_ipv6_containment; then
+        fail_reconcile_closed "${request_id}"
+        return 1
+    fi
+    if ! ipv6_containment_is_synced; then
+        LAST_ERROR="IPv6 containment is not fully synced"
+        fail_reconcile_closed "${request_id}"
+        return 1
+    fi
+    IPV6_RULES_SYNCED="true"
 
     if [[ "${K3S_MODE}" == "true" ]]; then
         # Keep an independent packet-filter guard in place until the complete

--- a/scripts/test-k3s-routing.sh
+++ b/scripts/test-k3s-routing.sh
@@ -91,6 +91,8 @@ ip -n "${ROUTER_NS}" -6 route add default via 2001:db8:100::2 dev clear0
 
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.ip_forward=1
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv6.conf.all.forwarding=1
+ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv6.conf.pod-r.forwarding=1
+ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv6.conf.clear0.forwarding=1
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.all.rp_filter=0
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.pod-r.rp_filter=0
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.tunnelsatsv2.rp_filter=0
@@ -104,6 +106,13 @@ if ! ip netns exec "${POD_NS}" ping -c 1 -W 2 198.51.100.2 >/dev/null; then
 fi
 if ! ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:100::2 >/dev/null; then
     echo "FAIL: baseline IPv6 clear-egress path is unreachable" >&2
+    ip -n "${POD_NS}" -6 address show >&2
+    ip -n "${POD_NS}" -6 route show table all >&2
+    ip -n "${ROUTER_NS}" -6 address show >&2
+    ip -n "${ROUTER_NS}" -6 route show table all >&2
+    ip -n "${CLEAR_NS}" -6 address show >&2
+    ip -n "${CLEAR_NS}" -6 route show table all >&2
+    ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:100::2 >&2 || true
     exit 1
 fi
 

--- a/scripts/test-k3s-routing.sh
+++ b/scripts/test-k3s-routing.sh
@@ -104,7 +104,7 @@ if ! ip netns exec "${POD_NS}" ping -c 1 -W 2 198.51.100.2 >/dev/null; then
     echo "FAIL: baseline clear-egress path is unreachable" >&2
     exit 1
 fi
-if ! ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:100::2 >/dev/null; then
+if ! ip netns exec "${POD_NS}" ping -6 -c 3 -W 2 2001:db8:100::2 >/dev/null; then
     echo "FAIL: baseline IPv6 clear-egress path is unreachable" >&2
     ip -n "${POD_NS}" -6 address show >&2
     ip -n "${POD_NS}" -6 route show table all >&2

--- a/scripts/test-k3s-routing.sh
+++ b/scripts/test-k3s-routing.sh
@@ -82,7 +82,6 @@ ip -n "${CLEAR_NS}" addr add 192.0.2.2/24 dev clear-peer
 ip -n "${CLEAR_NS}" addr add 198.51.100.2/32 dev lo
 ip -n "${ROUTER_NS}" -6 addr add 2001:db8:100::1/64 dev clear0 nodad
 ip -n "${CLEAR_NS}" -6 addr add 2001:db8:100::2/64 dev clear-peer nodad
-ip -n "${CLEAR_NS}" -6 addr add 2001:db8:ffff::2/128 dev lo nodad
 ip -n "${ROUTER_NS}" link set clear0 up
 ip -n "${CLEAR_NS}" link set clear-peer up
 ip -n "${CLEAR_NS}" route add 10.42.1.0/24 via 192.0.2.1
@@ -103,7 +102,7 @@ if ! ip netns exec "${POD_NS}" ping -c 1 -W 2 198.51.100.2 >/dev/null; then
     echo "FAIL: baseline clear-egress path is unreachable" >&2
     exit 1
 fi
-if ! ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:ffff::2 >/dev/null; then
+if ! ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:100::2 >/dev/null; then
     echo "FAIL: baseline IPv6 clear-egress path is unreachable" >&2
     exit 1
 fi
@@ -148,7 +147,7 @@ fi
 
 # The same workload has an ordinary IPv6 default route, but Option B must
 # deny it rather than exposing the clear observer to the workload's address.
-if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:ffff::2 >/dev/null 2>&1; then
+if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:100::2 >/dev/null 2>&1; then
     echo "FAIL: IPv6 traffic escaped through the clear observer" >&2
     exit 1
 fi
@@ -186,13 +185,13 @@ fi
 # Even if the dedicated IPv6 policy-table route drifts away, the independent
 # source blackhole rule must prevent fallback to the ordinary IPv6 default.
 ip -n "${ROUTER_NS}" -6 route del blackhole default metric 42760 table 51821
-if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:ffff::2 >/dev/null 2>&1; then
+if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:100::2 >/dev/null 2>&1; then
     echo "FAIL: IPv6 traffic escaped after the policy-table blackhole was removed" >&2
     exit 1
 fi
 ipv6_kill_route="$(
     ip netns exec "${ROUTER_NS}" \
-        ip -6 route get 2001:db8:ffff::2 from 2001:db8:42::7 iif pod-r 2>&1 || true
+        ip -6 route get 2001:db8:100::2 from 2001:db8:42::7 iif pod-r 2>&1 || true
 )"
 if [[ "${ipv6_kill_route}" == *"dev clear0"* ]]; then
     echo "FAIL: IPv6 kill switch fell through to ordinary egress" >&2

--- a/scripts/test-k3s-routing.sh
+++ b/scripts/test-k3s-routing.sh
@@ -48,8 +48,8 @@ ip -n "${ROUTER_NS}" link set "${POD_ROUTER_TMP}" name pod-r
 ip -n "${POD_NS}" link set "${POD_TMP}" name pod0
 ip -n "${ROUTER_NS}" addr add 10.42.1.1/24 dev pod-r
 ip -n "${POD_NS}" addr add 10.42.1.7/24 dev pod0
-ip -n "${ROUTER_NS}" -6 addr add 2001:db8:42::1/64 dev pod-r
-ip -n "${POD_NS}" -6 addr add 2001:db8:42::7/64 dev pod0
+ip -n "${ROUTER_NS}" -6 addr add 2001:db8:42::1/64 dev pod-r nodad
+ip -n "${POD_NS}" -6 addr add 2001:db8:42::7/64 dev pod0 nodad
 ip -n "${ROUTER_NS}" link set pod-r up
 ip -n "${POD_NS}" link set pod0 up
 ip -n "${POD_NS}" route add default via 10.42.1.1
@@ -80,9 +80,9 @@ ip -n "${CLEAR_NS}" link set "${CLEAR_TMP}" name clear-peer
 ip -n "${ROUTER_NS}" addr add 192.0.2.1/24 dev clear0
 ip -n "${CLEAR_NS}" addr add 192.0.2.2/24 dev clear-peer
 ip -n "${CLEAR_NS}" addr add 198.51.100.2/32 dev lo
-ip -n "${ROUTER_NS}" -6 addr add 2001:db8:100::1/64 dev clear0
-ip -n "${CLEAR_NS}" -6 addr add 2001:db8:100::2/64 dev clear-peer
-ip -n "${CLEAR_NS}" -6 addr add 2001:db8:ffff::2/128 dev lo
+ip -n "${ROUTER_NS}" -6 addr add 2001:db8:100::1/64 dev clear0 nodad
+ip -n "${CLEAR_NS}" -6 addr add 2001:db8:100::2/64 dev clear-peer nodad
+ip -n "${CLEAR_NS}" -6 addr add 2001:db8:ffff::2/128 dev lo nodad
 ip -n "${ROUTER_NS}" link set clear0 up
 ip -n "${CLEAR_NS}" link set clear-peer up
 ip -n "${CLEAR_NS}" route add 10.42.1.0/24 via 192.0.2.1

--- a/scripts/test-k3s-routing.sh
+++ b/scripts/test-k3s-routing.sh
@@ -18,6 +18,7 @@ VPN_ROUTER_TMP="wr${TEST_SUFFIX}"
 VPN_TMP="w0${TEST_SUFFIX}"
 CLEAR_ROUTER_TMP="cr${TEST_SUFFIX}"
 CLEAR_TMP="c0${TEST_SUFFIX}"
+IPV6_POLICY_STATE="/tmp/tunnelsats-ipv6-policy-${TEST_SUFFIX}.json"
 
 cleanup() {
     local namespace
@@ -31,6 +32,7 @@ cleanup() {
     for namespace in "${POD_NS}" "${VPN_NS}" "${CLEAR_NS}" "${ROUTER_NS}"; do
         ip netns del "${namespace}" >/dev/null 2>&1 || true
     done
+    rm -f "${IPV6_POLICY_STATE}" "${IPV6_POLICY_STATE}.tmp."*
 }
 trap cleanup EXIT
 
@@ -46,9 +48,12 @@ ip -n "${ROUTER_NS}" link set "${POD_ROUTER_TMP}" name pod-r
 ip -n "${POD_NS}" link set "${POD_TMP}" name pod0
 ip -n "${ROUTER_NS}" addr add 10.42.1.1/24 dev pod-r
 ip -n "${POD_NS}" addr add 10.42.1.7/24 dev pod0
+ip -n "${ROUTER_NS}" -6 addr add 2001:db8:42::1/64 dev pod-r
+ip -n "${POD_NS}" -6 addr add 2001:db8:42::7/64 dev pod0
 ip -n "${ROUTER_NS}" link set pod-r up
 ip -n "${POD_NS}" link set pod0 up
 ip -n "${POD_NS}" route add default via 10.42.1.1
+ip -n "${POD_NS}" -6 route add default via 2001:db8:42::1
 
 ip link add "${VPN_ROUTER_TMP}" type veth peer name "${VPN_TMP}"
 ip link set "${VPN_ROUTER_TMP}" netns "${ROUTER_NS}"
@@ -75,12 +80,18 @@ ip -n "${CLEAR_NS}" link set "${CLEAR_TMP}" name clear-peer
 ip -n "${ROUTER_NS}" addr add 192.0.2.1/24 dev clear0
 ip -n "${CLEAR_NS}" addr add 192.0.2.2/24 dev clear-peer
 ip -n "${CLEAR_NS}" addr add 198.51.100.2/32 dev lo
+ip -n "${ROUTER_NS}" -6 addr add 2001:db8:100::1/64 dev clear0
+ip -n "${CLEAR_NS}" -6 addr add 2001:db8:100::2/64 dev clear-peer
+ip -n "${CLEAR_NS}" -6 addr add 2001:db8:ffff::2/128 dev lo
 ip -n "${ROUTER_NS}" link set clear0 up
 ip -n "${CLEAR_NS}" link set clear-peer up
 ip -n "${CLEAR_NS}" route add 10.42.1.0/24 via 192.0.2.1
 ip -n "${ROUTER_NS}" route add default via 192.0.2.2 dev clear0
+ip -n "${CLEAR_NS}" -6 route add 2001:db8:42::/64 via 2001:db8:100::1
+ip -n "${ROUTER_NS}" -6 route add default via 2001:db8:100::2 dev clear0
 
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.ip_forward=1
+ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv6.conf.all.forwarding=1
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.all.rp_filter=0
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.pod-r.rp_filter=0
 ip netns exec "${ROUTER_NS}" sysctl -q -w net.ipv4.conf.tunnelsatsv2.rp_filter=0
@@ -92,11 +103,16 @@ if ! ip netns exec "${POD_NS}" ping -c 1 -W 2 198.51.100.2 >/dev/null; then
     echo "FAIL: baseline clear-egress path is unreachable" >&2
     exit 1
 fi
+if ! ip netns exec "${POD_NS}" ping -6 -c 1 -W 2 2001:db8:ffff::2 >/dev/null; then
+    echo "FAIL: baseline IPv6 clear-egress path is unreachable" >&2
+    exit 1
+fi
 
 # Expansion in the quoted program belongs to the nested shell.
 # shellcheck disable=SC2016
 ip netns exec "${ROUTER_NS}" env \
     ENTRYPOINT_PATH="${REPO_ROOT}/scripts/entrypoint.sh" \
+    IPV6_POLICY_STATE_FILE="${IPV6_POLICY_STATE}" \
     bash -c '
         source "${ENTRYPOINT_PATH}"
         K3S_MODE="true"
@@ -105,6 +121,11 @@ ip netns exec "${ROUTER_NS}" env \
         K3S_BYPASS_CIDRS="10.42.0.0/16,10.43.0.0/16"
         WG_IFACE="tunnelsatsv2"
         ensure_policy_routing
+        TARGET_IPV6_ADDRESSES=("2001:db8:42::7")
+        TARGET_IPV6_MACS=()
+        TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+        ensure_ipv6_containment
+        ipv6_containment_is_synced
 
         external_route="$(ip route get 198.51.100.2 from 10.42.1.7 iif pod-r)"
         if [[ "${external_route}" != *"dev tunnelsatsv2"* ]]; then
@@ -122,6 +143,13 @@ ip netns exec "${ROUTER_NS}" env \
 # A new outbound connection now succeeds through the VPN-side namespace.
 if ! ip netns exec "${POD_NS}" ping -c 1 -W 2 198.51.100.2 >/dev/null; then
     echo "FAIL: pod-initiated traffic did not traverse the VPN path" >&2
+    exit 1
+fi
+
+# The same workload has an ordinary IPv6 default route, but Option B must
+# deny it rather than exposing the clear observer to the workload's address.
+if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:ffff::2 >/dev/null 2>&1; then
+    echo "FAIL: IPv6 traffic escaped through the clear observer" >&2
     exit 1
 fi
 
@@ -155,4 +183,20 @@ if [[ "${kill_route}" == *"dev clear0"* ]]; then
     exit 1
 fi
 
-echo "k3s full-outbound routing integration test passed"
+# Even if the dedicated IPv6 policy-table route drifts away, the independent
+# source blackhole rule must prevent fallback to the ordinary IPv6 default.
+ip -n "${ROUTER_NS}" -6 route del blackhole default metric 42760 table 51821
+if ip netns exec "${POD_NS}" ping -6 -c 1 -W 1 2001:db8:ffff::2 >/dev/null 2>&1; then
+    echo "FAIL: IPv6 traffic escaped after the policy-table blackhole was removed" >&2
+    exit 1
+fi
+ipv6_kill_route="$(
+    ip netns exec "${ROUTER_NS}" \
+        ip -6 route get 2001:db8:ffff::2 from 2001:db8:42::7 iif pod-r 2>&1 || true
+)"
+if [[ "${ipv6_kill_route}" == *"dev clear0"* ]]; then
+    echo "FAIL: IPv6 kill switch fell through to ordinary egress" >&2
+    exit 1
+fi
+
+echo "k3s dual-stack fail-closed routing integration test passed"

--- a/server/app.py
+++ b/server/app.py
@@ -1374,6 +1374,11 @@ def read_dataplane_state():
         "forwarding_port": "",
         "k3s_bypass_cidrs": [],
         "rules_synced": False,
+        "ipv4_rules_synced": False,
+        "ipv6_rules_synced": False,
+        "ipv6_policy": "deny",
+        "target_ipv6_addresses": [],
+        "target_ipv6_default_route": False,
         "last_reconcile_at": "",
         "last_error": None,
         "docker_network": {
@@ -2097,6 +2102,11 @@ def local_status():
             "forwarding_port": dataplane["forwarding_port"],
             "k3s_bypass_cidrs": dataplane.get("k3s_bypass_cidrs", []),
             "rules_synced": dataplane["rules_synced"],
+            "ipv4_rules_synced": dataplane.get("ipv4_rules_synced", False),
+            "ipv6_rules_synced": dataplane.get("ipv6_rules_synced", False),
+            "ipv6_policy": dataplane.get("ipv6_policy", "deny"),
+            "target_ipv6_addresses": dataplane.get("target_ipv6_addresses", []),
+            "target_ipv6_default_route": dataplane.get("target_ipv6_default_route", False),
             "last_reconcile_at": dataplane["last_reconcile_at"],
             "last_error": dataplane["last_error"],
         }

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -1178,6 +1178,11 @@ class TestDataplaneAndRegressionFixes:
         assert data['docker_network']['name'] == 'docker-tunnelsats'
         assert data['k3s_bypass_cidrs'] == []
         assert data['rules_synced'] is False
+        assert data['ipv4_rules_synced'] is False
+        assert data['ipv6_rules_synced'] is False
+        assert data['ipv6_policy'] == 'deny'
+        assert data['target_ipv6_addresses'] == []
+        assert data['target_ipv6_default_route'] is False
         assert data['last_error'] is None
 
     @patch('app.docker_api')

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -92,6 +92,185 @@ ensure_reconcile_kill_switch
     assert result.returncode == 0, result.stderr
 
 
+def test_docker_endpoint_refresh_discovers_ipv6_address_gateway_and_mac():
+    result = run_bash(
+        r'''
+source "$1"
+
+K3S_MODE="false"
+SECURE_MODE="false"
+TARGET_CONTAINER_ID="target-id"
+TARGET_CONTAINER_NAME="lnd"
+DOCKER_POLICY_STATE_LOADED="true"
+persist_managed_docker_policy_state() { :; }
+docker_api() {
+    printf '%s\n' '{"NetworkSettings":{"Networks":{"umbrel":{"IPAddress":"10.21.0.9","IPPrefixLen":16,"Gateway":"10.21.0.1","GwPriority":0,"GlobalIPv6Address":"2001:db8:21::9","GlobalIPv6PrefixLen":64,"IPv6Gateway":"2001:db8:21::1","MacAddress":"02:42:ac:11:00:09"},"docker-tunnelsats":{"IPAddress":"10.9.9.9","IPPrefixLen":25,"Gateway":"10.9.9.1","GwPriority":100,"GlobalIPv6Address":"","IPv6Gateway":"","MacAddress":"02:42:0a:09:09:09"}}}}'
+}
+
+refresh_docker_target_endpoints
+[[ "${#TARGET_IPV4_ENDPOINTS[@]}" == "2" ]]
+[[ "${#TARGET_IPV6_ADDRESSES[@]}" == "1" ]]
+[[ "${TARGET_IPV6_ADDRESSES[0]}" == "2001:db8:21::9" ]]
+[[ "${TARGET_IPV6_MACS[0]}" == "02:42:ac:11:00:09" ]]
+[[ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" == "true" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_ipv6_containment_is_idempotent_and_fails_verification_on_route_drift():
+    result = run_bash(
+        r'''
+source "$1"
+
+TARGET_IPV6_ADDRESSES=("2001:db8:42::7")
+TARGET_IPV6_MACS=()
+TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+IPV6_POLICY_STATE_LOADED="true"
+MANAGED_TARGET_IPV6_ADDRESSES=()
+RULE_64=""
+RULE_65=""
+ROUTES=""
+FILTER_INSTALLED="false"
+ADD_COUNT=0
+persist_managed_ipv6_policy_state() { :; }
+
+ip() {
+    case "$*" in
+        "-6 rule show pref 32764") printf '%s\n' "${RULE_64}" ;;
+        "-6 rule show pref 32765") printf '%s\n' "${RULE_65}" ;;
+        "-6 rule add from 2001:db8:42::7 blackhole pref 32765")
+            RULE_65=$'32765:\tfrom 2001:db8:42::7 blackhole'
+            ADD_COUNT=$((ADD_COUNT + 1))
+            ;;
+        "-6 rule add from 2001:db8:42::7 table 51821 pref 32764")
+            RULE_64=$'32764:\tfrom 2001:db8:42::7 lookup 51821'
+            ADD_COUNT=$((ADD_COUNT + 1))
+            ;;
+        "-6 route show table 51821") printf '%s\n' "${ROUTES}" ;;
+        "-6 route replace blackhole default metric 42760 table 51821")
+            ROUTES="blackhole default metric 42760"
+            ADD_COUNT=$((ADD_COUNT + 1))
+            ;;
+        *) return 1 ;;
+    esac
+}
+ip6tables() {
+    if [[ "$*" == "-S FORWARD" ]]; then
+        if [ "${FILTER_INSTALLED}" = "true" ]; then
+            printf '%s\n' '-A FORWARD -s 2001:db8:42::7/128 ! -d fe80::/10 -m comment --comment tunnelsats-ipv6-deny -j DROP'
+        fi
+        return 0
+    fi
+    if [[ "$1" == "-C" ]]; then
+        [ "${FILTER_INSTALLED}" = "true" ]
+        return
+    fi
+    if [[ "$1" == "-I" ]]; then
+        FILTER_INSTALLED="true"
+        ADD_COUNT=$((ADD_COUNT + 1))
+        return 0
+    fi
+    return 1
+}
+
+ensure_ipv6_containment
+ipv6_containment_is_synced
+[[ "${ADD_COUNT}" == "4" ]]
+ensure_ipv6_containment
+ipv6_containment_is_synced
+[[ "${ADD_COUNT}" == "4" ]]
+
+ROUTES=""
+if ipv6_containment_is_synced; then exit 1; fi
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_ipv6_containment_refuses_to_claim_matching_unowned_policy_rule():
+    result = run_bash(
+        r'''
+source "$1"
+
+TARGET_IPV6_ADDRESSES=("2001:db8:42::7")
+TARGET_IPV6_MACS=()
+TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+IPV6_POLICY_STATE_LOADED="true"
+IPV6_POLICY_TABLE_MANAGED="false"
+MANAGED_TARGET_IPV6_ADDRESSES=()
+DELETE_COUNT=0
+persist_managed_ipv6_policy_state() { :; }
+ip6tables() {
+    case "$1" in
+        -C) return 0 ;;
+        -S) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+ip() {
+    case "$*" in
+        "-6 rule show pref 32765")
+            printf '%s\n' $'32765:\tfrom 2001:db8:42::7 blackhole'
+            ;;
+        "-6 rule show pref 32764") return 0 ;;
+        "-6 rule del"*) DELETE_COUNT=$((DELETE_COUNT + 1)); return 1 ;;
+        "-6 route show table 51821") return 0 ;;
+        "-6 route replace blackhole default metric 42760 table 51821") return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+if ensure_ipv6_containment; then exit 1; fi
+[[ "${DELETE_COUNT}" == "0" ]]
+[[ "${MANAGED_TARGET_IPV6_ADDRESSES[*]}" == "" ]]
+[[ "${LAST_ERROR}" == *"unowned rule"* ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rules_synced_reports_ipv4_and_ipv6_independently():
+    result = run_bash(
+        r'''
+source "$1"
+ipv4_rules_are_synced() { return 1; }
+ipv6_containment_is_synced() { return 0; }
+if rules_are_synced; then exit 1; fi
+[[ "${IPV4_RULES_SYNCED}" == "false" ]]
+[[ "${IPV6_RULES_SYNCED}" == "true" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_write_state_reports_ipv6_policy_and_independent_family_status():
+    result = run_bash(
+        r'''
+source "$1"
+STATE_FILE="${POLICY_TEST_STATE_FILE}.json"
+TARGET_IPV6_ADDRESSES=("2001:db8:42::7" "fd00:42::7")
+TARGET_HAS_IPV6_DEFAULT_ROUTE="true"
+RULES_SYNCED="false"
+IPV4_RULES_SYNCED="false"
+IPV6_RULES_SYNCED="true"
+
+write_state
+[[ "$(jq -r '.ipv6_policy' "${STATE_FILE}")" == "deny" ]]
+[[ "$(jq -r '.ipv4_rules_synced' "${STATE_FILE}")" == "false" ]]
+[[ "$(jq -r '.ipv6_rules_synced' "${STATE_FILE}")" == "true" ]]
+[[ "$(jq -r '.target_ipv6_default_route' "${STATE_FILE}")" == "true" ]]
+[[ "$(jq -r '.target_ipv6_addresses | join(",")' "${STATE_FILE}")" == "2001:db8:42::7,fd00:42::7" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_docker_attach_sets_priority_above_competing_endpoint():
     result = run_bash(
         r'''
@@ -676,13 +855,15 @@ resolve_svc_ip() {
     printf '%s\n' "10.43.0.10"
 }
 k8s_api() {
-    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-remote"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.9","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-unready"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.5","conditions":[{"type":"Ready","status":"False"}]}},{"metadata":{"name":"lnd-terminating","deletionTimestamp":"2026-07-31T08:00:00Z"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.6","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-local"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7","conditions":[{"type":"Ready","status":"True"}]}}]}'
+    printf '%s\n' '{"items":[{"metadata":{"name":"lnd-remote"},"spec":{"nodeName":"worker-b"},"status":{"phase":"Running","podIP":"10.42.2.9","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-unready"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.5","conditions":[{"type":"Ready","status":"False"}]}},{"metadata":{"name":"lnd-terminating","deletionTimestamp":"2026-07-31T08:00:00Z"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.6","conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"lnd-local"},"spec":{"nodeName":"worker-a"},"status":{"phase":"Running","podIP":"10.42.1.7","podIPs":[{"ip":"10.42.1.7"},{"ip":"2001:db8:42::7"}],"conditions":[{"type":"Ready","status":"True"}]}}]}'
 }
 
 detect_k3s_target
 [[ "${TARGET_IMPL}" == "lnd" ]]
 [[ "${TARGET_CONTAINER_NAME}" == "lnd" ]]
 [[ "${DOCKER_TARGET_IP}" == "10.42.1.7" ]]
+[[ "${TARGET_IPV6_ADDRESSES[0]}" == "2001:db8:42::7" ]]
+[[ "${TARGET_HAS_IPV6_DEFAULT_ROUTE}" == "true" ]]
 [[ "${LN_TARGET_PORT}" == "9735" ]]
 [[ -z "${LAST_ERROR}" ]]
 '''

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -297,6 +297,31 @@ describe('UI Routing and Initialization', () => {
         expect(document.getElementById('btn-dash-disable-routing').classList.contains('hidden')).toBe(true);
     });
 
+    test('fetchStatus never reports Protected when rules are unsynced without a detailed error', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    vpn_active: true,
+                    lnd_detected: true,
+                    cln_detected: false,
+                    lnd_routing_active: true,
+                    cln_routing_active: false,
+                    wg_status: 'Connected',
+                    target_impl: 'lnd',
+                    rules_synced: false,
+                    last_error: null
+                }),
+                ok: true
+            })
+        );
+
+        await window.fetchStatus();
+
+        expect(document.getElementById('statusBadge').textContent).toBe('Connected');
+        expect(document.getElementById('txt-routing-status').textContent).toBe('Dataplane Blocked');
+        expect(document.getElementById('txt-routing-error').textContent).toBe('Dataplane protection is not fully synced.');
+    });
+
     test('fetchStatus adjusts UI for secure_mode: true', async () => {
         global.fetch = jest.fn(() =>
             Promise.resolve({

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -725,16 +725,16 @@ async function fetchStatus() {
         const clnDetected = data.cln_detected === true;
         const lndRouting = data.lnd_routing_active === true;
         const clnRouting = data.cln_routing_active === true;
-        const dataplaneError = typeof data.last_error === 'string' && data.last_error.trim() !== ''
-            ? data.last_error.trim()
-            : '';
-
         const hasNode = lndDetected || clnDetected;
         const routingActive = lndRouting || clnRouting;
+        const rulesSynced = data.rules_synced === true;
+        const dataplaneError = typeof data.last_error === 'string' && data.last_error.trim() !== ''
+            ? data.last_error.trim()
+            : (hasNode && !rulesSynced ? 'Dataplane protection is not fully synced.' : '');
 
         // Update Header Badge
         const badge = document.getElementById('statusBadge');
-        if (vpnActive && hasNode && routingActive && !dataplaneError) {
+        if (vpnActive && hasNode && routingActive && rulesSynced && !dataplaneError) {
             badge.className = "px-4 py-2 rounded-full font-bold text-sm bg-green-900/50 text-tsgreen border border-green-700";
             badge.textContent = "Protected";
             const pingDot = document.getElementById('ping-tunnel');
@@ -1942,7 +1942,7 @@ async function pollUntilConnected(options = {}) {
         if (
             status
             && status.vpn_active === true
-            && status.rules_synced !== false
+            && status.rules_synced === true
             && !status.last_error
         ) {
             if (onConnected) onConnected(status);


### PR DESCRIPTION
Closes #127.

Implements Option B from the team architecture decision:
- discovers Docker and k3s target IPv6 endpoints
- installs independently owned IPv6 policy-table and source blackholes
- enforces tagged ip6tables drops, with MAC-based coverage in Secure Mode
- exposes independent IPv4/IPv6 synchronization status and requires aggregate sync before the UI reports Protected
- extends the k3s namespace integration test to prove IPv4 VPN egress and IPv6 denial, including route drift
- documents the explicit IPv6 deny-only product policy and implementation plan

Local validation:
- 218 backend tests passed
- 58 frontend tests passed
- 9 entrypoint smoke cases passed
- bash syntax and git diff checks passed
- ShellCheck has no warnings beyond the five pre-existing warnings on master

The root-only namespace test could not run under the local unprivileged account because sudo requires an interactive password; the PR CI job is the authoritative execution for that test.