### PR TITLE
fix(api): authenticate local management plane

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -20,8 +20,12 @@ Yes. The TunnelSats daemon handles dynamic reloading:
 The dashboard uses our internal **Dataplane API**. You can query this directly via SSH to debug your network state:
 
 ```bash
-curl -s http://umbrel.lan:9739/api/local/status | jq
+curl -su tunnelsats http://umbrel.lan:9739/api/local/status | jq
 ```
+
+Enter the per-app password shown in Umbrel's TunnelSats credentials panel.
+State-changing API calls also require the CSRF bootstrap flow documented in the
+repository README; an authenticated GET does not require a CSRF token.
 
 This returns a JSON payload containing the active WireGuard endpoint, internal routing metrics, and any failure logs (`last_error`). To check the live WireGuard handshake:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,44 @@ tunnel route is unavailable.
 
 ## 🛠 Architecture & Dataplane
 
+### Management API security
+
+The dashboard document and every local management endpoint require HTTP Basic
+authentication. On Umbrel, use the username `tunnelsats` and the per-app
+password shown in the app's credentials panel. The same credential is enforced
+by TunnelSats itself, so connecting directly to host port `9739` does not bypass
+authentication.
+
+Outside Umbrel, set a password of at least 24 characters with
+`MANAGEMENT_PASSWORD`. If neither `MANAGEMENT_PASSWORD` nor `APP_PASSWORD` is
+set, TunnelSats generates a random persistent password at
+`/data/management-password` with mode `0600`; retrieve it from the container
+console. Set `MANAGEMENT_ALLOWED_HOSTS` to a comma-separated list before using
+a LAN, Tailscale, ingress, or reverse-proxy hostname. Forwarded headers are
+ignored unless the direct proxy address is loopback or is explicitly listed as
+a CIDR in `MANAGEMENT_TRUSTED_PROXIES`. The bundled Umbrel compose already
+allows the device hostname, `.local` domain, and app Tor hidden service.
+
+All browser mutations additionally require a same-origin `Origin` and a CSRF
+token bound to a strict same-site cookie. For a CLI mutation, bootstrap a token
+and cookie first (the commands prompt for the password):
+
+```bash
+api_origin=http://127.0.0.1:9739
+cookie_jar=/tmp/tunnelsats-api-cookies
+csrf_token="$(curl -fsS -u tunnelsats -c "${cookie_jar}" \
+  "${api_origin}/api/local/session" | jq -r .csrf_token)"
+curl -fsS -u tunnelsats -b "${cookie_jar}" \
+  -H "Origin: ${api_origin}" \
+  -H "X-TunnelSats-CSRF-Token: ${csrf_token}" \
+  -X POST "${api_origin}/api/local/reconcile"
+```
+
+Keep port `9739` behind the intended authenticated proxy wherever the
+deployment permits it. A host firewall should limit direct access to trusted
+management sources; application authentication remains mandatory even on
+allowed networks.
+
 Because Umbrel is immutable, host-level WireGuard services and persistent host networking rules are not reliable across upgrades/reboots. This app keeps the full dataplane inside the app container and reconciles drift continuously.
 
 ### IPv6 policy: fail-closed denial
@@ -170,14 +208,10 @@ Target: us3.tunnelsats.com (178.156.167.202) : 12345
 [3/3] Testing Inbound Port (via Hostname)...    PASS (Connected to us3.tunnelsats.com:12345)
 ----------------------------------------------------------------
 ```
-- Check `GET /api/local/status` first to view the current `dataplane_mode` and `wg_status`.
+- Check `GET /api/local/status` first to view the current `dataplane_mode` and
+  `wg_status` (for example, `curl -su tunnelsats
+  http://127.0.0.1:9739/api/local/status`).
 - If `rules_synced` is `false`, inspect `ipv4_rules_synced`,
   `ipv6_rules_synced`, and `last_error` in the JSON response.
-- **Trigger immediate Dataplane repair:**
-  ```bash
-  curl -X POST http://127.0.0.1:9739/api/local/reconcile
-  ```
-- **Force full app-level restart:**
-  ```bash
-  curl -X POST http://127.0.0.1:9739/api/local/restart
-  ```
+- To trigger reconcile or restart from a CLI, use the authenticated CSRF flow
+  in **Management API security** above and change the final endpoint as needed.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,82 +1,70 @@
-# Issue #126 implementation plan: remove stale real-IP announcements
+# Issue #125 implementation plan: authenticate the management API
 
 ## Decision
 
-Treat Lightning gossip announcements as part of the protected state, independently
-from packet routing. TunnelSats must disable automatic or explicit clearnet
-announcement settings, withdraw stale LND gossip addresses when it has direct
-container access, and fail closed whenever the remaining state cannot be verified.
+Protect the management plane in the application itself so direct access to the
+host-network listener cannot bypass authentication. Umbrel deployments use the
+high-entropy per-app `APP_PASSWORD`; other deployments may provide an explicit
+credential or let TunnelSats create a persistent random credential in `/data`.
+HTTP source-address filtering remains defense in depth, never authorization.
 
 ## Security invariants
 
-- Never display `Protected` while an active LND `externalip`/`nat=true` or CLN
-  non-TunnelSats `announce-addr`/`ip-discovery=true` conflict is present.
-- Preserve explicitly retained Tor `.onion` announcements; remove other non-
-  TunnelSats public announcements.
-- Require an explicit privacy confirmation before changing user-owned address
-  discovery or announcement settings.
-- Save the original active settings only once in `backupConfig` and restore only
-  that saved set. Repeated configuration and restore operations remain idempotent.
-- In direct mode, do not mark LND gossip verified until `lncli getinfo` has been
-  queried after restart, every conflicting live URI has been withdrawn with
-  `peers updatenodeannouncement`, and a second query is clean.
-- In secure or k3s modes where authenticated LND RPC is unavailable, keep the
-  aggregate status in a warning state instead of trusting a manual confirmation.
-- Explain that withdrawing an address updates current gossip but cannot erase
-  historical snapshots held by third parties.
+- No `/api/local` response, subscription renewal/claim, or dashboard document is
+  available without a valid management credential.
+- Every state-changing management request requires a server-issued CSRF token
+  in both a same-site cookie and a custom request header.
+- Browser mutations require a non-null `Origin` whose authority matches the
+  validated request `Host`; both must resolve through an explicit deployment
+  allowlist.
+- Forwarded client, host, and scheme values are trusted only from explicitly
+  trusted reverse proxies. Direct callers cannot spoof `X-Forwarded-*` headers.
+- Missing, unreadable, or weak management credentials fail closed. Generated
+  credentials are random, persisted with mode `0600`, and never written to logs.
+- Security audit logs identify accepted administrative actions and fixed reject
+  reasons without recording authorization headers, CSRF values, request bodies,
+  WireGuard material, or other secrets.
 
 ## Implementation
 
