### PR TITLE
fix(lightning): remove stale real-IP announcements

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,69 +1,82 @@
-# Issue #127 implementation plan: fail-closed IPv6 denial
+# Issue #126 implementation plan: remove stale real-IP announcements
 
 ## Decision
 
-Implement Option B from issue #127. The deployed TunnelSats WireGuard fleet
-assigns only IPv4 client addresses and provides only IPv4 transit, so advertising
-IPv6 tunnel support would require new customer configurations and a coordinated
-backend/server rollout. Until that exists, the selected Lightning workload must
-not have non-local IPv6 egress.
+Treat Lightning gossip announcements as part of the protected state, independently
+from packet routing. TunnelSats must disable automatic or explicit clearnet
+announcement settings, withdraw stale LND gossip addresses when it has direct
+container access, and fail closed whenever the remaining state cannot be verified.
 
 ## Security invariants
 
-- Keep the existing IPv4 policy-routing and WireGuard behavior unchanged.
-- Treat IPv6 as a separately verified dataplane family with policy `deny`.
-- Discover every non-link-local IPv6 address assigned to the selected Docker
-  container or Kubernetes pod before reporting protection.
-- Install two independent IPv6 controls for each discovered source: a policy
-  rule into a table whose default is blackholed, followed by a source blackhole
-  fallback, and a tagged `ip6tables` FORWARD drop for non-local egress.
-- Preserve IPv6 loopback inside the workload and link-local traffic required for
-  neighbor discovery; do not add any global/ULA bypass.
-- Never set aggregate `rules_synced` to true unless both IPv4 routing and IPv6
-  containment verify successfully. A global/ULA target address whose rules
-  cannot be installed or verified remains unprotected and reports an error.
+- Never display `Protected` while an active LND `externalip`/`nat=true` or CLN
+  non-TunnelSats `announce-addr`/`ip-discovery=true` conflict is present.
+- Preserve explicitly retained Tor `.onion` announcements; remove other non-
+  TunnelSats public announcements.
+- Require an explicit privacy confirmation before changing user-owned address
+  discovery or announcement settings.
+- Save the original active settings only once in `backupConfig` and restore only
+  that saved set. Repeated configuration and restore operations remain idempotent.
+- In direct mode, do not mark LND gossip verified until `lncli getinfo` has been
+  queried after restart, every conflicting live URI has been withdrawn with
+  `peers updatenodeannouncement`, and a second query is clean.
+- In secure or k3s modes where authenticated LND RPC is unavailable, keep the
+  aggregate status in a warning state instead of trusting a manual confirmation.
+- Explain that withdrawing an address updates current gossip but cannot erase
+  historical snapshots held by third parties.
 
 ## Implementation
 
-1. Extend target discovery in `scripts/entrypoint.sh`.
-   - Parse IPv6 endpoint addresses and IPv6 gateways from Docker inspect data.
-   - Parse the complete Kubernetes `status.podIPs` array while retaining the
-     IPv4 pod IP for the existing dataplane.
-   - Normalize and deduplicate non-loopback, non-link-local IPv6 addresses.
-2. Add an idempotent IPv6 containment reconciler.
-   - Seed a dedicated IPv6 policy table with a blackhole default.
-   - Install per-source lookup and fallback-blackhole rules before the packet
-     filter is considered ready.
-   - Maintain a tagged `ip6tables` chain that returns link-local/ND traffic and
-     drops all other forwarded IPv6 from current target addresses.
-   - Remove stale rules only when they are provably owned by TunnelSats.
-3. Split validation and status by address family.
-   - Preserve `rules_synced` as the aggregate compatibility field.
-   - Add `ipv4_rules_synced`, `ipv6_rules_synced`, `ipv6_policy`,
-     `target_ipv6_addresses`, and `target_ipv6_default_route` to state and the
-     local status API.
-   - Require aggregate `rules_synced: true` before the dashboard renders the
-     workload as Protected, even when no detailed error string is available.
-   - Reconciliation evaluates both validators independently so diagnostics do
-     not hide the state of one family behind a failure in the other.
-4. Keep cleanup fail-closed during ordinary reconciliation failures and remove
-   owned IPv6 state only during a full shutdown cleanup.
-5. Add tests.
-   - Unit-test Docker and k3s IPv6 discovery, idempotent containment, stale rule
-     cleanup, independent status fields, and verification failure behavior.
-   - Extend the root-only namespace integration test with a dual-stack pod and
-     clear-net observer. Prove IPv4 traverses the VPN observer, IPv6 is denied,
-     and removing a containment route cannot fall through to the ordinary IPv6
-     default route.
-   - Run shell syntax checks, backend tests, frontend tests, and the available
-     root-only integration tests.
-6. Document the explicit IPv6 product policy in `README.md` and `k3s/README.md`.
+1. Add shared configuration parsing and atomic transformation helpers in
+   `server/app.py`.
+   - Audit active LND `externalip`, `externalhosts`, and `nat` values.
+   - Audit active CLN `announce-addr` and `ip-discovery` values.
+   - Classify TunnelSats and `.onion` endpoints separately from conflicting
+     clearnet endpoints.
+2. Harden direct-mode configuration.
+   - Return a conflict response until the caller confirms address changes.
+   - Persist original conflicting settings under `backupConfig.lnd` or
+     `backupConfig.cln` before editing the node config.
+   - Disable conflicting announcements/discovery, retain requested Tor entries,
+     and install only the intended TunnelSats announcement.
+   - Restart the selected node after the atomic config update.
+3. Purge and verify LND gossip in direct mode.
+   - Execute authenticated `lncli getinfo` inside the detected LND container.
+   - Remove each live non-TunnelSats, non-retained-Tor URI with
+     `lncli peers updatenodeannouncement --address_remove=...`.
+   - Query again and persist an endpoint-bound verification result. Return an
+     error and leave protection fail-closed if inspection, removal, or
+     verification fails.
+4. Make restore deliberate and idempotent.
+   - Disable TunnelSats-managed announcement lines.
+   - Restore exactly the settings captured in `backupConfig` and clear only the
+     successfully restored backup entry.
+   - Restart only detected node implementations whose config was processed.
+5. Improve secure-mode guidance.
+   - Tell LND users to remove/comment `externalip`, set `nat=false`, restart,
+     withdraw each old address with the copyable Umbrel `docker exec lnd lncli`
+     command, and verify live URIs.
+   - Tell CLN users to remove non-TunnelSats `announce-addr` values and disable
+     `ip-discovery` before restart.
+   - Include the historical-gossip retention warning in setup and restore UI.
+6. Gate local status.
+   - Audit readable node configs on every `/api/local/status` request.
+   - Override aggregate `rules_synced` and `last_error` when a config conflict
+     exists, direct-mode LND gossip has not been verified for the current
+     TunnelSats endpoint, or the deployment mode cannot perform that verification.
+   - Return structured announcement-conflict and verification fields for UI and
+     diagnostics while preserving existing dataplane fields.
+7. Add backend and frontend regression coverage for multiple values, `nat=true`
+   and `nat=1`, CLN discovery, confirmation, backup/restore, retained Tor,
+   already-advertised real addresses, RPC failure, secure-mode instructions, and
+   protected-status suppression.
 
 ## Review gates
 
-1. Local review/fix cycle: inspect the complete branch diff for security,
-   ownership, cleanup, race, compatibility, and test gaps; fix every finding and
-   rerun the relevant checks until clean.
+1. Local review/fix cycle: inspect the complete branch diff for privacy leaks,
+   backup corruption, partial failure behavior, restore safety, parsing gaps,
+   command injection, status fail-open behavior, and missing tests; fix all
+   findings and rerun the full relevant test suite until clean.
 2. Greptile review/fix cycle: push the branch, open a pull request, request a
    Greptile review, resolve every actionable finding, and repeat review/checks
-   until Greptile has no findings left.
+   until Greptile reports no findings.

--- a/server/app.py
+++ b/server/app.py
@@ -809,7 +809,7 @@ def audit_node_announcement_config(
         return {"readable": False, "settings": [], "conflicts": []}
     except (IOError, OSError) as exc:
         app.logger.warning(f"Failed to audit {node_type.upper()} announcement config {path}: {exc}")
-        return {"readable": False, "settings": [], "conflicts": [f"{node_type}:config-unreadable"]}
+        return {"readable": False, "settings": [], "conflicts": ["config-unreadable"]}
 
     keys = set(_node_announcement_keys(node_type))
     entries = [entry for entry in _parse_active_config_entries(lines) if entry["key"] in keys]
@@ -2601,11 +2601,15 @@ def local_status():
             "lnd", LND_CONFIG_PATH, str(server_domain), expected_port
         )
         announcement_conflicts.extend(f"lnd:{item}" for item in lnd_audit["conflicts"])
+        if lnd_detected and not lnd_audit["readable"] and not lnd_audit["conflicts"]:
+            announcement_conflicts.append("lnd:config-unavailable")
     if cln_detected or (cln_container_config and os.path.exists(cln_container_config)):
         cln_audit = audit_node_announcement_config(
             "cln", cln_container_config, str(server_domain), expected_port
         )
         announcement_conflicts.extend(f"cln:{item}" for item in cln_audit["conflicts"])
+        if cln_detected and not cln_audit["readable"] and not cln_audit["conflicts"]:
+            announcement_conflicts.append("cln:config-unavailable")
 
     verification_required = bool(lnd_detected and lnd_routing_active)
     verification = meta_data.get("lndAnnouncementVerification")

--- a/server/app.py
+++ b/server/app.py
@@ -109,6 +109,12 @@ LND_MIDDLEWARE_PATTERN = r"(^|[_-])(lightning[_-]app|lnd[_-]app|lightning[_-]ui)
 CLN_CONTAINER_PATTERN = r"(^|[_-])(core-lightning|clightning|lightningd|cln)([_-]|\d|$)"
 WG_INTERFACE_NAME = "tunnelsatsv2"
 WG_HANDSHAKE_MAX_AGE_SECONDS = 180