-1. Add shared configuration parsing and atomic transformation helpers in
-   `server/app.py`.
-   - Audit active LND `externalip`, `externalhosts`, and `nat` values.
-   - Audit active CLN `announce-addr` and `ip-discovery` values.
-   - Classify TunnelSats and `.onion` endpoints separately from conflicting
-     clearnet endpoints.
-2. Harden direct-mode configuration.
-   - Return a conflict response until the caller confirms address changes.
-   - Persist original conflicting settings under `backupConfig.lnd` or
-     `backupConfig.cln` before editing the node config.
-   - Disable conflicting announcements/discovery, retain requested Tor entries,
-     and install only the intended TunnelSats announcement.
-   - Restart the selected node after the atomic config update.
-3. Purge and verify LND gossip in direct mode.
-   - Execute authenticated `lncli getinfo` inside the detected LND container.
-   - Remove each live non-TunnelSats, non-retained-Tor URI with
-     `lncli peers updatenodeannouncement --address_remove=...`.
-   - Query again and persist an endpoint-bound verification result. Return an
-     error and leave protection fail-closed if inspection, removal, or
-     verification fails.
-4. Make restore deliberate and idempotent.
-   - Disable TunnelSats-managed announcement lines.
-   - Restore exactly the settings captured in `backupConfig` and clear only the
-     successfully restored backup entry.
-   - Restart only detected node implementations whose config was processed.
-5. Improve secure-mode guidance.
-   - Tell LND users to remove/comment `externalip`, set `nat=false`, restart,
-     withdraw each old address with the copyable Umbrel `docker exec lnd lncli`
-     command, and verify live URIs.
-   - Tell CLN users to remove non-TunnelSats `announce-addr` values and disable
-     `ip-discovery` before restart.
-   - Include the historical-gossip retention warning in setup and restore UI.
-6. Gate local status.
-   - Audit readable node configs on every `/api/local/status` request.
-   - Override aggregate `rules_synced` and `last_error` when a config conflict
-     exists, direct-mode LND gossip has not been verified for the current
-     TunnelSats endpoint, or the deployment mode cannot perform that verification.
-   - Return structured announcement-conflict and verification fields for UI and
-     diagnostics while preserving existing dataplane fields.
-7. Add backend and frontend regression coverage for multiple values, `nat=true`
-   and `nat=1`, CLN discovery, confirmation, backup/restore, retained Tor,
-   already-advertised real addresses, RPC failure, secure-mode instructions, and
-   protected-status suppression.
+1. Add centralized management security middleware in `server/app.py`.
+   - Resolve the direct peer and forwarded values safely around `ProxyFix`.
+   - Keep the existing network allowlist as the first, secondary restriction.
+   - Validate `Host`, HTTP Basic credentials, CSRF, and `Origin` in that order.
+   - Return generic JSON errors, an appropriate Basic challenge, and no-store
+     response headers for protected API responses.
+2. Add credential and CSRF lifecycle support.
+   - Prefer `MANAGEMENT_PASSWORD`, then Umbrel `APP_PASSWORD`.
+   - Generate a persistent high-entropy password when neither is configured.
+   - Expose an authenticated session bootstrap endpoint that returns the
+     process-scoped CSRF token and sets a strict same-site cookie.
+3. Update the browser client.
+   - Route management requests through a shared fetch helper.
+   - Lazily bootstrap CSRF state and attach the token header to every mutation.
+   - Preserve existing confirmation flows and surface authentication failures
+     without leaking backend details.
+4. Harden deployment defaults and operational guidance.
+   - Pass Umbrel's per-app password plus its device hostnames to the container.
+   - Configure k3s with an operator-supplied Secret option, safe internal Host
+     defaults, and a default-deny ingress policy that only admits explicitly
+     labelled management clients.
+   - Document credential retrieval/rotation, additional allowed hosts, reverse
+     proxy trust, CSRF-aware CLI usage, and host-firewall recommendations.
+5. Add regression and security coverage.
+   - Cover valid, invalid, missing, weak, and generated credentials.
+   - Cover CSRF cookie/header binding, missing and cross-origin requests, Host
+     rejection, direct forwarded-header spoofing, and trusted proxy behavior.
+   - Demonstrate that an ordinary k3s pod source cannot read or mutate the API
+     without authentication, while an authenticated intended client can.
+   - Update frontend and manifest tests for the authenticated request flow and
+     deployment controls.
 
 ## Review gates
 
-1. Local review/fix cycle: inspect the complete branch diff for privacy leaks,
-   backup corruption, partial failure behavior, restore safety, parsing gaps,
-   command injection, status fail-open behavior, and missing tests; fix all
-   findings and rerun the full relevant test suite until clean.
-2. Greptile review/fix cycle: push the branch, open a pull request, request a
-   Greptile review, resolve every actionable finding, and repeat review/checks
-   until Greptile reports no findings.
+1. Local review/fix cycle: inspect the complete branch diff for authentication
+   bypasses, proxy trust mistakes, Host/Origin parsing gaps, CSRF bypasses,
+   fail-open configuration, secret disclosure, deployment lockouts, and missing
+   tests; fix every finding and rerun all relevant suites until clean.
+2. Greptile review/fix cycle: push the branch, open a pull request, request
+   `@greptileai review`, resolve every actionable inline or summary finding, and
+   repeat review/checks until Greptile reports no remaining findings.

--- a/k3s/README.md
+++ b/k3s/README.md
@@ -21,6 +21,40 @@ kubectl delete -k k3s/
 > carefully — they cover the errors you are most likely to hit on a first
 > install.
 
+## Management authentication and ingress
+
+The management API authenticates every read and mutation even though the pod
+uses `hostNetwork`. Before deploying, you may create a password Secret (use at
+least 24 characters):
+
+```sh
+kubectl create secret generic tunnelsats-management \
+  --from-literal=password='<replace-with-a-long-random-password>' \
+  -n <ns>
+```
+
+If the Secret is absent, TunnelSats creates a random password in the persistent
+volume at `/data/management-password`. Retrieve it with:
+
+```sh
+kubectl exec -n <ns> deploy/tunnelsats -- cat /data/management-password
+```
+
+The shipped ingress NetworkPolicy denies ordinary pods and permits TCP 9739
+only from same-namespace pods labelled
+`tunnelsats.io/management-client=true`. Label only the intended ingress or
+reverse proxy. For an ingress in another namespace, edit
+`networkpolicy.yaml` to add an exact namespace and pod selector. Because CNI
+handling of `hostNetwork` workloads varies, treat this policy as defense in
+depth: the application credential, Host allowlist, Origin check, and CSRF check
+remain authoritative.
+
+Add every external ingress hostname to `MANAGEMENT_ALLOWED_HOSTS` in
+`deployment.yaml`. If the proxy rewrites host, scheme, or client address, also
+set `MANAGEMENT_TRUSTED_PROXIES` to its narrow pod CIDR or address; never trust
+the whole cluster CIDR. Restrict node port 9739 with the host firewall when the
+cluster networking model exposes it beyond the intended proxy.
+
 ## 1. Namespace & RBAC
 
 TunnelSats discovers and restarts your LND/CLN pod through the Kubernetes API.

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -51,6 +51,19 @@ spec:
           env:
             - name: K3S_MODE
               value: "true"
+            # If this optional Secret is absent, TunnelSats creates a random
+            # persistent password at /data/management-password with mode 0600.
+            # See k3s/README.md for creation and retrieval instructions.
+            - name: MANAGEMENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tunnelsats-management
+                  key: password
+                  optional: true
+            # Add the external ingress hostname explicitly when using an ingress.
+            # Internal Service DNS variants are derived from K8S_NAMESPACE.
+            - name: MANAGEMENT_ALLOWED_HOSTS
+              value: "localhost,127.0.0.1,::1,tunnelsats"
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/k3s/kustomization.yaml
+++ b/k3s/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - pvc.yaml
   - deployment.yaml
   - service.yaml
+  - networkpolicy.yaml

--- a/k3s/networkpolicy.yaml
+++ b/k3s/networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tunnelsats-management-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: tunnelsats
+  policyTypes:
+    - Ingress
+  ingress:
+    # Label only the intended same-namespace ingress/proxy workload. Ordinary
+    # pods receive no network-level access to the management listener.
+    - from:
+        - podSelector:
+            matchLabels:
+              tunnelsats.io/management-client: "true"
+      ports:
+        - protocol: TCP
+          port: 9739

--- a/server/app.py
+++ b/server/app.py
@@ -527,7 +527,13 @@ def _read_or_create_management_password():
     if configured is None:
         configured = os.environ.get("MANAGEMENT_PASSWORD") or os.environ.get("APP_PASSWORD")
     if configured is not None:
-        return configured if _valid_management_password(configured) else None
+        if _valid_management_password(configured):
+            return configured
+        app.logger.warning(
+            "Supplied MANAGEMENT_PASSWORD/APP_PASSWORD is too short (minimum %d characters)",
+            MANAGEMENT_PASSWORD_MIN_LENGTH,
+        )
+        return None
 
     password_path = os.path.join(DATA_DIR, MANAGEMENT_PASSWORD_FILE)
     with _management_password_lock:
@@ -2309,7 +2315,12 @@ def restrict_local_api():
         return _management_security_error(503, "Management API unavailable")
     if not _management_credentials_are_valid():
         _audit_management_request("rejected", "credentials", effective_remote_addr)
-        return _management_security_error(401, "Unauthorized", challenge=True)
+        return _management_security_error(
+            401,
+            "Unauthorized",
+            challenge=True,
+            csrf_refresh=True,
+        )
 
     if _management_request_changes_state():
         supplied_csrf = request.headers.get(MANAGEMENT_CSRF_HEADER, "")

--- a/server/app.py
+++ b/server/app.py
@@ -1,7 +1,11 @@
 import json
 import os
 import re