+ANNOUNCEMENT_CONFLICT_ERROR = (
+    "Conflicting real-IP announcement setting detected in node configuration."
+)
+ANNOUNCEMENT_VERIFICATION_ERROR = (
+    "LND gossip announcements have not been verified free of conflicting clearnet addresses."
+)
 
 # k3s mode: set via env var K3S_MODE=true to use the Kubernetes API instead of the Docker socket
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
@@ -732,6 +738,339 @@ def upsert_config_line_in_section(path: str, section_header: str, prefix: str, r
     return True, changed
 
 
+def _parse_active_config_entries(lines: Iterable[str]) -> List[Dict[str, str]]:
+    """Parse active key/value config lines without treating commented values as active."""
+    entries: List[Dict[str, str]] = []
+    for index, line in enumerate(lines):
+        stripped = str(line).strip()
+        if not stripped or stripped.startswith(("#", ";")):
+            continue
+        match = re.match(r"^([A-Za-z0-9_.-]+)\s*=\s*(.*?)\s*$", stripped)
+        if not match:
+            continue
+        entries.append({
+            "index": str(index),
+            "key": match.group(1).lower(),
+            "value": match.group(2).strip(),
+            "line": stripped,
+        })
+    return entries
+
+
+def _address_host(address: str) -> str:
+    endpoint = str(address or "").strip()
+    if "@" in endpoint:
+        endpoint = endpoint.rsplit("@", 1)[1]
+    if endpoint.startswith("[") and "]" in endpoint:
+        return endpoint[1:endpoint.index("]")].lower().rstrip(".")
+    host, separator, _port = endpoint.rpartition(":")
+    if separator and host:
+        return host.lower().rstrip(".")
+    return endpoint.lower().rstrip(".")
+
+
+def _is_onion_address(address: str) -> bool:
+    return _address_host(address).endswith(".onion")
+
+
+def _is_expected_tunnelsats_address(address: str, dns: str, port: int) -> bool:
+    endpoint = str(address or "").strip()
+    if "@" in endpoint:
+        endpoint = endpoint.rsplit("@", 1)[1]
+    return endpoint.lower().rstrip(".") == f"{dns}:{port}".lower().rstrip(".")
+
+
+def _config_bool(value: str) -> Optional[bool]:
+    token = re.split(r"\s*[#;]\s*|\s+", str(value or "").strip(), maxsplit=1)[0].lower()
+    if token in ("true", "1", "yes", "on"):
+        return True
+    if token in ("false", "0", "no", "off"):
+        return False
+    return None
+
+
+def _node_announcement_keys(node_type: str) -> Tuple[str, ...]:
+    if node_type == "lnd":
+        return ("externalip", "externalhosts", "nat")
+    return ("announce-addr", "ip-discovery", "bind-addr", "always-use-proxy")
+
+
+def audit_node_announcement_config(
+    node_type: str,
+    path: str,
+    dns: str,
+    port: int,
+) -> Dict[str, Any]:
+    """Return active announcement settings and privacy conflicts for one node config."""
+    try:
+        with open(path, "r", encoding="utf-8") as conf_fp:
+            lines = conf_fp.readlines()
+    except FileNotFoundError:
+        return {"readable": False, "settings": [], "conflicts": []}
+    except (IOError, OSError) as exc:
+        app.logger.warning(f"Failed to audit {node_type.upper()} announcement config {path}: {exc}")
+        return {"readable": False, "settings": [], "conflicts": [f"{node_type}:config-unreadable"]}
+
+    keys = set(_node_announcement_keys(node_type))
+    entries = [entry for entry in _parse_active_config_entries(lines) if entry["key"] in keys]
+    conflicts: List[str] = []
+    for entry in entries:
+        key = entry["key"]
+        value = entry["value"]
+        if node_type == "lnd":
+            if key == "externalip" and not _is_onion_address(value):
+                conflicts.append(f"externalip={value}")
+            elif key == "externalhosts" and not (
+                _is_onion_address(value) or _is_expected_tunnelsats_address(value, dns, port)
+            ):
+                conflicts.append(f"externalhosts={value}")
+            elif key == "nat" and _config_bool(value) is True:
+                conflicts.append(f"nat={value}")
+        else:
+            if key == "announce-addr" and not (
+                _is_onion_address(value) or _is_expected_tunnelsats_address(value, dns, port)
+            ):
+                conflicts.append(f"announce-addr={value}")
+            elif key == "ip-discovery" and _config_bool(value) is True:
+                conflicts.append(f"ip-discovery={value}")
+
+    return {"readable": True, "settings": entries, "conflicts": conflicts}
+
+
+def _write_config_lines_atomic(path: str, lines: List[str]) -> bool:
+    file_mode = 0o600
+    file_uid = 1000
+    file_gid = 1000
+    if os.path.exists(path):
+        try:
+            stat_result = os.stat(path)
+            file_mode = stat_result.st_mode & 0o777
+            file_uid = stat_result.st_uid
+            file_gid = stat_result.st_gid
+        except (IOError, OSError) as exc:
+            app.logger.warning(f"Failed to read config ownership for {path}: {exc}")
+
+    parent_dir = os.path.dirname(path) or "."
+    tmp_path = os.path.join(parent_dir, f".{os.path.basename(path)}.tmp.{uuid.uuid4().hex}")
+    try:
+        os.makedirs(parent_dir, exist_ok=True)
+        with open(tmp_path, "w", encoding="utf-8") as conf_fp:
+            conf_fp.writelines(lines)
+        os.chmod(tmp_path, file_mode)
+        try:
+            os.chown(tmp_path, file_uid, file_gid)
+        except OSError:
+            pass
+        os.replace(tmp_path, path)
+        return True
+    except (IOError, OSError) as exc:
+        app.logger.warning(f"Failed to atomically update node config {path}: {exc}")
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
+        return False
+
+
+def _ensure_lnd_application_lines(lines: List[str], desired: List[str]) -> List[str]:
+    section_start = None
+    section_end = len(lines)
+    for index, line in enumerate(lines):
+        if line.strip().lower() != "[application options]":
+            continue
+        section_start = index
+        for next_index in range(index + 1, len(lines)):
+            candidate = lines[next_index].strip()
+            if candidate.startswith("[") and candidate.endswith("]"):
+                section_end = next_index
+                break
+        break
+    if section_start is None:
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        if lines and lines[-1].strip():
+            lines.append("\n")
+        lines.extend(["[Application Options]\n", *[f"{line}\n" for line in desired]])
+        return lines
+    if section_end > 0 and not lines[section_end - 1].endswith("\n"):
+        lines[section_end - 1] += "\n"
+    lines[section_end:section_end] = [f"{line}\n" for line in desired]
+    return lines
+
+
+def apply_node_announcement_protection(
+    node_type: str,
+    path: str,
+    dns: str,
+    port: int,
+    retain_tor: bool,
+) -> Tuple[bool, bool, List[str]]:
+    """Disable conflicting settings and install the TunnelSats announcement atomically."""
+    try:
+        with open(path, "r", encoding="utf-8") as conf_fp:
+            original_lines = conf_fp.readlines()
+    except FileNotFoundError:
+        original_lines = []
+    except (IOError, OSError) as exc:
+        app.logger.warning(f"Failed to read {node_type.upper()} config for protection: {exc}")
+        return False, False, []
+
+    entries = _parse_active_config_entries(original_lines)
+    relevant_keys = set(_node_announcement_keys(node_type))
+    backup_lines = [entry["line"] for entry in entries if entry["key"] in relevant_keys]
+    expected = f"{dns}:{port}"
+    kept: set = set()
+    updated_lines: List[str] = []
+
+    for index, line in enumerate(original_lines):
+        entry = next((item for item in entries if int(item["index"]) == index), None)
+        if entry is None or entry["key"] not in relevant_keys:
+            updated_lines.append(line)
+            continue
+
+        key = entry["key"]
+        value = entry["value"]
+        keep = False
+        mark_kept = True
+        if node_type == "lnd":
+            if key == "externalhosts" and _is_expected_tunnelsats_address(value, dns, port):
+                keep = "externalhosts" not in kept
+            elif key == "externalip" and retain_tor and _is_onion_address(value):
+                keep = True
+                mark_kept = False
+            elif key == "externalhosts" and retain_tor and _is_onion_address(value):
+                keep = True
+                mark_kept = False
+            elif key == "nat" and _config_bool(value) is False:
+                keep = "nat" not in kept
+        else:
+            if key == "announce-addr" and _is_expected_tunnelsats_address(value, dns, port):
+                keep = "announce-addr" not in kept
+            elif key == "announce-addr" and retain_tor and _is_onion_address(value):
+                keep = True
+                mark_kept = False
+            elif key == "ip-discovery" and _config_bool(value) is False:
+                keep = "ip-discovery" not in kept
+            elif key == "bind-addr" and value == "0.0.0.0:9736":
+                keep = "bind-addr" not in kept
+            elif key == "always-use-proxy" and value.lower() == "false":
+                keep = "always-use-proxy" not in kept
+
+        if keep:
+            if mark_kept:
+                kept.add(key)
+            updated_lines.append(line)
+        else:
+            newline = "\n" if line.endswith("\n") else ""
+            updated_lines.append(f"# TunnelSats disabled: {entry['line']}{newline}")
+
+    desired: List[str] = []
+    if node_type == "lnd":
+        if "externalhosts" not in kept:
+            desired.append(f"externalhosts={expected}")
+        if "nat" not in kept:
+            desired.append("nat=false")
+        updated_lines = _ensure_lnd_application_lines(updated_lines, desired)
+    else:
+        if "announce-addr" not in kept:
+            desired.append(f"announce-addr={expected}")
+        if "ip-discovery" not in kept:
+            desired.append("ip-discovery=false")
+        if "bind-addr" not in kept:
+            desired.append("bind-addr=0.0.0.0:9736")
+        if "always-use-proxy" not in kept:
+            desired.append("always-use-proxy=false")
+        if updated_lines and not updated_lines[-1].endswith("\n"):
+            updated_lines[-1] += "\n"
+        updated_lines.extend(f"{line}\n" for line in desired)
+
+    changed = updated_lines != original_lines
+    if changed and not _write_config_lines_atomic(path, updated_lines):
+        return False, False, backup_lines
+    return True, changed, backup_lines
+
+
+def restore_node_announcement_config(
+    node_type: str,
+    path: str,
+    backup_lines: List[str],
+    dns: str,
+    port: int,
+) -> Tuple[bool, bool]:
+    """Remove managed values and reactivate exactly the settings captured before setup."""
+    if not os.path.exists(path):
+        return False, False
+    try:
+        with open(path, "r", encoding="utf-8") as conf_fp:
+            original_lines = conf_fp.readlines()
+    except (IOError, OSError) as exc:
+        app.logger.warning(f"Failed to read {node_type.upper()} config for restore: {exc}")
+        return False, False
+
+    expected_counts: Dict[str, int] = {}
+    for saved_line in backup_lines:
+        expected_counts[saved_line] = expected_counts.get(saved_line, 0) + 1
+    restored_counts: Dict[str, int] = {}
+    expected_endpoint = f"{dns}:{port}"
+    updated_lines: List[str] = []
+
+    for line in original_lines:
+        stripped = line.strip()
+        tagged = re.match(r"^#\s*TunnelSats disabled:\s*(.*?)\s*$", stripped)
+        if tagged:
+            saved = tagged.group(1)
+            if restored_counts.get(saved, 0) < expected_counts.get(saved, 0):
+                updated_lines.append(f"{saved}\n")
+                restored_counts[saved] = restored_counts.get(saved, 0) + 1
+            else:
+                updated_lines.append(line)
+            continue
+
+        parsed = _parse_active_config_entries([line])
+        if not parsed:
+            updated_lines.append(line)
+            continue
+        entry = parsed[0]
+        saved = entry["line"]
+        if restored_counts.get(saved, 0) < expected_counts.get(saved, 0):
+            updated_lines.append(line)
+            restored_counts[saved] = restored_counts.get(saved, 0) + 1
+            continue
+
+        managed = False
+        if node_type == "lnd":
+            managed = (
+                entry["key"] == "externalhosts"
+                and _is_expected_tunnelsats_address(entry["value"], dns, port)
+            ) or (entry["key"] == "nat" and _config_bool(entry["value"]) is False)
+        else:
+            managed = (
+                entry["key"] == "announce-addr"
+                and entry["value"].lower() == expected_endpoint.lower()
+            ) or (
+                entry["key"] == "ip-discovery" and _config_bool(entry["value"]) is False
+            ) or (
+                entry["key"] == "bind-addr" and entry["value"] == "0.0.0.0:9736"
+            ) or (
+                entry["key"] == "always-use-proxy" and entry["value"].lower() == "false"
+            )
+        if managed:
+            newline = "\n" if line.endswith("\n") else ""
+            updated_lines.append(f"# TunnelSats disabled managed: {entry['line']}{newline}")
+        else:
+            updated_lines.append(line)
+
+    for saved_line, count in expected_counts.items():
+        missing = count - restored_counts.get(saved_line, 0)
+        updated_lines.extend(f"{saved_line}\n" for _ in range(max(0, missing)))
+
+    changed = updated_lines != original_lines
+    if changed and not _write_config_lines_atomic(path, updated_lines):
+        return False, False
+    return True, changed
+
+
 def _parse_config_comments(config_text):
     meta: Dict[str, Any] = {}
     for line in config_text.split("\n"):
@@ -819,6 +1158,63 @@ def _set_restart_pending(meta_path, _ignored_meta, key, is_pending):
         except (IOError, OSError) as exc:
             app.logger.warning(f"Failed to persist restart-pending state for {key}: {exc}")
             return False
+
+
+def _update_announcement_metadata(
+    meta_path: str,
+    node_type: str,
+    backup_lines: Optional[List[str]] = None,
+    verification: Optional[Dict[str, Any]] = None,
+    clear_backup: bool = False,
+) -> bool:
+    with _metadata_lock:
+        try:
+            with open(meta_path, "r", encoding="utf-8") as meta_fp:
+                meta = json.load(meta_fp)
+        except (IOError, OSError, json.JSONDecodeError):
+            return False
+        if not isinstance(meta, dict):
+            return False
+
+        backup_config = meta.get("backupConfig")
+        if not isinstance(backup_config, dict):
+            backup_config = {}
+        if backup_lines is not None and node_type not in backup_config:
+            backup_config[node_type] = {
+                "lines": list(backup_lines),
+                "capturedAt": datetime.now(timezone.utc).isoformat(),
+            }
+        if clear_backup:
+            backup_config.pop(node_type, None)
+        if backup_config:
+            meta["backupConfig"] = backup_config
+        else:
+            meta.pop("backupConfig", None)
+
+        if node_type == "lnd":
+            if verification is None:
+                meta.pop("lndAnnouncementVerification", None)
+            else:
+                meta["lndAnnouncementVerification"] = verification
+        try:
+            _write_file_secure(meta_path, json.dumps(meta, indent=2))
+            return True
+        except (IOError, OSError) as exc:
+            app.logger.warning(f"Failed to persist announcement metadata: {exc}")
+            return False
+
+
+def _backup_lines_from_meta(meta: Dict[str, Any], node_type: str) -> Optional[List[str]]:
+    backup_config = meta.get("backupConfig")
+    if not isinstance(backup_config, dict):
+        return None
+    node_backup = backup_config.get(node_type)
+    if not isinstance(node_backup, dict):
+        return None
+    lines = node_backup.get("lines")
+    if not isinstance(lines, list) or not all(isinstance(line, str) for line in lines):
+        return None
+    return lines
 
 
 def _has_required_wireguard_blocks(config_text):
@@ -1107,6 +1503,139 @@ def docker_api_post(path):
     except (subprocess.SubprocessError, FileNotFoundError, TimeoutError, OSError) as exc:
         app.logger.warning(f"Docker API POST failed for path {path}: {exc}")
         return False
+
+
+def docker_exec(container_id: str, command: List[str]) -> Tuple[bool, str]:
+    """Execute a fixed argv inside a container through the mounted Docker socket."""
+    if not os.path.exists(DOCKER_SOCK) or not re.fullmatch(r"[A-Za-z0-9_.-]+", container_id or ""):
+        return False, ""
+    create_payload = json.dumps({
+        "AttachStdout": True,
+        "AttachStderr": True,
+        "Tty": True,
+        "Cmd": [str(part) for part in command],
+    })
+    try:
+        create_result = subprocess.run(
+            [
+                "curl", "-sS", "--fail", "-X", "POST", "--unix-socket", DOCKER_SOCK,
+                "-H", "Content-Type: application/json", "--data-binary", create_payload,
+                f"http://localhost/containers/{container_id}/exec",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if create_result.returncode != 0:
+            return False, create_result.stderr.strip()
+        exec_id = str(json.loads(create_result.stdout).get("Id", ""))
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+", exec_id):
+            return False, ""
+
+        start_result = subprocess.run(
+            [
+                "curl", "-sS", "--fail", "-X", "POST", "--unix-socket", DOCKER_SOCK,
+                "-H", "Content-Type: application/json", "--data-binary",
+                json.dumps({"Detach": False, "Tty": True}),
+                f"http://localhost/exec/{exec_id}/start",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        inspect_result = subprocess.run(
+            [
+                "curl", "-sS", "--fail", "--unix-socket", DOCKER_SOCK,
+                f"http://localhost/exec/{exec_id}/json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if start_result.returncode != 0 or inspect_result.returncode != 0:
+            return False, (start_result.stdout + start_result.stderr).strip()
+        inspect_payload = json.loads(inspect_result.stdout)
+        return inspect_payload.get("ExitCode") == 0, start_result.stdout.strip()
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError) as exc:
+        app.logger.warning(f"Docker exec failed for container {container_id[:12]}: {exc}")
+        return False, ""
+
+
+def _parse_lnd_getinfo_uris(output: str) -> Optional[List[str]]:
+    raw = str(output or "").replace("\r", "")
+    start = raw.find("{")
+    if start < 0:
+        return None
+    try:
+        payload, _end = json.JSONDecoder().raw_decode(raw[start:])
+    except json.JSONDecodeError:
+        return None
+    uris = payload.get("uris")
+    if not isinstance(uris, list) or not all(isinstance(uri, str) for uri in uris):
+        return None
+    addresses = []
+    for uri in uris:
+        endpoint = uri.rsplit("@", 1)[-1].strip()
+        if endpoint and endpoint not in addresses:
+            addresses.append(endpoint)
+    return addresses
+
+
+def _query_lnd_addresses(container_id: str, attempts: int = 5) -> Optional[List[str]]:
+    """Allow LND a short readiness window after its required restart."""
+    for attempt in range(max(1, attempts)):
+        ok, output = docker_exec(container_id, ["lncli", "getinfo"])
+        addresses = _parse_lnd_getinfo_uris(output) if ok else None
+        if addresses is not None:
+            return addresses
+        if attempt + 1 < attempts:
+            time.sleep(2)
+    return None
+
+
+def clean_and_verify_lnd_announcements(
+    dns: str,
+    port: int,
+    retain_tor: bool,
+) -> Tuple[bool, List[str], List[str]]:
+    """Withdraw live non-TunnelSats clearnet LND URIs, then verify the live set."""
+    container_id = container_id_by_match(LND_CONTAINER_PATTERN)
+    if not container_id:
+        return False, [], []
+
+    addresses = _query_lnd_addresses(container_id)
+    if addresses is None:
+        return False, [], []
+
+    conflicts = [
+        address for address in addresses
+        if not _is_expected_tunnelsats_address(address, dns, port)
+        and not (retain_tor and _is_onion_address(address))
+    ]
+    removed: List[str] = []
+    for address in conflicts:
+        removed_ok, _ = docker_exec(
+            container_id,
+            ["lncli", "peers", "updatenodeannouncement", f"--address_remove={address}"],
+        )
+        if not removed_ok:
+            return False, removed, conflicts
+        removed.append(address)
+
+    verified_addresses = _query_lnd_addresses(container_id)
+    if verified_addresses is None:
+        return False, removed, conflicts
+    remaining = [
+        address for address in verified_addresses
+        if not _is_expected_tunnelsats_address(address, dns, port)
+        and not (retain_tor and _is_onion_address(address))
+    ]
+    if not any(
+        _is_expected_tunnelsats_address(address, dns, port)
+        for address in verified_addresses
+    ):
+        remaining.append(f"missing expected announcement {dns}:{port}")
+    return not remaining, removed, remaining
 
 
 def _k8s_list_pods_in_namespace(ns, token):
@@ -2046,12 +2575,14 @@ def local_status():
     server_domain = ""
     expires_at = ""
     vpn_port = ""
+    meta_data: Dict[str, Any] = {}
     meta_path = os.path.join(DATA_DIR, META_FILE)
     with _metadata_lock:
         try:
             with open(meta_path, "r", encoding="utf-8") as fp:
                 meta = json.load(fp)
                 if isinstance(meta, dict):
+                    meta_data = meta
                     server_domain = meta.get("serverDomain", "")
                     expires_at = meta.get("expiresAt", "")
                     vpn_port = meta.get("vpnPort", "")
@@ -2059,6 +2590,44 @@ def local_status():
             pass
         except (IOError, OSError, json.JSONDecodeError) as exc:
             app.logger.warning(f"Failed to read or parse metadata file {meta_path}: {exc}")
+
+    try:
+        expected_port = int(vpn_port or 0)
+    except (TypeError, ValueError):
+        expected_port = 0
+    announcement_conflicts: List[str] = []
+    if lnd_detected or os.path.exists(LND_CONFIG_PATH):
+        lnd_audit = audit_node_announcement_config(
+            "lnd", LND_CONFIG_PATH, str(server_domain), expected_port
+        )
+        announcement_conflicts.extend(f"lnd:{item}" for item in lnd_audit["conflicts"])
+    if cln_detected or (cln_container_config and os.path.exists(cln_container_config)):
+        cln_audit = audit_node_announcement_config(
+            "cln", cln_container_config, str(server_domain), expected_port
+        )
+        announcement_conflicts.extend(f"cln:{item}" for item in cln_audit["conflicts"])
+
+    verification_required = bool(lnd_detected and lnd_routing_active)
+    verification = meta_data.get("lndAnnouncementVerification")
+    expected_endpoint = f"{server_domain}:{expected_port}"
+    announcement_verified: Optional[bool] = None
+    if verification_required:
+        announcement_verified = bool(
+            not SECURE_MODE
+            and not K3S_MODE
+            and isinstance(verification, dict)
+            and verification.get("verified") is True
+            and verification.get("endpoint") == expected_endpoint
+        )
+
+    effective_rules_synced = bool(dataplane["rules_synced"])
+    effective_error = dataplane["last_error"]
+    if announcement_conflicts:
+        effective_rules_synced = False
+        effective_error = ANNOUNCEMENT_CONFLICT_ERROR
+    elif verification_required and not announcement_verified:
+        effective_rules_synced = False
+        effective_error = ANNOUNCEMENT_VERIFICATION_ERROR
 
     # Enrich with location metadata using unified helper
     lat, lng, label, flag = None, None, None, None
@@ -2101,14 +2670,17 @@ def local_status():
             "docker_network": dataplane["docker_network"],
             "forwarding_port": dataplane["forwarding_port"],
             "k3s_bypass_cidrs": dataplane.get("k3s_bypass_cidrs", []),
-            "rules_synced": dataplane["rules_synced"],
+            "rules_synced": effective_rules_synced,
             "ipv4_rules_synced": dataplane.get("ipv4_rules_synced", False),
             "ipv6_rules_synced": dataplane.get("ipv6_rules_synced", False),
             "ipv6_policy": dataplane.get("ipv6_policy", "deny"),
             "target_ipv6_addresses": dataplane.get("target_ipv6_addresses", []),
             "target_ipv6_default_route": dataplane.get("target_ipv6_default_route", False),
             "last_reconcile_at": dataplane["last_reconcile_at"],
-            "last_error": dataplane["last_error"],
+            "last_error": effective_error,
+            "announcement_conflicts": announcement_conflicts,
+            "announcement_verification_required": verification_required,
+            "announcement_verified": announcement_verified,
         }
     )
 
@@ -2305,6 +2877,8 @@ def configure_node():
     app.logger.info("Action Request: Configuring Node")
     payload = request.get_json(silent=True) or {}
     node_type = str(payload.get("nodeType", "")).strip().lower()
+    confirmed = payload.get("confirmAddressChanges") is True
+    retain_tor = payload.get("retainTorAnnouncements", True) is not False
 
     if node_type not in ("lnd", "cln"):
         return jsonify({"success": False, "error": "Invalid nodeType. Use 'lnd' or 'cln'."}), 400
@@ -2341,17 +2915,25 @@ def configure_node():
 
     if SECURE_MODE:
         _, config_path = resolve_node_config(node_type)
-        config_lines = []
         if node_type == "lnd":
             config_lines = [
-                f"externalhosts={dns}:{port}"
+                f"externalhosts={dns}:{port}",
+                "nat=false",
             ]
+            cleanup_lines = ["externalip=", "nat=true", "nat=1"]
+            gossip_command = (
+                "docker exec lnd lncli peers updatenodeannouncement "
+                "--address_remove=<your-old-ip>:9735"
+            )
         else:
             config_lines = [
                 "bind-addr=0.0.0.0:9736",
                 f"announce-addr={dns}:{port}",
-                "always-use-proxy=false"
+                "ip-discovery=false",
+                "always-use-proxy=false",
             ]
+            cleanup_lines = ["announce-addr=<non-TunnelSats-address>", "ip-discovery=true"]
+            gossip_command = ""
 
         return jsonify({
             "success": True,
@@ -2359,6 +2941,13 @@ def configure_node():
             "node_type": node_type,
             "config_path": config_path,
             "config_lines": config_lines,
+            "cleanup_lines": cleanup_lines,
+            "gossip_command": gossip_command,
+            "retain_tor_supported": True,
+            "historical_warning": (
+                "Withdrawing an address updates live Lightning gossip, but third-party "
+                "explorers and historical collectors may retain addresses published earlier."
+            ),
             "port": port,
             "dns": dns
         })
@@ -2379,11 +2968,23 @@ def configure_node():
                 "dns": dns
             }), 422
 
-        lnd_processed, lnd_changed = upsert_config_line_in_section(
-            LND_CONFIG_PATH,
-            "[Application Options]",
-            "externalhosts=",
-            f"externalhosts={dns}:{port}",
+        audit = audit_node_announcement_config("lnd", LND_CONFIG_PATH, dns, port)
+        if audit["conflicts"] and not confirmed:
+            return jsonify({
+                "success": False,
+                "requires_confirmation": True,
+                "node_type": "lnd",
+                "conflicts": audit["conflicts"],
+                "retain_tor_supported": True,
+                "error": ANNOUNCEMENT_CONFLICT_ERROR,
+            }), 409
+        original_settings = [entry["line"] for entry in audit["settings"]]
+        if not _update_announcement_metadata(
+            meta_path, "lnd", backup_lines=original_settings, verification=None
+        ):
+            return jsonify({"success": False, "error": "Failed to back up LND announcement settings."}), 500
+        lnd_processed, lnd_changed, _ = apply_node_announcement_protection(
+            "lnd", LND_CONFIG_PATH, dns, port, retain_tor
         )
         if not lnd_processed:
             return jsonify({"success": False, "error": "Failed to modify LND config."}), 500
@@ -2392,12 +2993,32 @@ def configure_node():
             return jsonify({"success": False, "error": "Failed to restart LND container."}), 500
         _set_restart_pending(meta_path, meta, lnd_pending_key, False)
 
+        verified, removed, remaining = clean_and_verify_lnd_announcements(dns, port, retain_tor)
+        verification = {
+            "endpoint": f"{dns}:{port}",
+            "verified": verified,
+            "checkedAt": datetime.now(timezone.utc).isoformat(),
+            "removed": removed,
+            "remainingConflicts": remaining,
+        }
+        if not _update_announcement_metadata(meta_path, "lnd", verification=verification):
+            return jsonify({"success": False, "error": "Failed to save LND announcement verification."}), 500
+        if not verified:
+            return jsonify({
+                "success": False,
+                "error": ANNOUNCEMENT_VERIFICATION_ERROR,
+                "removed_addresses": removed,
+                "remaining_conflicts": remaining,
+            }), 500
+
         return jsonify(
             {
                 "success": True,
                 "lnd": True,
                 "cln": False,
                 "lnd_changed": lnd_changed,
+                "announcement_verified": True,
+                "removed_addresses": removed,
                 "port": port,
                 "dns": dns,
             }
@@ -2416,13 +3037,23 @@ def configure_node():
             "dns": dns
         }), 422
 
-    cln_steps = (
-        ("bind-addr=", "bind-addr=0.0.0.0:9736"),
-        ("announce-addr=", f"announce-addr={dns}:{port}"),
-        ("always-use-proxy=", "always-use-proxy=false"),
-    )
     cln_container_config, _ = resolve_node_config("cln")
-    cln_processed, cln_changed = upsert_config_lines(cln_container_config, cln_steps)
+    audit = audit_node_announcement_config("cln", cln_container_config, dns, port)
+    if audit["conflicts"] and not confirmed:
+        return jsonify({
+            "success": False,
+            "requires_confirmation": True,
+            "node_type": "cln",
+            "conflicts": audit["conflicts"],
+            "retain_tor_supported": True,
+            "error": ANNOUNCEMENT_CONFLICT_ERROR,
+        }), 409
+    original_settings = [entry["line"] for entry in audit["settings"]]
+    if not _update_announcement_metadata(meta_path, "cln", backup_lines=original_settings):
+        return jsonify({"success": False, "error": "Failed to back up CLN announcement settings."}), 500
+    cln_processed, cln_changed, _ = apply_node_announcement_protection(
+        "cln", cln_container_config, dns, port, retain_tor
+    )
     if not cln_processed:
         return jsonify({"success": False, "error": "Failed to modify CLN config."}), 500
 
@@ -2456,8 +3087,13 @@ def restore_node():
                 "node_type": "lnd",
                 "config_path": lnd_path,
                 "config_lines": [
-                    "externalhosts="
-                ]
+                    "externalhosts=",
+                    "nat=false",
+                ],
+                "restore_notes": [
+                    "Only re-enable old externalip or nat settings you deliberately want to publish.",
+                    "Previously published IP addresses may remain in third-party historical snapshots.",
+                ],
             })
         if cln_detected:
             _, cln_path = resolve_node_config("cln")