+import base64
+import binascii
+import secrets
 import socket
+import stat
 import subprocess
 import uuid
 import threading
@@ -10,11 +14,11 @@ from datetime import datetime, timezone
 import time
 from ipaddress import ip_address, ip_network
 from typing import Dict, Any, List, Optional, Tuple, Iterable
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import requests
 import yaml
-from flask import Flask, abort, jsonify, request, send_from_directory
+from flask import Flask, g, jsonify, request, send_from_directory
 from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.utils import secure_filename
@@ -119,6 +123,16 @@ ANNOUNCEMENT_VERIFICATION_ERROR = (
 # k3s mode: set via env var K3S_MODE=true to use the Kubernetes API instead of the Docker socket
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
 SECURE_MODE = os.environ.get("SECURE_MODE", "false").lower() == "true"
+
+MANAGEMENT_USERNAME = os.environ.get("MANAGEMENT_USERNAME", "tunnelsats")
+MANAGEMENT_PASSWORD_FILE = "management-password"
+MANAGEMENT_PASSWORD_MIN_LENGTH = 24
+MANAGEMENT_CSRF_COOKIE = "tunnelsats_csrf"
+MANAGEMENT_CSRF_HEADER = "X-TunnelSats-CSRF-Token"
+MANAGEMENT_CSRF_REFRESH_HEADER = "X-TunnelSats-CSRF-Refresh"
+_management_password_lock = threading.Lock()
+_management_password_file_cache: Tuple[str, Optional[str]] = ("", None)
+_management_csrf_token = secrets.token_urlsafe(32)
 
 def check_tcp_port(ip, port):
     try:
@@ -340,6 +354,282 @@ def is_loopback_ip(remote_addr):
         return ip_address(remote_addr).is_loopback
     except ValueError:
         return False
+
+
+def _parse_networks(raw_networks):
+    parsed = []
+    for item in str(raw_networks or "").split(","):
+        item = item.strip()
+        if not item:
+            continue
+        try:
+            parsed.append(ip_network(item, strict=False))
+        except ValueError:
+            app.logger.error("Ignoring invalid management proxy network configuration")
+    return tuple(parsed)
+
+
+def _trusted_proxy_networks():
+    configured = app.config.get("MANAGEMENT_TRUSTED_PROXIES")
+    if configured is None:
+        configured = os.environ.get("MANAGEMENT_TRUSTED_PROXIES", "")
+    return (
+        ip_network("127.0.0.0/8"),
+        ip_network("::1/128"),
+        *_parse_networks(configured),
+    )
+
+
+def _peer_is_trusted_proxy(remote_addr):
+    try:
+        candidate = ip_address(remote_addr)
+        ipv4_mapped = getattr(candidate, "ipv4_mapped", None)
+        if ipv4_mapped:
+            candidate = ipv4_mapped
+    except ValueError:
+        return False
+    return any(candidate in network for network in _trusted_proxy_networks())
+
+
+def _management_request_context():
+    """Return security-relevant values without trusting direct forwarded headers."""
+    proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
+    direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.remote_addr or ""
+    trusted_proxy = _peer_is_trusted_proxy(direct_remote_addr)
+    if trusted_proxy:
+        effective_remote_addr = request.remote_addr or direct_remote_addr
+        effective_host = request.host
+        effective_scheme = request.scheme
+    else:
+        effective_remote_addr = direct_remote_addr
+        effective_host = proxyfix_orig.get("HTTP_HOST") or request.environ.get("HTTP_HOST", "")
+        effective_scheme = proxyfix_orig.get("wsgi.url_scheme") or request.scheme
+    return effective_remote_addr, effective_host, effective_scheme, trusted_proxy
+
+
+def _parse_host_authority(raw_host):
+    value = str(raw_host or "").strip()
+    if not value or any(char.isspace() for char in value) or any(char in value for char in "/?#@"):
+        return None
+    if value.count(":") >= 2 and not value.startswith("["):
+        try:
+            return ip_address(value).compressed, None
+        except ValueError:
+            return None
+    try:
+        parsed = urlsplit(f"//{value}")
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if not hostname or parsed.username is not None or parsed.password is not None:
+        return None
+    try:
+        hostname = ip_address(hostname).compressed
+    except ValueError:
+        pass
+    return hostname, port
+
+
+def _allowed_management_hosts():
+    configured = app.config.get("MANAGEMENT_ALLOWED_HOSTS")
+    if configured is None:
+        configured = os.environ.get("MANAGEMENT_ALLOWED_HOSTS", "")
+    values = ["localhost", "127.0.0.1", "::1"]
+    values.extend(str(configured or "").split(","))
+    for variable in ("DEVICE_HOSTNAME", "DEVICE_DOMAIN_NAME"):
+        values.append(os.environ.get(variable, ""))
+    if K3S_MODE:
+        values.extend(
+            (
+                "tunnelsats",
+                f"tunnelsats.{K8S_NAMESPACE}",
+                f"tunnelsats.{K8S_NAMESPACE}.svc",
+                f"tunnelsats.{K8S_NAMESPACE}.svc.cluster.local",
+            )
+        )
+    allowed = set()
+    for value in values:
+        if "://" in str(value):
+            origin = _canonical_origin(value)
+            if origin:
+                allowed.add(origin[1])
+        else:
+            authority = _parse_host_authority(value)
+            if authority:
+                allowed.add(authority[0])
+    return allowed
+
+
+def _host_is_allowed(raw_host):
+    authority = _parse_host_authority(raw_host)
+    return authority is not None and authority[0] in _allowed_management_hosts()
+
+
+def _canonical_origin(raw_origin):
+    value = str(raw_origin or "").strip()
+    if not value or value == "null":
+        return None
+    try:
+        parsed = urlsplit(value)
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in ("http", "https")
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    try:
+        hostname = ip_address(hostname).compressed
+    except ValueError:
+        pass
+    return parsed.scheme, hostname, port or (443 if parsed.scheme == "https" else 80)
+
+
+def _origin_matches_request(raw_origin, raw_host, scheme):
+    origin = _canonical_origin(raw_origin)
+    authority = _parse_host_authority(raw_host)
+    scheme = str(scheme or "").lower()
+    if origin is None or authority is None or scheme not in ("http", "https"):
+        return False
+    hostname, port = authority
+    request_origin = (scheme, hostname, port or (443 if scheme == "https" else 80))
+    if origin != request_origin:
+        return False
+
+    configured = app.config.get("MANAGEMENT_ALLOWED_ORIGINS")
+    if configured is None:
+        configured = os.environ.get("MANAGEMENT_ALLOWED_ORIGINS", "")
+    configured_items = [item.strip() for item in str(configured or "").split(",") if item.strip()]
+    configured_origins = {
+        parsed
+        for parsed in (_canonical_origin(item) for item in configured_items)
+        if parsed is not None
+    }
+    return not configured_items or origin in configured_origins
+
+
+def _valid_management_password(password):
+    return isinstance(password, str) and len(password) >= MANAGEMENT_PASSWORD_MIN_LENGTH
+
+
+def _read_or_create_management_password():
+    global _management_password_file_cache
+
+    configured = app.config.get("MANAGEMENT_PASSWORD")
+    if configured is None:
+        configured = os.environ.get("MANAGEMENT_PASSWORD") or os.environ.get("APP_PASSWORD")
+    if configured is not None:
+        return configured if _valid_management_password(configured) else None
+
+    password_path = os.path.join(DATA_DIR, MANAGEMENT_PASSWORD_FILE)
+    with _management_password_lock:
+        cached_path, cached_password = _management_password_file_cache
+        if cached_path == password_path and cached_password is not None:
+            return cached_password
+        try:
+            os.makedirs(DATA_DIR, mode=0o700, exist_ok=True)
+            try:
+                file_descriptor = os.open(
+                    password_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+            except FileExistsError:
+                file_descriptor = None
+
+            if file_descriptor is not None:
+                generated = secrets.token_urlsafe(32)
+                with os.fdopen(file_descriptor, "w", encoding="utf-8") as password_fp:
+                    password_fp.write(generated)
+                    password_fp.flush()
+                    os.fsync(password_fp.fileno())
+                password = generated
+                app.logger.warning(
+                    "Generated a management password; retrieve it from /data/management-password"
+                )
+            else:
+                read_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+                password_fd = os.open(password_path, read_flags)
+                try:
+                    password_stat = os.fstat(password_fd)
+                    if (
+                        not stat.S_ISREG(password_stat.st_mode)
+                        or password_stat.st_nlink != 1
+                        or password_stat.st_size > 4096
+                    ):
+                        raise OSError("unsafe management credential file")
+                    os.fchmod(password_fd, 0o600)
+                    password_bytes = os.read(password_fd, 4097)
+                finally:
+                    os.close(password_fd)
+                password = password_bytes.decode("utf-8").strip()
+        except (IOError, OSError, UnicodeDecodeError):
+            app.logger.error("Management authentication is unavailable: credential storage failed")
+            password = None
+
+        if not _valid_management_password(password):
+            app.logger.error("Management authentication is unavailable: credential is missing or weak")
+            password = None
+        _management_password_file_cache = (password_path, password)
+        return password
+
+
+def _management_credentials_are_valid():
+    password = _read_or_create_management_password()
+    authorization = request.headers.get("Authorization", "")
+    if password is None or len(authorization) > 8192 or not authorization.startswith("Basic "):
+        return False
+    try:
+        decoded = base64.b64decode(authorization[6:].strip(), validate=True).decode("utf-8")
+        username, supplied_password = decoded.split(":", 1)
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return False
+    return secrets.compare_digest(username, MANAGEMENT_USERNAME) and secrets.compare_digest(
+        supplied_password, password
+    )
+
+
+def _management_request_is_protected():
+    return (
+        request.path == "/"
+        or request.path.endswith(".html")
+        or request.path in ("/api/subscription/renew", "/api/subscription/claim")
+        or request.path.startswith("/api/local")
+    )
+
+
+def _management_request_changes_state():
+    return request.method not in ("GET", "HEAD", "OPTIONS")
+
+
+def _management_security_error(status, message, challenge=False, csrf_refresh=False):
+    response = jsonify({"success": False, "error": message})
+    response.status_code = status
+    if challenge:
+        response.headers["WWW-Authenticate"] = 'Basic realm="TunnelSats management", charset="UTF-8"'
+    if csrf_refresh:
+        response.headers[MANAGEMENT_CSRF_REFRESH_HEADER] = "required"
+    return response
+
+
+def _audit_management_request(outcome, reason, remote_addr):
+    log_method = app.logger.info if outcome == "accepted" else app.logger.warning
+    log_method(
+        "Management request %s: method=%s endpoint=%s remote=%s reason=%s",
+        outcome,
+        request.method,
+        request.endpoint or "unknown",
+        remote_addr or "unknown",
+        reason,
+    )
 
 
 def normalize_version(raw_version):
@@ -2000,19 +2290,67 @@ def reconcile_result_success(result):
 
 @app.before_request
 def restrict_local_api():
-    if request.path.startswith("/api/local") or request.path == "/api/subscription/renew":
-        proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
-        direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.remote_addr
+    if not _management_request_is_protected():
+        return None
 
-        # Trust X-Forwarded-For only when the immediate peer is loopback (local reverse proxy).
-        # Direct clients can otherwise spoof forwarded headers to bypass local-network checks.
-        if is_loopback_ip(direct_remote_addr):
-            effective_remote_addr = request.remote_addr
-        else:
-            effective_remote_addr = direct_remote_addr
+    effective_remote_addr, effective_host, effective_scheme, trusted_proxy = (
+        _management_request_context()
+    )
+    if not client_is_allowed(effective_remote_addr):
+        _audit_management_request("rejected", "network", effective_remote_addr)
+        return _management_security_error(403, "Forbidden")
+    if not _host_is_allowed(effective_host):
+        _audit_management_request("rejected", "host", effective_remote_addr)
+        return _management_security_error(403, "Forbidden")
 
-        if not client_is_allowed(effective_remote_addr):
-            abort(403)
+    password_available = _read_or_create_management_password() is not None
+    if not password_available:
+        _audit_management_request("rejected", "authentication-unavailable", effective_remote_addr)
+        return _management_security_error(503, "Management API unavailable")
+    if not _management_credentials_are_valid():
+        _audit_management_request("rejected", "credentials", effective_remote_addr)
+        return _management_security_error(401, "Unauthorized", challenge=True)
+
+    if _management_request_changes_state():
+        supplied_csrf = request.headers.get(MANAGEMENT_CSRF_HEADER, "")
+        cookie_csrf = request.cookies.get(MANAGEMENT_CSRF_COOKIE, "")
+        if not (
+            supplied_csrf
+            and cookie_csrf
+            and secrets.compare_digest(supplied_csrf, cookie_csrf)
+            and secrets.compare_digest(supplied_csrf, _management_csrf_token)
+        ):
+            _audit_management_request("rejected", "csrf", effective_remote_addr)
+            return _management_security_error(403, "Forbidden", csrf_refresh=True)
+        if not _origin_matches_request(request.headers.get("Origin"), effective_host, effective_scheme):
+            _audit_management_request("rejected", "origin", effective_remote_addr)
+            return _management_security_error(403, "Forbidden")
+
+        _audit_management_request("accepted", "authorized-mutation", effective_remote_addr)
+
+    g.management_authenticated = True
+    g.management_effective_scheme = effective_scheme
+    g.management_trusted_proxy = trusted_proxy
+    return None
+
+
+@app.after_request
+def protect_management_response(response):
+    if _management_request_is_protected():
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Pragma"] = "no-cache"
+        response.headers.add("Vary", "Authorization")
+        response.headers.add("Vary", "Cookie")
+    if getattr(g, "management_authenticated", False) and request.method in ("GET", "HEAD"):
+        response.set_cookie(
+            MANAGEMENT_CSRF_COOKIE,
+            _management_csrf_token,
+            secure=getattr(g, "management_effective_scheme", "http") == "https",
+            httponly=False,
+            samesite="Strict",
+            path="/",
+        )
+    return response
 
 
 # Proxy function to forward requests to the core Tunnelsats API
@@ -2465,6 +2803,11 @@ def renew_subscription():
 
 
 # --- LOCAL APP ROUTES ---
+
+@app.route("/api/local/session", methods=["GET"])
+def local_session():
+    return jsonify({"authenticated": True, "csrf_token": _management_csrf_token})
+
 
 @app.route("/api/local/status", methods=["GET"])
 def local_status():

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -4,6 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import pytest
 import json
+import base64
 import stat
 import subprocess
 import tempfile
@@ -14,6 +15,14 @@ from app import app
 import app as app_module
 
 # --- Fixtures ---
+
+TEST_MANAGEMENT_PASSWORD = 'T' * app_module.MANAGEMENT_PASSWORD_MIN_LENGTH
+INVALID_MANAGEMENT_PASSWORD = 'I' * app_module.MANAGEMENT_PASSWORD_MIN_LENGTH
+
+
+def management_auth_header(password=TEST_MANAGEMENT_PASSWORD, username='tunnelsats'):
+    encoded = base64.b64encode(f'{username}:{password}'.encode('utf-8')).decode('ascii')
+    return {'Authorization': f'Basic {encoded}'}
 
 @pytest.fixture(autouse=True)
 def clear_caches():
@@ -35,9 +44,28 @@ def mock_lnd_announcement_cleanup():
 
 @pytest.fixture
 def client():
+    previous_testing = app.config.get('TESTING')
+    previous_password = app.config.get('MANAGEMENT_PASSWORD')
+    previous_hosts = app.config.get('MANAGEMENT_ALLOWED_HOSTS')
     app.config['TESTING'] = True
+    app.config['MANAGEMENT_PASSWORD'] = TEST_MANAGEMENT_PASSWORD
+    app.config['MANAGEMENT_ALLOWED_HOSTS'] = 'localhost'
     with app.test_client() as client:
+        client.environ_base['HTTP_AUTHORIZATION'] = management_auth_header()['Authorization']
+        client.environ_base['HTTP_ORIGIN'] = 'http://localhost'
+        client.environ_base['HTTP_X_TUNNELSATS_CSRF_TOKEN'] = app_module._management_csrf_token
+        session_response = client.get('/api/local/session')
+        assert session_response.status_code == 200
         yield client
+    app.config['TESTING'] = previous_testing
+    if previous_password is None:
+        app.config.pop('MANAGEMENT_PASSWORD', None)
+    else:
+        app.config['MANAGEMENT_PASSWORD'] = previous_password
+    if previous_hosts is None:
+        app.config.pop('MANAGEMENT_ALLOWED_HOSTS', None)
+    else:
+        app.config['MANAGEMENT_ALLOWED_HOSTS'] = previous_hosts
 
 @pytest.fixture
 def data_dir(tmp_path):
@@ -220,6 +248,323 @@ def test_denied_api_request_returns_json_with_original_status(client):
         'success': False,
         'error': 'Forbidden',
     }
+
+
+class TestManagementApiSecurity:
+    def test_missing_credentials_are_challenged_on_lan(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/status',
+                headers={'Host': 'localhost'},
+                environ_base={'REMOTE_ADDR': '192.168.1.25'},
+            )
+
+        assert res.status_code == 401
+        assert res.get_json() == {'success': False, 'error': 'Unauthorized'}
+        assert res.headers['WWW-Authenticate'].startswith('Basic realm="TunnelSats management"')
+
+    def test_unauthenticated_tailscale_client_cannot_read_or_mutate(self, client):
+        with app.test_client() as raw_client:
+            read_response = raw_client.get(
+                '/api/local/status',
+                headers={'Host': 'localhost'},
+                environ_base={'REMOTE_ADDR': '100.117.194.79'},
+            )
+            mutation_response = raw_client.post(
+                '/api/local/restart',
+                headers={'Host': 'localhost', 'Origin': 'http://localhost'},
+                environ_base={'REMOTE_ADDR': '100.117.194.79'},
+            )
+
+        assert read_response.status_code == 401
+        assert mutation_response.status_code == 401
+
+    def test_invalid_credentials_are_rejected(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/session',
+                headers={**management_auth_header(INVALID_MANAGEMENT_PASSWORD), 'Host': 'localhost'},
+            )
+
+        assert res.status_code == 401
+        assert res.get_json() == {'success': False, 'error': 'Unauthorized'}
+
+    def test_ipv6_loopback_host_is_allowed_with_valid_authentication(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/session',
+                headers={**management_auth_header(), 'Host': '[::1]:9739'},
+                environ_base={'REMOTE_ADDR': '::1'},
+            )
+
+        assert res.status_code == 200
+
+    def test_dashboard_document_requires_authentication(self, client):
+        with app.test_client() as raw_client:
+            denied = raw_client.get('/', headers={'Host': 'localhost'})
+            allowed = raw_client.get('/', headers={**management_auth_header(), 'Host': 'localhost'})
+
+        assert denied.status_code == 401
+        assert allowed.status_code == 200
+        assert f'{app_module.MANAGEMENT_CSRF_COOKIE}=' in allowed.headers.get('Set-Cookie', '')
+
+    def test_alternate_html_path_cannot_bypass_authentication(self, client):
+        with app.test_client() as raw_client:
+            denied = raw_client.get('/web/index.html', headers={'Host': 'localhost'})
+            authenticated = raw_client.get(
+                '/web/index.html',
+                headers={**management_auth_header(), 'Host': 'localhost'},
+            )
+
+        assert denied.status_code == 401
+        assert authenticated.status_code == 404
+
+    def test_session_bootstrap_sets_strict_csrf_cookie(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/session',
+                headers={**management_auth_header(), 'Host': 'localhost'},
+            )
+
+        assert res.status_code == 200
+        assert res.get_json() == {
+            'authenticated': True,
+            'csrf_token': app_module._management_csrf_token,
+        }
+        cookie = res.headers['Set-Cookie']
+        assert f'{app_module.MANAGEMENT_CSRF_COOKIE}=' in cookie
+        assert 'SameSite=Strict' in cookie
+        assert 'HttpOnly' not in cookie
+        assert res.headers['Cache-Control'] == 'no-store'
+
+    def test_mutation_requires_csrf_header_bound_to_cookie(self, client):
+        with app.test_client() as raw_client:
+            auth_headers = {**management_auth_header(), 'Host': 'localhost'}
+            session = raw_client.get('/api/local/session', headers=auth_headers)
+            assert session.status_code == 200
+
+            missing_header = raw_client.post(
+                '/api/local/restart',
+                headers={**auth_headers, 'Origin': 'http://localhost'},
+            )
+            wrong_header = raw_client.post(
+                '/api/local/restart',
+                headers={
+                    **auth_headers,
+                    'Origin': 'http://localhost',
+                    app_module.MANAGEMENT_CSRF_HEADER: 'incorrect-csrf-token',
+                },
+            )
+
+        assert missing_header.status_code == 403
+        assert wrong_header.status_code == 403
+        assert missing_header.headers[app_module.MANAGEMENT_CSRF_REFRESH_HEADER] == 'required'
+        assert wrong_header.headers[app_module.MANAGEMENT_CSRF_REFRESH_HEADER] == 'required'
+
+    @patch('builtins.open', new_callable=MagicMock)
+    def test_valid_authentication_csrf_and_origin_allow_mutation(self, mock_open, client):
+        mock_open.return_value.__enter__.return_value = MagicMock()
+        with app.test_client() as raw_client:
+            auth_headers = {**management_auth_header(), 'Host': 'localhost'}
+            session = raw_client.get('/api/local/session', headers=auth_headers)
+            token = session.get_json()['csrf_token']
+            res = raw_client.post(
+                '/api/local/restart',
+                headers={
+                    **auth_headers,
+                    'Origin': 'http://localhost',
+                    app_module.MANAGEMENT_CSRF_HEADER: token,
+                },
+            )
+
+        assert res.status_code == 200
+        assert res.get_json()['success'] is True
+
+    def test_cross_origin_and_missing_origin_mutations_are_rejected(self, client):
+        with app.test_client() as raw_client:
+            auth_headers = {**management_auth_header(), 'Host': 'localhost'}
+            token = raw_client.get('/api/local/session', headers=auth_headers).get_json()['csrf_token']
+            csrf_headers = {
+                **auth_headers,
+                app_module.MANAGEMENT_CSRF_HEADER: token,
+            }
+            cross_origin = raw_client.post(
+                '/api/local/restart',
+                headers={**csrf_headers, 'Origin': 'http://attacker.example'},
+            )
+            missing_origin = raw_client.post('/api/local/restart', headers=csrf_headers)
+
+        assert cross_origin.status_code == 403
+        assert missing_origin.status_code == 403
+        assert app_module.MANAGEMENT_CSRF_REFRESH_HEADER not in cross_origin.headers
+        assert app_module.MANAGEMENT_CSRF_REFRESH_HEADER not in missing_origin.headers
+
+    def test_unlisted_host_is_rejected_before_authentication(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/status',
+                headers={**management_auth_header(), 'Host': 'attacker.example'},
+            )
+
+        assert res.status_code == 403
+        assert res.get_json() == {'success': False, 'error': 'Forbidden'}
+
+    def test_direct_client_cannot_spoof_forwarded_host(self, client):
+        with app.test_client() as raw_client:
+            res = raw_client.get(
+                '/api/local/session',
+                headers={
+                    **management_auth_header(),
+                    'Host': 'attacker.example',
+                    'X-Forwarded-Host': 'localhost',
+                    'X-Forwarded-Proto': 'http',
+                },
+                environ_base={'REMOTE_ADDR': '192.168.1.25'},
+            )
+
+        assert res.status_code == 403
+
+    def test_loopback_reverse_proxy_forwarding_is_trusted(self, client):
+        previous_hosts = app.config['MANAGEMENT_ALLOWED_HOSTS']
+        app.config['MANAGEMENT_ALLOWED_HOSTS'] = 'proxy.example'
+        try:
+            with app.test_client() as raw_client:
+                res = raw_client.get(
+                    '/api/local/session',
+                    headers={
+                        **management_auth_header(),
+                        'Host': 'backend.invalid',
+                        'X-Forwarded-For': '192.168.1.25',
+                        'X-Forwarded-Host': 'proxy.example',
+                        'X-Forwarded-Proto': 'https',
+                    },
+                    environ_base={'REMOTE_ADDR': '127.0.0.1'},
+                )
+        finally:
+            app.config['MANAGEMENT_ALLOWED_HOSTS'] = previous_hosts
+
+        assert res.status_code == 200
+        assert 'Secure' in res.headers['Set-Cookie']
+
+    def test_explicit_reverse_proxy_network_is_trusted(self, client):
+        previous_hosts = app.config['MANAGEMENT_ALLOWED_HOSTS']
+        previous_proxies = app.config.get('MANAGEMENT_TRUSTED_PROXIES')
+        app.config['MANAGEMENT_ALLOWED_HOSTS'] = 'proxy.example'
+        app.config['MANAGEMENT_TRUSTED_PROXIES'] = '10.21.21.4/32'
+        try:
+            with app.test_client() as raw_client:
+                res = raw_client.get(
+                    '/api/local/session',
+                    headers={
+                        **management_auth_header(),
+                        'Host': 'backend.invalid',
+                        'X-Forwarded-For': '192.168.1.25',
+                        'X-Forwarded-Host': 'proxy.example',
+                        'X-Forwarded-Proto': 'https',
+                    },
+                    environ_base={'REMOTE_ADDR': '10.21.21.4'},
+                )
+        finally:
+            app.config['MANAGEMENT_ALLOWED_HOSTS'] = previous_hosts
+            if previous_proxies is None:
+                app.config.pop('MANAGEMENT_TRUSTED_PROXIES', None)
+            else:
+                app.config['MANAGEMENT_TRUSTED_PROXIES'] = previous_proxies
+
+        assert res.status_code == 200
+
+    def test_invalid_explicit_origin_allowlist_fails_closed(self, client):
+        previous_origins = app.config.get('MANAGEMENT_ALLOWED_ORIGINS')
+        app.config['MANAGEMENT_ALLOWED_ORIGINS'] = 'not-an-origin'
+        try:
+            with app.test_client() as raw_client:
+                auth_headers = {**management_auth_header(), 'Host': 'localhost'}
+                token = raw_client.get('/api/local/session', headers=auth_headers).get_json()['csrf_token']
+                res = raw_client.post(
+                    '/api/local/restart',
+                    headers={
+                        **auth_headers,
+                        'Origin': 'http://localhost',
+                        app_module.MANAGEMENT_CSRF_HEADER: token,
+                    },
+                )
+        finally:
+            if previous_origins is None:
+                app.config.pop('MANAGEMENT_ALLOWED_ORIGINS', None)
+            else:
+                app.config['MANAGEMENT_ALLOWED_ORIGINS'] = previous_origins
+
+        assert res.status_code == 403
+
+    def test_ordinary_k3s_pod_cannot_invoke_management_api_unauthenticated(self, client):
+        with app.test_client() as raw_client:
+            read_response = raw_client.get(
+                '/api/local/status',
+                headers={'Host': 'localhost'},
+                environ_base={'REMOTE_ADDR': '10.42.0.23'},
+            )
+            mutation_response = raw_client.post(
+                '/api/local/restart',
+                headers={'Host': 'localhost', 'Origin': 'http://localhost'},
+                environ_base={'REMOTE_ADDR': '10.42.0.23'},
+            )
+
+        assert read_response.status_code == 401
+        assert mutation_response.status_code == 401
+
+    def test_weak_configured_password_fails_closed(self):
+        previous_password = app.config.get('MANAGEMENT_PASSWORD')
+        app.config['MANAGEMENT_PASSWORD'] = 'too-short'
+        try:
+            with app.test_client() as raw_client:
+                res = raw_client.get('/api/local/session', headers={'Host': 'localhost'})
+        finally:
+            if previous_password is None:
+                app.config.pop('MANAGEMENT_PASSWORD', None)
+            else:
+                app.config['MANAGEMENT_PASSWORD'] = previous_password
+
+        assert res.status_code == 503
+        assert res.get_json() == {'success': False, 'error': 'Management API unavailable'}
+
+    def test_missing_password_generates_persistent_private_credential(self, monkeypatch, tmp_path):
+        previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)
+        monkeypatch.delenv('MANAGEMENT_PASSWORD', raising=False)
+        monkeypatch.delenv('APP_PASSWORD', raising=False)
+        monkeypatch.setattr(app_module, 'DATA_DIR', str(tmp_path))
+        monkeypatch.setattr(app_module, '_management_password_file_cache', ('', None))
+        try:
+            first = app_module._read_or_create_management_password()
+            second = app_module._read_or_create_management_password()
+        finally:
+            if previous_password is not None:
+                app.config['MANAGEMENT_PASSWORD'] = previous_password
+
+        credential_path = tmp_path / app_module.MANAGEMENT_PASSWORD_FILE
+        assert first == second
+        assert len(first) >= app_module.MANAGEMENT_PASSWORD_MIN_LENGTH
+        assert credential_path.read_text() == first
+        assert stat.S_IMODE(credential_path.stat().st_mode) == (stat.S_IRUSR | stat.S_IWUSR)
+
+    def test_generated_password_file_rejects_symlinks(self, monkeypatch, tmp_path):
+        target_path = tmp_path / 'unrelated-secret'
+        target_path.write_text('unrelated-secret-that-must-not-be-used')
+        target_path.chmod(0o644)
+        (tmp_path / app_module.MANAGEMENT_PASSWORD_FILE).symlink_to(target_path)
+        previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)
+        monkeypatch.delenv('MANAGEMENT_PASSWORD', raising=False)
+        monkeypatch.delenv('APP_PASSWORD', raising=False)
+        monkeypatch.setattr(app_module, 'DATA_DIR', str(tmp_path))
+        monkeypatch.setattr(app_module, '_management_password_file_cache', ('', None))
+        try:
+            password = app_module._read_or_create_management_password()
+        finally:
+            if previous_password is not None:
+                app.config['MANAGEMENT_PASSWORD'] = previous_password
+
+        assert password is None
+        assert target_path.read_text() == 'unrelated-secret-that-must-not-be-used'
+        assert stat.S_IMODE(target_path.stat().st_mode) == 0o644
 
 
 def test_missing_static_asset_remains_404(client):

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -262,6 +262,7 @@ class TestManagementApiSecurity:
         assert res.status_code == 401
         assert res.get_json() == {'success': False, 'error': 'Unauthorized'}
         assert res.headers['WWW-Authenticate'].startswith('Basic realm="TunnelSats management"')