@@ -2467,8 +3103,12 @@ def restore_node():
                 "config_lines": [
                     "bind-addr=",
                     "announce-addr=",
-                    "always-use-proxy="
-                ]
+                    "ip-discovery=false",
+                    "always-use-proxy=",
+                ],
+                "restore_notes": [
+                    "Only re-enable old announce-addr or ip-discovery settings you deliberately want to publish."
+                ],
             })
         return jsonify({
             "success": True,
@@ -2482,13 +3122,32 @@ def restore_node():
     lnd_detected = lnd_exists()
     cln_detected = cln_exists()
 
-    lnd_processed, lnd_changed = comment_out_config_lines(
-        LND_CONFIG_PATH,
-        (
-            "externalhosts=",
-            "tor.skip-proxy-for-clearnet-targets=",
-        ),
-    )
+    meta_path = os.path.join(DATA_DIR, META_FILE)
+    meta: Dict[str, Any] = {}
+    try:
+        with _metadata_lock:
+            with open(meta_path, "r", encoding="utf-8") as meta_fp:
+                loaded_meta = json.load(meta_fp)
+                if isinstance(loaded_meta, dict):
+                    meta = loaded_meta
+    except (FileNotFoundError, IOError, OSError, json.JSONDecodeError):
+        pass
+    dns = str(meta.get("serverDomain", "")).strip()
+    try:
+        port = int(meta.get("vpnPort", 0))
+    except (TypeError, ValueError):
+        port = 0
+
+    lnd_backup = _backup_lines_from_meta(meta, "lnd")
+    if lnd_backup is None:
+        lnd_processed, lnd_changed = comment_out_config_lines(
+            LND_CONFIG_PATH,
+            ("externalhosts=", "tor.skip-proxy-for-clearnet-targets="),
+        )
+    else:
+        lnd_processed, lnd_changed = restore_node_announcement_config(
+            "lnd", LND_CONFIG_PATH, lnd_backup, dns, port
+        )
     if lnd_processed and lnd_detected:
         if not restart_container_by_pattern(LND_CONTAINER_PATTERN, is_lnd=True):
             errors.append("Failed to restart LND container.")
@@ -2496,14 +3155,16 @@ def restore_node():
         app.logger.info("LND config restored, but no running LND container detected. Skipping restart.")
 
     cln_container_config, _ = resolve_node_config("cln")
-    cln_processed, cln_changed = comment_out_config_lines(
-        cln_container_config,
-        (
-            "bind-addr=",
-            "announce-addr=",
-            "always-use-proxy=",
-        ),
-    )
+    cln_backup = _backup_lines_from_meta(meta, "cln")
+    if cln_backup is None:
+        cln_processed, cln_changed = comment_out_config_lines(
+            cln_container_config,
+            ("bind-addr=", "announce-addr=", "always-use-proxy="),
+        )
+    else:
+        cln_processed, cln_changed = restore_node_announcement_config(
+            "cln", cln_container_config, cln_backup, dns, port
+        )
     if cln_processed and cln_detected:
         if not restart_container_by_pattern(CLN_CONTAINER_PATTERN):
             errors.append("Failed to restart CLN container.")
@@ -2512,6 +3173,12 @@ def restore_node():
 
     if errors:
         return jsonify({"success": False, "error": " ".join(errors)}), 500
+
+    if meta:
+        if lnd_processed:
+            _update_announcement_metadata(meta_path, "lnd", clear_backup=True, verification=None)
+        if cln_processed:
+            _update_announcement_metadata(meta_path, "cln", clear_backup=True)
 
     return jsonify(
         {

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -25,6 +25,14 @@ def clear_caches():
         app_module._in_flight_probes.clear()
     yield
 
+
+@pytest.fixture(autouse=True)
+def mock_lnd_announcement_cleanup():
+    """Keep legacy endpoint tests focused; privacy-specific tests override this result."""
+    original = app_module.clean_and_verify_lnd_announcements
+    with patch('app.clean_and_verify_lnd_announcements', return_value=(True, [], [])) as mocked:
+        yield mocked, original
+
 @pytest.fixture
 def client():
     app.config['TESTING'] = True
@@ -1491,7 +1499,10 @@ class TestDataplaneAndRegressionFixes:
             with patch('app.DATA_DIR', tmp_dir):
                 with patch('app.CLN_CONFIG_PATH', cln_path):
                     with patch('app.restart_container_by_pattern', return_value=True) as mock_restart:
-                        res = client.post('/api/local/configure-node', json={'nodeType': 'cln'})
+                        res = client.post('/api/local/configure-node', json={
+                            'nodeType': 'cln',
+                            'confirmAddressChanges': True,
+                        })
 
             assert res.status_code == 200
             payload = json.loads(res.data)
@@ -1528,7 +1539,10 @@ class TestDataplaneAndRegressionFixes:
             with patch('app.DATA_DIR', tmp_dir):
                 with patch('app.CLN_CONFIG_PATH', cln_path):
                     with patch('app.restart_container_by_pattern', return_value=True):
-                        res = client.post('/api/local/configure-node', json={'nodeType': 'cln'})
+                        res = client.post('/api/local/configure-node', json={
+                            'nodeType': 'cln',
+                            'confirmAddressChanges': True,
+                        })
 
             assert res.status_code == 200
             with open(cln_path, 'r') as f:
@@ -1537,7 +1551,8 @@ class TestDataplaneAndRegressionFixes:
             assert cln_content.count('announce-addr=de2.tunnelsats.com:35825\n') == 1
             assert cln_content.count('always-use-proxy=false\n') == 1
             assert cln_content.count('bind-addr=0.0.0.0:9736\n') == 1
-            assert 'old.tunnelsats.com' not in cln_content
+            assert '\nannounce-addr=old.tunnelsats.com' not in cln_content
+            assert '# TunnelSats disabled: announce-addr=old.tunnelsats.com:2222' in cln_content
 
     @patch('app.container_ids_by_match', return_value=['mock'])
     def test_configure_node_cln_leaves_file_unchanged_when_atomic_write_fails(self, mock_ids, client):
@@ -1559,12 +1574,15 @@ class TestDataplaneAndRegressionFixes:
                 with patch('app.CLN_CONFIG_PATH', cln_path):
                     with patch('app.os.replace', side_effect=OSError('replace failed')):
                         with patch('app.restart_container_by_pattern', return_value=True) as mock_restart:
-                            res = client.post('/api/local/configure-node', json={'nodeType': 'cln'})
+                            res = client.post('/api/local/configure-node', json={
+                                'nodeType': 'cln',
+                                'confirmAddressChanges': True,
+                            })
 
             assert res.status_code == 500
             payload = json.loads(res.data)
             assert payload['success'] is False
-            assert payload['error'] == 'Failed to modify CLN config.'
+            assert payload['error'] == 'Failed to back up CLN announcement settings.'
             mock_restart.assert_not_called()
 
             with open(cln_path, 'r') as f:
@@ -1591,7 +1609,7 @@ class TestDataplaneAndRegressionFixes:
             payload = json.loads(res.data)
             assert payload['success'] is True
             assert payload['lnd'] is True
-            assert payload['lnd_changed'] is False
+            assert payload['lnd_changed'] is True
             mock_restart.assert_called_once_with(app_module.LND_CONTAINER_PATTERN, is_lnd=True)
 
     @patch('app.container_ids_by_match', return_value=['mock'])
@@ -1640,7 +1658,7 @@ class TestDataplaneAndRegressionFixes:
             assert res.status_code == 200
             payload = json.loads(res.data)
             assert payload['success'] is True
-            assert payload['lnd_changed'] is False
+            assert payload['lnd_changed'] is True
             mock_restart.assert_called_once_with(app_module.LND_CONTAINER_PATTERN, is_lnd=True)
 
             with open(meta_path, 'r') as f:
@@ -1972,6 +1990,249 @@ class TestDataplaneAndRegressionFixes:
                 assert res.status_code == 200
                 with open(meta_path, 'r') as f:
                     assert json.load(f) == []
+
+
+class TestAnnouncementPrivacy:
+    @patch('app.container_ids_by_match', return_value=['mock'])
+    def test_lnd_conflicts_require_confirmation_then_backup_disable_and_restore(
+        self, _mock_ids, mock_lnd_announcement_cleanup, client
+    ):
+        cleanup_mock, _original_cleanup = mock_lnd_announcement_cleanup
+        cleanup_mock.return_value = (True, ['198.51.100.10:9735'], [])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            meta_path = os.path.join(tmp_dir, app_module.META_FILE)
+            lnd_path = os.path.join(tmp_dir, 'lnd.conf')
+            original = (
+                '[Application Options]\n'
+                'externalip=198.51.100.10:9735\n'
+                'externalip=203.0.113.9:9735\n'
+                'externalip=examplehiddenservice.onion:9735\n'
+                'externalhosts=old.example.com:9735\n'
+                'nat=1\n'
+                'nat=true # automatic discovery'
+            )
+            with open(meta_path, 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+            with open(lnd_path, 'w') as f:
+                f.write(original)
+
+            with patch('app.DATA_DIR', tmp_dir), patch('app.LND_CONFIG_PATH', lnd_path), \
+                    patch('app.restart_container_by_pattern', return_value=True):
+                blocked = client.post('/api/local/configure-node', json={'nodeType': 'lnd'})
+                assert blocked.status_code == 409
+                assert json.loads(blocked.data)['requires_confirmation'] is True
+                with open(lnd_path) as f:
+                    assert f.read() == original
+
+                configured = client.post('/api/local/configure-node', json={
+                    'nodeType': 'lnd',
+                    'confirmAddressChanges': True,
+                    'retainTorAnnouncements': True,
+                })
+                assert configured.status_code == 200
+
+                with open(lnd_path) as f:
+                    protected = f.read()
+                assert '# TunnelSats disabled: externalip=198.51.100.10:9735' in protected
+                assert '# TunnelSats disabled: externalip=203.0.113.9:9735' in protected
+                assert 'externalip=examplehiddenservice.onion:9735\n' in protected
+                assert 'externalhosts=de2.tunnelsats.com:35825\n' in protected
+                assert 'nat=false\n' in protected
+                assert '\nnat=1\n' not in protected
+                assert '# TunnelSats disabled: nat=true # automatic discovery\n' in protected
+
+                with open(meta_path) as f:
+                    protected_meta = json.load(f)
+                assert protected_meta['backupConfig']['lnd']['lines'] == [
+                    'externalip=198.51.100.10:9735',
+                    'externalip=203.0.113.9:9735',
+                    'externalip=examplehiddenservice.onion:9735',
+                    'externalhosts=old.example.com:9735',
+                    'nat=1',
+                    'nat=true # automatic discovery',
+                ]
+                assert protected_meta['lndAnnouncementVerification']['verified'] is True
+                cleanup_mock.assert_called_once_with('de2.tunnelsats.com', 35825, True)
+
+                restored = client.post('/api/local/restore-node')
+                assert restored.status_code == 200
+                with open(lnd_path) as f:
+                    restored_content = f.read()
+                for expected in original.splitlines()[1:]:
+                    assert f'\n{expected}\n' in restored_content
+                assert '\nexternalhosts=de2.tunnelsats.com:35825\n' not in restored_content
+                with open(meta_path) as f:
+                    restored_meta = json.load(f)
+                assert 'backupConfig' not in restored_meta
+                assert 'lndAnnouncementVerification' not in restored_meta
+
+    @patch('app.container_ids_by_match', return_value=['mock'])
+    def test_cln_discovery_and_clearnet_announcement_require_confirmation(self, _mock_ids, client):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            meta_path = os.path.join(tmp_dir, app_module.META_FILE)
+            cln_path = os.path.join(tmp_dir, 'config')
+            with open(meta_path, 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+            with open(cln_path, 'w') as f:
+                f.write(
+                    'announce-addr=198.51.100.20:9735\n'
+                    'announce-addr=keepme.onion:9735\n'
+                    'ip-discovery=true\n'
+                )
+
+            with patch('app.DATA_DIR', tmp_dir), patch('app.CLN_CONFIG_PATH', cln_path), \
+                    patch('app.restart_container_by_pattern', return_value=True):
+                blocked = client.post('/api/local/configure-node', json={'nodeType': 'cln'})
+                payload = json.loads(blocked.data)
+                assert blocked.status_code == 409
+                assert payload['conflicts'] == [
+                    'announce-addr=198.51.100.20:9735',
+                    'ip-discovery=true',
+                ]
+                configured = client.post('/api/local/configure-node', json={
+                    'nodeType': 'cln',
+                    'confirmAddressChanges': True,
+                    'retainTorAnnouncements': True,
+                })
+                assert configured.status_code == 200
+
+                with open(cln_path) as f:
+                    first_configured_content = f.read()
+                configured_again = client.post('/api/local/configure-node', json={'nodeType': 'cln'})
+                assert configured_again.status_code == 200
+                assert json.loads(configured_again.data)['cln_changed'] is False
+                with open(cln_path) as f:
+                    assert f.read() == first_configured_content
+
+            with open(cln_path) as f:
+                content = f.read()
+            assert '\nannounce-addr=198.51.100.20:9735\n' not in content
+            assert 'announce-addr=keepme.onion:9735\n' in content
+            assert 'announce-addr=de2.tunnelsats.com:35825\n' in content
+            assert 'ip-discovery=false\n' in content
+
+    def test_live_lnd_cleanup_withdraws_real_address_and_verifies_again(
+        self, mock_lnd_announcement_cleanup
+    ):
+        _cleanup_mock, original_cleanup = mock_lnd_announcement_cleanup
+        first = json.dumps({'uris': [
+            'pubkey@198.51.100.10:9735',
+            'pubkey@nodehidden.onion:9735',
+            'pubkey@de2.tunnelsats.com:35825',
+        ]})
+        final = json.dumps({'uris': [
+            'pubkey@nodehidden.onion:9735',
+            'pubkey@de2.tunnelsats.com:35825',
+        ]})
+        with patch('app.container_id_by_match', return_value='container123'), \
+                patch('app.docker_exec', side_effect=[
+                    (True, first),
+                    (True, ''),
+                    (True, final),
+                ]) as exec_mock:
+            result = original_cleanup('de2.tunnelsats.com', 35825, True)
+
+        assert result == (True, ['198.51.100.10:9735'], [])
+        assert exec_mock.call_args_list[1].args[1] == [
+            'lncli', 'peers', 'updatenodeannouncement',
+            '--address_remove=198.51.100.10:9735',
+        ]
+
+    def test_status_fails_closed_on_active_lnd_announcement_conflicts(self, client):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lnd_path = os.path.join(tmp_dir, 'lnd.conf')
+            with open(lnd_path, 'w') as f:
+                f.write(
+                    '[Application Options]\n'
+                    'externalhosts=de2.tunnelsats.com:35825\n'
+                    'externalip=198.51.100.42:9735\n'
+                    'nat=true\n'
+                )
+            with open(os.path.join(tmp_dir, app_module.META_FILE), 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+            dataplane = app_module.read_dataplane_state()
+            dataplane.update({'rules_synced': True, 'last_error': None})
+            containers = [{
+                'Names': ['/lightning_lnd_1'], 'Id': 'lnd1',
+                'NetworkSettings': {'Networks': {'main': {'IPAddress': '10.21.21.9'}}},
+            }]
+            run_result = MagicMock(returncode=1, stdout='')
+            with patch('app.DATA_DIR', tmp_dir), patch('app.LND_CONFIG_PATH', lnd_path), \
+                    patch('app._get_wireguard_state', return_value=('Connected', '')), \
+                    patch('app.list_containers', return_value=containers), \
+                    patch('app.read_dataplane_state', return_value=dataplane), \
+                    patch('app.subprocess.run', return_value=run_result):
+                response = client.get('/api/local/status')
+
+        payload = json.loads(response.data)
+        assert payload['rules_synced'] is False
+        assert payload['last_error'] == app_module.ANNOUNCEMENT_CONFLICT_ERROR
+        assert payload['announcement_conflicts'] == [
+            'lnd:externalip=198.51.100.42:9735',
+            'lnd:nat=true',
+        ]
+
+    def test_status_requires_endpoint_bound_rpc_verification_and_secure_mode_stays_unverified(self, client):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            lnd_path = os.path.join(tmp_dir, 'lnd.conf')
+            meta_path = os.path.join(tmp_dir, app_module.META_FILE)
+            with open(lnd_path, 'w') as f:
+                f.write(
+                    '[Application Options]\n'
+                    'externalhosts=de2.tunnelsats.com:35825\n'
+                    'nat=false\n'
+                )
+            with open(meta_path, 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+            dataplane = app_module.read_dataplane_state()
+            dataplane.update({'rules_synced': True, 'last_error': None})
+            containers = [{
+                'Names': ['/lightning_lnd_1'], 'Id': 'lnd1',
+                'NetworkSettings': {'Networks': {'main': {'IPAddress': '10.21.21.9'}}},
+            }]
+            common_patches = (
+                patch('app.DATA_DIR', tmp_dir),
+                patch('app.LND_CONFIG_PATH', lnd_path),
+                patch('app._get_wireguard_state', return_value=('Connected', '')),
+                patch('app.list_containers', return_value=containers),
+                patch('app.read_dataplane_state', return_value=dataplane),
+                patch('app.subprocess.run', return_value=MagicMock(returncode=1, stdout='')),
+            )
+            with common_patches[0], common_patches[1], common_patches[2], \
+                    common_patches[3], common_patches[4], common_patches[5]:
+                unverified = json.loads(client.get('/api/local/status').data)
+
+            assert unverified['rules_synced'] is False
+            assert unverified['last_error'] == app_module.ANNOUNCEMENT_VERIFICATION_ERROR
+
+            with open(meta_path, 'w') as f:
+                json.dump({
+                    'vpnPort': 35825,
+                    'serverDomain': 'de2.tunnelsats.com',
+                    'lndAnnouncementVerification': {
+                        'verified': True,
+                        'endpoint': 'de2.tunnelsats.com:35825',
+                    },
+                }, f)
+            with patch('app.DATA_DIR', tmp_dir), patch('app.LND_CONFIG_PATH', lnd_path), \
+                    patch('app._get_wireguard_state', return_value=('Connected', '')), \
+                    patch('app.list_containers', return_value=containers), \
+                    patch('app.read_dataplane_state', return_value=dataplane), \
+                    patch('app.subprocess.run', return_value=MagicMock(returncode=1, stdout='')):
+                verified = json.loads(client.get('/api/local/status').data)
+            assert verified['rules_synced'] is True
+            assert verified['announcement_verified'] is True
+
+            with patch('app.DATA_DIR', tmp_dir), patch('app.LND_CONFIG_PATH', lnd_path), \
+                    patch('app.SECURE_MODE', True), patch('app.lnd_exists', return_value=True), \
+                    patch('app.cln_exists', return_value=False), \
+                    patch('app._get_wireguard_state', return_value=('Connected', '')), \
+                    patch('app.read_dataplane_state', return_value=dataplane), \
+                    patch('app.subprocess.run', return_value=MagicMock(returncode=1, stdout='')):
+                secure = json.loads(client.get('/api/local/status').data)
+            assert secure['rules_synced'] is False
+            assert secure['announcement_verified'] is False
+            assert secure['last_error'] == app_module.ANNOUNCEMENT_VERIFICATION_ERROR
 
 class TestFullE2E_Workflow:
     @patch('app.requests.post')

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -2172,6 +2172,30 @@ class TestAnnouncementPrivacy:
             'lnd:nat=true',
         ]
 
+    def test_status_fails_closed_when_detected_lnd_config_is_unavailable(self, client):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            missing_lnd_path = os.path.join(tmp_dir, 'missing-lnd.conf')
+            with open(os.path.join(tmp_dir, app_module.META_FILE), 'w') as f:
+                json.dump({'vpnPort': 35825, 'serverDomain': 'de2.tunnelsats.com'}, f)
+            dataplane = app_module.read_dataplane_state()
+            dataplane.update({'rules_synced': True, 'last_error': None})
+            containers = [{
+                'Names': ['/lightning_lnd_1'], 'Id': 'lnd1',
+                'NetworkSettings': {'Networks': {'main': {'IPAddress': '10.21.21.9'}}},
+            }]
+            with patch('app.DATA_DIR', tmp_dir), \
+                    patch('app.LND_CONFIG_PATH', missing_lnd_path), \
+                    patch('app._get_wireguard_state', return_value=('Connected', '')), \
+                    patch('app.list_containers', return_value=containers), \
+                    patch('app.read_dataplane_state', return_value=dataplane), \
+                    patch('app.subprocess.run', return_value=MagicMock(returncode=1, stdout='')):
+                response = client.get('/api/local/status')
+
+        payload = json.loads(response.data)
+        assert payload['rules_synced'] is False
+        assert payload['last_error'] == app_module.ANNOUNCEMENT_CONFLICT_ERROR
+        assert payload['announcement_conflicts'] == ['lnd:config-unavailable']
+
     def test_status_requires_endpoint_bound_rpc_verification_and_secure_mode_stays_unverified(self, client):
         with tempfile.TemporaryDirectory() as tmp_dir:
             lnd_path = os.path.join(tmp_dir, 'lnd.conf')

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -1367,6 +1367,47 @@ describe('Phase 3b: Install Config', () => {
         );
     });
 
+    test('configureNode requires explicit confirmation before disabling conflicting announcements', async () => {
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce({
+                status: 409,
+                ok: false,
+                json: () => Promise.resolve({
+                    success: false,
+                    requires_confirmation: true,
+                    conflicts: ['externalip=198.51.100.10:9735', 'nat=true']
+                })
+            })
+            .mockResolvedValueOnce({
+                status: 200,
+                ok: true,
+                json: () => Promise.resolve({
+                    success: true,
+                    lnd: true,
+                    port: 35825,
+                    dns: 'de2.tunnelsats.com'
+                })
+            })
+            .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+        window.confirmAnnouncementChanges = jest.fn().mockResolvedValue({
+            confirmed: true,
+            retainTorAnnouncements: true
+        });
+
+        await window.configureNode();
+
+        expect(window.confirmAnnouncementChanges).toHaveBeenCalledWith('lnd', [
+            'externalip=198.51.100.10:9735',
+            'nat=true'
+        ]);
+        expect(global.fetch.mock.calls[1][0]).toBe('/api/local/configure-node');
+        expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
+            nodeType: 'lnd',
+            confirmAddressChanges: true,
+            retainTorAnnouncements: true
+        });
+    });
+
     test('configureNode handles HTML error pages gracefully without throwing syntax error', async () => {
         global.fetch.mockImplementationOnce((url) => {
             if (url === '/api/local/configure-node') {
@@ -1463,7 +1504,10 @@ describe('Phase 3b: Install Config', () => {
                         manual_mode: true,
                         node_type: 'lnd',
                         config_path: '/path/to/lnd.conf',
-                        config_lines: ['line1', 'line2']
+                        config_lines: ['externalhosts=de2.tunnelsats.com:35825', 'nat=false'],
+                        cleanup_lines: ['externalip=', 'nat=true'],
+                        gossip_command: 'docker exec lnd lncli peers updatenodeannouncement --address_remove=<your-old-ip>:9735',
+                        historical_warning: 'Historical collectors may retain old addresses.'
                     }),
                     ok: true
                 });
@@ -1477,7 +1521,10 @@ describe('Phase 3b: Install Config', () => {
         expect(modal).toBeTruthy();
         expect(modal.textContent).toContain('Manual Setup Required');
         expect(modal.textContent).toContain('/path/to/lnd.conf');
-        expect(modal.textContent).toContain('line1\nline2');
+        expect(modal.textContent).toContain('externalhosts=de2.tunnelsats.com:35825\nnat=false');
+        expect(modal.textContent).toContain('externalip=');
+        expect(modal.textContent).toContain('updatenodeannouncement');
+        expect(modal.textContent).toContain('Historical collectors');
 
         // Close modal
         const doneBtn = Array.from(modal.querySelectorAll('button')).find(btn => btn.textContent === 'Done');

--- a/web/index.html
+++ b/web/index.html
@@ -502,13 +502,15 @@
                     <div id="secure-mode-warning-box" class="hidden bg-yellow-950/30 border border-tsyellow/40 rounded-xl p-5 mb-6 text-sm text-gray-300 leading-relaxed shadow-lg">
                         <strong class="text-base text-tsyellow mb-2 flex items-center gap-1.5">⚠️ Action Required: Manual Configuration (Secure Mode)</strong>
                         <p class="mb-2">TunnelSats is running in Secure Mode (without root Docker socket access) to comply with Umbrel's security guidelines. Because of this sandbox isolation, <strong>you must manually edit your Lightning configuration file</strong> to announce your TunnelSats external IP and port.</p>
-                        <p class="mb-2 text-tsyellow"><strong>CRITICAL:</strong> If you skip this, your Lightning node will not broadcast its clearnet IP address to the network. As a result, other nodes will be unable to connect to you or open channels to you (inbound connections will fail).</p>
+                        <p class="mb-2 text-tsyellow"><strong>CRITICAL:</strong> Existing <code>externalip</code>, <code>nat=true</code>, <code>announce-addr</code>, or <code>ip-discovery=true</code> settings can keep publishing your real IP even when packet routing is protected. The generated instructions include mandatory cleanup and LND gossip-withdrawal steps.</p>
+                        <p class="mb-2 text-red-300">Removing a live announcement cannot erase historical IP snapshots retained by third-party explorers or gossip collectors.</p>
                         <p class="font-semibold text-white mb-1">How to apply:</p>
                         <ol class="list-decimal pl-5 space-y-1 text-gray-400">
                             <li>Select LND or CLN below and click <strong>Configure Node</strong> to fetch the exact configuration parameters.</li>
                             <li>Open the Umbrel <strong>Files</strong> app (or connect via SSH).</li>
                             <li>Navigate to the target file path shown in the instructions.</li>
-                            <li>Paste the configuration lines, save the file, and then restart your <strong>Lightning Node or Core Lightning</strong> app from the Umbrel dashboard.</li>
+                            <li>Disable the conflicting announcement/discovery lines shown in the privacy cleanup, add the TunnelSats lines, save, and restart your <strong>Lightning Node or Core Lightning</strong> app.</li>
+                            <li>For LND, withdraw every old clearnet address with the copyable <code>lncli peers updatenodeannouncement</code> command and verify the current <code>uris</code>.</li>
                         </ol>
                     </div>
 
@@ -802,6 +804,7 @@
                             <div class="text-sm text-gray-300 space-y-3 leading-relaxed">
                                 <p>To comply with Umbrel's official security rules, TunnelSats runs in a hardened sandbox (without root system access or direct access to the Docker socket). Consequently, it cannot write to your node's config files or trigger container restarts automatically.</p>
                                 <p class="text-tsyellow font-semibold">Without these manual config changes, your Lightning node will not broadcast its TunnelSats clearnet IP/port to the gossip network. This means other nodes will not know how to connect to you, and inbound channel opens will fail.</p>
+                                <p class="text-red-300 font-semibold">Before adding TunnelSats, remove/comment LND <code>externalip=</code> values and set <code>nat=false</code>, or remove non-TunnelSats CLN <code>announce-addr=</code> values and set <code>ip-discovery=false</code>. Deliberate Tor <code>.onion</code> announcements may be retained.</p>
                                 <h4 class="text-white font-semibold mt-4 mb-2">How to apply manually:</h4>
                                 <ol class="list-decimal pl-5 space-y-2">
                                     <li>Navigate to the <strong>Install</strong> tab, select your implementation, and click <strong>Configure Node</strong>.</li>
@@ -809,7 +812,9 @@
                                     <li>Open the Umbrel <strong>Files</strong> app, navigate to the config file (e.g. <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">~/umbrel/app-data/lightning/data/lnd/lnd.conf</code> for LND), paste the lines, and save.</li>
                                     <li>Alternatively, connect via SSH and edit the files using <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">nano</code> or <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">vim</code>.</li>
                                     <li>Go back to your Umbrel dashboard, open the <strong>Lightning Node</strong> or <strong>Core Lightning</strong> app settings, and click <strong>Restart</strong>.</li>
+                                    <li>For each old LND clearnet address, run <code class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">docker exec lnd lncli peers updatenodeannouncement --address_remove=&lt;old-ip&gt;:9735</code>, then inspect <code>docker exec lnd lncli getinfo</code>.</li>
                                 </ol>
+                                <p class="text-tsyellow">The withdrawal updates active gossip, but historical explorers and collectors may retain addresses that were published previously.</p>
 
                                 <h4 class="text-white font-semibold mt-4 mb-2">Running Diagnostic Verification:</h4>
                                 <p>To test inbound/outbound connectivity in Official Store installations (where host scripts are stripped for store compliance), run our verification script over SSH:</p>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -1363,6 +1363,71 @@ async function confirmRestartModal(nodeType) {
     });
 }
 
+async function confirmAnnouncementChanges(nodeType, conflicts) {
+    return new Promise((resolve) => {
+        const { overlay, panel, mountAndAnimate } = createModalOverlay('announcement-confirmation-modal');
+        let settled = false;
+        const complete = (confirmed, retainTorAnnouncements = true) => {
+            if (settled) return;
+            settled = true;
+            overlay.remove();
+            resolve({ confirmed, retainTorAnnouncements });
+        };
+
+        const title = document.createElement('h3');
+        title.className = 'text-xl font-bold text-white mb-4';
+        title.textContent = 'Real-IP announcement conflict detected';
+
+        const body = document.createElement('p');
+        body.className = 'text-sm text-gray-300 leading-relaxed mb-4';
+        body.textContent = `TunnelSats found ${nodeType.toUpperCase()} settings that can publish a non-TunnelSats address. Continuing will back up and disable these user-owned settings before restarting the node.`;
+
+        const list = document.createElement('ul');
+        list.className = 'list-disc pl-5 space-y-1 text-sm font-mono text-red-300 mb-4 break-all';
+        (Array.isArray(conflicts) ? conflicts : []).forEach((conflict) => {
+            const item = document.createElement('li');
+            item.textContent = conflict;
+            list.appendChild(item);
+        });
+
+        const torLabel = document.createElement('label');
+        torLabel.className = 'flex items-start gap-3 rounded-lg border border-gray-800 bg-black/30 p-3 text-sm text-gray-300 mb-4 cursor-pointer';
+        const torCheckbox = document.createElement('input');
+        torCheckbox.type = 'checkbox';
+        torCheckbox.checked = true;
+        torCheckbox.className = 'mt-1';
+        const torText = document.createElement('span');
+        torText.textContent = 'Retain existing Tor .onion announcements. Uncheck to disable and back them up too.';
+        torLabel.append(torCheckbox, torText);
+
+        const history = document.createElement('p');
+        history.className = 'text-xs text-tsyellow leading-relaxed mb-6';
+        history.textContent = 'This withdraws addresses from current gossip, but third-party explorers and historical collectors may retain earlier snapshots.';
+
+        const actions = document.createElement('div');
+        actions.className = 'flex gap-3';
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'flex-1 rounded-xl border border-gray-700 px-4 py-3 text-sm font-bold text-gray-300';
+        cancelBtn.textContent = 'Cancel';
+        const confirmBtn = document.createElement('button');
+        confirmBtn.type = 'button';
+        confirmBtn.className = 'flex-1 rounded-xl bg-red-500 px-4 py-3 text-sm font-bold text-white';
+        confirmBtn.textContent = 'Back Up & Disable';
+        actions.append(cancelBtn, confirmBtn);
+
+        cancelBtn.addEventListener('click', () => complete(false));
+        confirmBtn.addEventListener('click', () => complete(true, torCheckbox.checked));
+        overlay.addEventListener('click', (event) => {
+            if (event.target === overlay) complete(false);
+        });
+
+        panel.append(title, body, list, torLabel, history, actions);
+        mountAndAnimate();
+        confirmBtn.focus();
+    });
+}
+
 function createModalOverlay(id) {
     const existingModal = document.getElementById(id);
     if (existingModal) {
@@ -1399,7 +1464,7 @@ function createModalOverlay(id) {
     return { overlay, panel, closeModal, mountAndAnimate };
 }
 
-function showManualConfigModal(nodeType, path, lines) {
+function showManualConfigModal(nodeType, path, lines, cleanupLines = [], gossipCommand = '', historicalWarning = '') {
     const { overlay, panel, closeModal, mountAndAnimate } = createModalOverlay('manual-config-modal');
 
     const title = document.createElement('h3');
@@ -1442,6 +1507,40 @@ function showManualConfigModal(nodeType, path, lines) {
     copyLinesBtn.textContent = 'Copy Configuration Lines';
     copyLinesBtn.addEventListener('click', () => copyToClipboard(linesContent, 'Configuration lines'));
 
+    const privacyBox = document.createElement('div');
+    privacyBox.className = 'rounded-xl border border-red-500/40 bg-red-950/20 p-4 mb-6 text-sm text-gray-300 space-y-3';
+    const privacyTitle = document.createElement('p');
+    privacyTitle.className = 'font-bold text-red-300';
+    privacyTitle.textContent = 'Required privacy cleanup';
+    privacyBox.appendChild(privacyTitle);
+    if (cleanupLines.length > 0) {
+        const cleanupList = document.createElement('ul');
+        cleanupList.className = 'list-disc pl-5 space-y-1 font-mono text-xs break-all';
+        cleanupLines.forEach((line) => {
+            const item = document.createElement('li');
+            item.textContent = `Remove/comment or disable: ${line}`;
+            cleanupList.appendChild(item);
+        });
+        privacyBox.appendChild(cleanupList);
+    }
+    if (gossipCommand) {
+        const command = document.createElement('pre');
+        command.className = 'bg-black/60 border border-gray-800 rounded-lg p-3 text-xs text-tsgreen overflow-x-auto whitespace-pre-wrap break-all';
+        command.textContent = gossipCommand;
+        const copyCommand = document.createElement('button');
+        copyCommand.type = 'button';
+        copyCommand.className = 'w-full rounded-lg border border-gray-700 py-2 text-xs font-bold text-gray-200';
+        copyCommand.textContent = 'Copy gossip-withdrawal command';
+        copyCommand.addEventListener('click', () => copyToClipboard(gossipCommand, 'Gossip-withdrawal command'));
+        privacyBox.append(command, copyCommand);
+    }
+    if (historicalWarning) {
+        const warning = document.createElement('p');
+        warning.className = 'text-xs text-tsyellow leading-relaxed';
+        warning.textContent = historicalWarning;
+        privacyBox.appendChild(warning);
+    }
+
     const instructionsHeader = document.createElement('p');
     instructionsHeader.className = 'font-bold text-sm text-white mb-2';
     instructionsHeader.textContent = 'Instructions:';
@@ -1452,14 +1551,18 @@ function showManualConfigModal(nodeType, path, lines) {
         ol.innerHTML = `
             <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
             <li>Navigate to the configuration file path shown above.</li>
-            <li>Add (or update if already present) the configuration line under the existing <b>[Application Options]</b> section (do not create a duplicate section header or duplicate lines).</li>
+            <li>Remove/comment every active <code>externalip=</code> line and set <code>nat=false</code>. You may retain deliberate <code>.onion</code> announcements.</li>
+            <li>Add or update the TunnelSats lines under the existing <b>[Application Options]</b> section (do not create duplicate lines).</li>
             <li>Go back to the Umbrel dashboard and restart your <b>Lightning Node</b> app.</li>
+            <li>For every previously announced clearnet address, replace the placeholder in the command above and run it over SSH.</li>
+            <li>Run <code>docker exec lnd lncli getinfo</code> and verify that <code>uris</code> contains only the intended TunnelSats and retained Tor addresses.</li>
         `;
     } else {
         ol.innerHTML = `
             <li>Open the Umbrel <b>Files</b> app (or use SSH).</li>
             <li>Navigate to the configuration file path shown above.</li>
-            <li>Add (or update if already present) each configuration line shown above (do not create duplicate lines).</li>
+            <li>Remove/comment non-TunnelSats <code>announce-addr=</code> lines, retain deliberate <code>.onion</code> values if desired, and disable <code>ip-discovery</code>.</li>
+            <li>Add or update each TunnelSats configuration line shown above (do not create duplicate lines).</li>
             <li>Go back to the Umbrel dashboard and restart your <b>Core Lightning</b> app.</li>
         `;
     }
@@ -1469,7 +1572,7 @@ function showManualConfigModal(nodeType, path, lines) {
     doneBtn.textContent = 'Done';
     doneBtn.addEventListener('click', closeModal);
 
-    panel.append(title, desc, pathLabel, pathValContainer, linesLabel, pre, copyLinesBtn, instructionsHeader, ol, doneBtn);
+    panel.append(title, desc, pathLabel, pathValContainer, linesLabel, pre, copyLinesBtn, privacyBox, instructionsHeader, ol, doneBtn);
     mountAndAnimate();
 }
 
@@ -1526,7 +1629,15 @@ function showManualRestoreModal(targets) {
             linesList.appendChild(li);
         });
 
-        itemDiv.append(nodeLabel, pathValContainer, linesLabel, linesList);
+        const notesList = document.createElement('ul');
+        notesList.className = 'list-disc pl-5 mt-3 text-xs text-tsyellow space-y-1';
+        (Array.isArray(t.restore_notes) ? t.restore_notes : []).forEach((note) => {
+            const li = document.createElement('li');
+            li.textContent = note;
+            notesList.appendChild(li);
+        });
+
+        itemDiv.append(nodeLabel, pathValContainer, linesLabel, linesList, notesList);
         container.appendChild(itemDiv);
     });
 
@@ -1604,17 +1715,42 @@ async function configureNode() {
     setActionMessage('configure-node-msg', 'Applying node configuration...', 'info');
 
     try {
-        const res = await fetch('/api/local/configure-node', {
+        let res = await fetch('/api/local/configure-node', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ nodeType: selectedNodeType })
         });
-        const data = await safeFetchJson(res);
+        let data = await safeFetchJson(res);
+
+        if (res.status === 409 && data.requires_confirmation === true) {
+            const decision = await confirmAnnouncementChanges(selectedNodeType, data.conflicts);
+            if (!decision.confirmed) {
+                setActionMessage('configure-node-msg', 'Configuration cancelled; existing announcement settings were not changed.', 'info');
+                return;
+            }
+            res = await fetch('/api/local/configure-node', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    nodeType: selectedNodeType,
+                    confirmAddressChanges: true,
+                    retainTorAnnouncements: decision.retainTorAnnouncements
+                })
+            });
+            data = await safeFetchJson(res);
+        }
 
         if (res.ok && data.success !== false) {
             if (data.manual_mode) {
                 setActionMessage('configure-node-msg', 'Manual configuration required.', 'info');
-                showManualConfigModal(data.node_type, data.config_path, data.config_lines);
+                showManualConfigModal(
+                    data.node_type,
+                    data.config_path,
+                    data.config_lines,
+                    data.cleanup_lines,
+                    data.gossip_command,
+                    data.historical_warning
+                );
             } else {
                 const location = data.dns && data.port ? `${data.dns}:${data.port}` : 'configured endpoint';
                 setActionMessage('configure-node-msg', `Node configured successfully: ${location}`, 'success');


### PR DESCRIPTION
Closes #126.

Implements the consensus plan from the linked TrezorHannes issue comment:
- audits and disables conflicting LND and CLN announcement settings with explicit confirmation
- backs up original settings once and restores only that saved set
- withdraws stale LND clearnet URIs through authenticated lncli and verifies the resulting live URI set
- preserves requested Tor announcements
- keeps protected status fail-closed on config conflicts or missing LND gossip verification
- expands secure-mode manual cleanup, withdrawal, verification, and historical-gossip guidance

Validation:
- 223 backend tests passed
- 59 frontend tests passed
- 9 entrypoint logic checks passed
- Python and shell syntax checks passed
- local review/fix cycle completed with no remaining findings