+        assert res.headers[app_module.MANAGEMENT_CSRF_REFRESH_HEADER] == 'required'
 
     def test_unauthenticated_tailscale_client_cannot_read_or_mutate(self, client):
         with app.test_client() as raw_client:
@@ -512,20 +513,26 @@ class TestManagementApiSecurity:
         assert read_response.status_code == 401
         assert mutation_response.status_code == 401
 
-    def test_weak_configured_password_fails_closed(self):
-        previous_password = app.config.get('MANAGEMENT_PASSWORD')
-        app.config['MANAGEMENT_PASSWORD'] = 'too-short'
+    def test_weak_environment_password_fails_closed_with_diagnostic(self, monkeypatch):
+        previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)
+        weak_password = 'too-short'
+        monkeypatch.setenv('MANAGEMENT_PASSWORD', weak_password)
         try:
-            with app.test_client() as raw_client:
-                res = raw_client.get('/api/local/session', headers={'Host': 'localhost'})
+            with patch.object(app.logger, 'warning') as warning:
+                with app.test_client() as raw_client:
+                    res = raw_client.get('/api/local/session', headers={'Host': 'localhost'})
         finally:
-            if previous_password is None:
-                app.config.pop('MANAGEMENT_PASSWORD', None)
-            else:
+            if previous_password is not None:
                 app.config['MANAGEMENT_PASSWORD'] = previous_password
 
         assert res.status_code == 503
         assert res.get_json() == {'success': False, 'error': 'Management API unavailable'}
+        diagnostic_call = (
+            'Supplied MANAGEMENT_PASSWORD/APP_PASSWORD is too short (minimum %d characters)',
+            app_module.MANAGEMENT_PASSWORD_MIN_LENGTH,
+        )
+        assert [call.args for call in warning.call_args_list].count(diagnostic_call) == 1
+        assert weak_password not in str(warning.call_args_list)
 
     def test_missing_password_generates_persistent_private_credential(self, monkeypatch, tmp_path):
         previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)

--- a/server/tests/test_k3s_manifest.py
+++ b/server/tests/test_k3s_manifest.py
@@ -6,6 +6,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOYMENT_PATH = REPO_ROOT / "k3s" / "deployment.yaml"
 ROLE_PATH = REPO_ROOT / "k3s" / "role.yaml"
+NETWORK_POLICY_PATH = REPO_ROOT / "k3s" / "networkpolicy.yaml"
+KUSTOMIZATION_PATH = REPO_ROOT / "k3s" / "kustomization.yaml"
 
 
 def load_deployment():
@@ -40,6 +42,43 @@ def test_k3s_manifest_exposes_tunnelsats_node_name_to_runtime():
     }
     assert env["LND_K8S_POD_SELECTOR"]["value"] == "app=lnd"
     assert env["K3S_BYPASS_CIDRS"]["value"] == "10.42.0.0/16,10.43.0.0/16"
+
+
+def test_k3s_manifest_uses_optional_management_secret_and_explicit_hosts():
+    deployment = load_deployment()
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env = {entry["name"]: entry for entry in container["env"]}
+
+    assert env["MANAGEMENT_PASSWORD"]["valueFrom"]["secretKeyRef"] == {
+        "name": "tunnelsats-management",
+        "key": "password",
+        "optional": True,
+    }
+    assert "tunnelsats" in env["MANAGEMENT_ALLOWED_HOSTS"]["value"].split(",")
+
+
+def test_k3s_management_ingress_denies_ordinary_pods():
+    with NETWORK_POLICY_PATH.open(encoding="utf-8") as manifest:
+        policy = yaml.safe_load(manifest)
+    with KUSTOMIZATION_PATH.open(encoding="utf-8") as manifest:
+        kustomization = yaml.safe_load(manifest)
+
+    assert "networkpolicy.yaml" in kustomization["resources"]
+    assert policy["spec"]["podSelector"]["matchLabels"] == {"app": "tunnelsats"}
+    assert policy["spec"]["policyTypes"] == ["Ingress"]
+    ingress = policy["spec"]["ingress"]
+    assert ingress == [
+        {
+            "from": [
+                {
+                    "podSelector": {
+                        "matchLabels": {"tunnelsats.io/management-client": "true"}
+                    }
+                }
+            ],
+            "ports": [{"protocol": "TCP", "port": 9739}],
+        }
+    ]
 
 
 def test_k3s_role_can_install_last_resort_network_policy():

--- a/server/tests/test_management_manifest.py
+++ b/server/tests/test_management_manifest.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "tunnelsats" / "docker-compose.yml"
+MANIFEST_PATH = REPO_ROOT / "tunnelsats" / "umbrel-app.yml"
+
+
+def test_umbrel_passes_per_app_password_and_explicit_hosts():
+    with COMPOSE_PATH.open(encoding="utf-8") as compose_file:
+        compose = yaml.safe_load(compose_file)
+
+    environment = compose["services"]["tunnelsats"]["environment"]
+    assert "MANAGEMENT_PASSWORD=${APP_PASSWORD}" in environment
+    allowed_hosts = next(
+        entry for entry in environment if entry.startswith("MANAGEMENT_ALLOWED_HOSTS=")
+    )
+    assert "${DEVICE_HOSTNAME}" in allowed_hosts
+    assert "${DEVICE_DOMAIN_NAME}" in allowed_hosts
+    assert "${APP_HIDDEN_SERVICE}" in allowed_hosts
+    assert "localhost" in allowed_hosts
+
+
+def test_umbrel_surfaces_management_login_credentials():
+    with MANIFEST_PATH.open(encoding="utf-8") as manifest_file:
+        manifest = yaml.safe_load(manifest_file)
+
+    assert manifest["defaultUsername"] == "tunnelsats"
+    assert manifest["defaultPassword"] == "$APP_PASSWORD"

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - apparmor:unconfined
     environment:
       - SECURE_MODE=${SECURE_MODE:-false}
+      # Umbrel provides a unique high-entropy password for each app. The Flask
+      # management plane independently enforces it, including on direct :9739 access.
+      - MANAGEMENT_PASSWORD=${APP_PASSWORD}
+      - MANAGEMENT_ALLOWED_HOSTS=localhost,127.0.0.1,::1,${DEVICE_HOSTNAME},${DEVICE_DOMAIN_NAME},${APP_HIDDEN_SERVICE}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -29,5 +29,5 @@ gallery:
   - https://raw.githubusercontent.com/Tunnelsats/ts-umbrel-app/master/tunnelsats/gallery/2.png
   - https://raw.githubusercontent.com/Tunnelsats/ts-umbrel-app/master/tunnelsats/gallery/3.png
 path: ""
-defaultUsername: ""
-defaultPassword: ""
+defaultUsername: "tunnelsats"
+defaultPassword: "$APP_PASSWORD"

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -29,6 +29,7 @@ function createMockGlobeInstance() {
 
 function setupDOM() {
     document.documentElement.innerHTML = html.toString();
+    document.cookie = 'tunnelsats_csrf=test-management-csrf-token; path=/';
     // Mock QRCode globally (loaded via CDN in real app)
     global.QRCode = jest.fn().mockImplementation(() => ({
         makeCode: jest.fn()
@@ -775,7 +776,11 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
             '/api/subscription/claim',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-management-csrf-token'
+                }),
                 body: JSON.stringify({ paymentHash: 'buy-hash-123', wgPublicKey: '', wgPresharedKey: '', referralCode: null })
             })
         );
@@ -1187,7 +1192,11 @@ describe('Phase 3a: Import Config', () => {
             '/api/local/upload-config',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-management-csrf-token'
+                }),
                 body: JSON.stringify({ config: expectedConfig })
             })
         );
@@ -1234,7 +1243,11 @@ describe('Phase 3a: Import Config', () => {
             '/api/local/upload-config',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-management-csrf-token'
+                }),
                 body: JSON.stringify({ config: expectedConfig })
             })
         );
@@ -1345,7 +1358,11 @@ describe('Phase 3b: Install Config', () => {
             '/api/local/configure-node',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-management-csrf-token'
+                }),
                 body: JSON.stringify({ nodeType: 'lnd' })
             })
         );
@@ -1361,7 +1378,11 @@ describe('Phase 3b: Install Config', () => {
             '/api/local/configure-node',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-management-csrf-token'
+                }),
                 body: JSON.stringify({ nodeType: 'cln' })
             })
         );
@@ -1700,5 +1721,100 @@ describe('Subscription Renewal Fixes', () => {
         
         expect(fetchStatusSpy).toHaveBeenCalled();
         expect(invoiceBox.textContent).toContain('Renewal Successful');
+    });
+});
+
+describe('Management request security', () => {
+    beforeEach(() => {
+        setupDOM();
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ wg_status: 'Disconnected', servers: [] })
+        }));
+        evalScript();
+    });
+
+    afterEach(() => { jest.restoreAllMocks(); });
+
+    test('bootstraps a CSRF token before a mutation when the cookie is absent', async () => {
+        document.cookie = 'tunnelsats_csrf=; Max-Age=0; path=/';
+        global.fetch.mockClear();
+        global.fetch.mockImplementation((url, options) => {
+            if (url === '/api/local/session') {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ csrf_token: 'bootstrapped-csrf-token' })
+                });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+        });
+
+        await window.managementFetch('/api/local/restart', { method: 'POST' });
+
+        expect(global.fetch.mock.calls[0]).toEqual([
+            '/api/local/session',
+            { credentials: 'same-origin' }
+        ]);
+        expect(global.fetch.mock.calls[1][0]).toBe('/api/local/restart');
+        expect(global.fetch.mock.calls[1][1]).toEqual(expect.objectContaining({
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: expect.objectContaining({
+                'X-TunnelSats-CSRF-Token': 'bootstrapped-csrf-token'
+            })
+        }));
+    });
+
+    test('authenticated reads use same-origin credentials without a CSRF header', async () => {
+        global.fetch.mockClear();
+        await window.managementFetch('/api/local/status');
+
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/api/local/status',
+            { credentials: 'same-origin' }
+        );
+    });
+
+    test('refreshes a stale CSRF token once after a backend restart', async () => {
+        global.fetch.mockClear();
+        let mutationAttempts = 0;
+        global.fetch.mockImplementation((url, options) => {
+            if (url === '/api/local/session') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    headers: { get: () => null },
+                    json: () => Promise.resolve({ csrf_token: 'rotated-csrf-token' })
+                });
+            }
+            mutationAttempts += 1;
+            if (mutationAttempts === 1) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 403,
+                    headers: {
+                        get: (name) => name === 'X-TunnelSats-CSRF-Refresh' ? 'required' : null
+                    },
+                    json: () => Promise.resolve({ error: 'Forbidden' })
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: { get: () => null },
+                json: () => Promise.resolve({ success: true })
+            });
+        });
+
+        const response = await window.managementFetch('/api/local/restart', { method: 'POST' });
+
+        expect(response.ok).toBe(true);
+        expect(global.fetch.mock.calls.map((call) => call[0])).toEqual([
+            '/api/local/restart',
+            '/api/local/session',
+            '/api/local/restart'
+        ]);
+        expect(global.fetch.mock.calls[2][1].headers['X-TunnelSats-CSRF-Token'])
+            .toBe('rotated-csrf-token');
     });
 });

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -10,6 +10,10 @@ const DISCOUNTS = { 1: 0, 3: 0.05, 6: 0.10, 12: 0.20 };
 let currentSatsPerDollar = null;
 const POLL_INTERVAL_MS = 3000;
 let tsServers = [];
+const MANAGEMENT_CSRF_COOKIE = 'tunnelsats_csrf';
+const MANAGEMENT_CSRF_HEADER = 'X-TunnelSats-CSRF-Token';
+const MANAGEMENT_CSRF_REFRESH_HEADER = 'X-TunnelSats-CSRF-Refresh';
+let csrfBootstrapPromise = null;
 
 // Badge States Constants for Routing Status
 const BADGE_STATES = {
@@ -97,6 +101,15 @@ async function mockFetch(url) {
             }
         };
     }
+    if (url === '/api/local/session') {
+        return {
+            ok: true,
+            body: {
+                authenticated: true,
+                csrf_token: 'mock-management-csrf-token'
+            }
+        };
+    }
     if (url === '/api/servers' || url === '/api/local/servers') {
         return {
             ok: true,
@@ -117,6 +130,64 @@ async function mockFetch(url) {
         };
     }
     return { ok: false, status: 404, body: { error: 'Not Found' } };
+}
+
+function readManagementCsrfCookie() {
+    const prefix = `${MANAGEMENT_CSRF_COOKIE}=`;
+    const entry = document.cookie
+        .split(';')
+        .map((value) => value.trim())
+        .find((value) => value.startsWith(prefix));
+    return entry ? decodeURIComponent(entry.slice(prefix.length)) : '';
+}
+
+async function ensureManagementCsrfToken(forceRefresh = false) {
+    if (!forceRefresh) {
+        const existing = readManagementCsrfCookie();
+        if (existing) return existing;
+    }
+
+    if (!csrfBootstrapPromise) {
+        csrfBootstrapPromise = fetch('/api/local/session', { credentials: 'same-origin' })
+            .then(async (response) => {
+                const payload = await response.json();
+                if (!response.ok || !payload.csrf_token) {
+                    throw new Error('Management authentication is required.');
+                }
+                return payload.csrf_token;
+            })
+            .finally(() => {
+                csrfBootstrapPromise = null;
+            });
+    }
+    return csrfBootstrapPromise;
+}
+
+async function managementFetch(url, options = {}) {
+    const method = String(options.method || 'GET').toUpperCase();
+    const requestOptions = { ...options, credentials: 'same-origin' };
+    if (!['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+        const csrfToken = await ensureManagementCsrfToken();
+        requestOptions.headers = {
+            ...(options.headers || {}),
+            [MANAGEMENT_CSRF_HEADER]: csrfToken
+        };
+    }
+    const response = await fetch(url, requestOptions);
+    const csrfRefreshRequired = response.status === 403
+        && response.headers
+        && typeof response.headers.get === 'function'
+        && response.headers.get(MANAGEMENT_CSRF_REFRESH_HEADER) === 'required';
+    if (!csrfRefreshRequired || ['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+        return response;
+    }
+
+    const refreshedToken = await ensureManagementCsrfToken(true);
+    requestOptions.headers = {
+        ...(requestOptions.headers || {}),
+        [MANAGEMENT_CSRF_HEADER]: refreshedToken
+    };
+    return fetch(url, requestOptions);
 }
 
 function initGlobe() {
@@ -629,7 +700,7 @@ function switchTab(tabId) {
     }
 
     if (tabId === 'renew') {
-        fetch('/api/local/meta').then(r => r.json()).then(data => {
+        managementFetch('/api/local/meta').then(r => r.json()).then(data => {
             let lookupId = data.serverId;
             // Handle naming mismatch: /api/local/meta (metadata JSON) uses camelCase.
             const sDomain = data.serverDomain || data.server_domain;
@@ -717,7 +788,7 @@ function applySecureModeUI(isSecureMode) {
 // 1. Fetch Local Status
 async function fetchStatus() {
     try {
-        const res = await fetch('/api/local/status');
+        const res = await managementFetch('/api/local/status');
         const data = await res.json();
 
         const vpnActive = data.vpn_active === true;
@@ -1042,7 +1113,10 @@ async function createSub(mode) {
             }
         }
 
-        const res = await fetch(endpoint, {
+        const requestFunction = endpoint === '/api/subscription/renew'
+            ? managementFetch
+            : (url, options) => fetch(url, options);
+        const res = await requestFunction(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
@@ -1181,7 +1255,7 @@ async function claimSubscription(mode) {
     }
 
     try {
-        const res = await fetch('/api/subscription/claim', {
+        const res = await managementFetch('/api/subscription/claim', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ paymentHash: activePaymentHash, wgPublicKey: "", wgPresharedKey: "", referralCode: null })
@@ -1715,7 +1789,7 @@ async function configureNode() {
     setActionMessage('configure-node-msg', 'Applying node configuration...', 'info');
 
     try {
-        let res = await fetch('/api/local/configure-node', {
+        let res = await managementFetch('/api/local/configure-node', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ nodeType: selectedNodeType })
@@ -1728,7 +1802,7 @@ async function configureNode() {
                 setActionMessage('configure-node-msg', 'Configuration cancelled; existing announcement settings were not changed.', 'info');
                 return;
             }
-            res = await fetch('/api/local/configure-node', {
+            res = await managementFetch('/api/local/configure-node', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -1784,7 +1858,7 @@ async function restoreNode() {
     setActionMessage('restore-node-msg', 'Restoring node configuration...', 'info');
 
     try {
-        const res = await fetch('/api/local/restore-node', { method: 'POST' });
+        const res = await managementFetch('/api/local/restore-node', { method: 'POST' });
         const data = await safeFetchJson(res);
 
         if (res.ok && data.success !== false) {
@@ -2021,7 +2095,7 @@ async function importConfig() {
     setImportMessage("Importing...", 'info');
 
     try {
-        let res = await fetch('/api/local/upload-config', {
+        let res = await managementFetch('/api/local/upload-config', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ config })
@@ -2039,7 +2113,7 @@ async function importConfig() {
 
             // Retry with confirm=true
             setImportMessage("Saving expired config...", 'info');
-            res = await fetch('/api/local/upload-config', {
+            res = await managementFetch('/api/local/upload-config', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ config, confirm: true })
@@ -2095,7 +2169,7 @@ async function pollUntilConnected(options = {}) {
 
 async function restartTunnel(pollOptions = {}) {
     try {
-        const res = await fetch('/api/local/restart', { method: 'POST' });
+        const res = await managementFetch('/api/local/restart', { method: 'POST' });
         if (res.ok) {
             // The container entrypoint will catch the trigger file, and restart `wg-quick`.
             void pollUntilConnected(pollOptions);


### PR DESCRIPTION
## Summary

- require high-entropy management authentication for the dashboard, local API, renewal, and claim flows
- enforce explicit Host validation, trusted-proxy handling, same-origin checks, and cookie-bound CSRF tokens for mutations
- pass Umbrel app credentials through the manifest, add k3s Secret support and ingress policy controls, and document secure operations
- add backend, frontend, proxy, manifest, LAN, Tailscale, and k3s security coverage

Closes #125

## Local review

Completed an adversarial review for authentication bypasses, forwarded-header trust, Host/Origin parsing, CSRF enforcement, credential storage, and deployment exposure. Fixed symlink/hardlink credential-file handling and IPv6 Host normalization findings.

## Testing

- 246 backend tests passed
- 61 frontend tests passed
- Python and JavaScript syntax checks passed
- shell syntax and git diff checks passed
- Docker Compose interpolation/validation passed