### PR TITLE
chore(release): bump version to v3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [3.3.4]
 
 - Hardened dataplane policy routing and fallback blackhole rules for target node network isolation. Integrated automated version sync guardrails.
+
+## [3.3.5]
+
+- Authenticate the local management plane; enforce fail-closed IPv4/IPv6 routing for Docker and k3s; prevent Lightning real-IP announcements; and update CI actions.

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.3.4
+          image: tunnelsats/ts-umbrel-app:3.3.5
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/server/app.py
+++ b/server/app.py
@@ -31,7 +31,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.3.4"
+APP_VERSION = "v3.3.5"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:

--- a/server/tests/test_bump_version.py
+++ b/server/tests/test_bump_version.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import re
 import shutil
 import subprocess
 
@@ -119,11 +120,14 @@ def test_preflight_failure_does_not_partially_update_files(
     bump_module, version_workspace
 ):
     deployment = version_workspace / "k3s/deployment.yaml"
-    deployment.write_text(
-        deployment.read_text().replace(
-            "image: tunnelsats/ts-umbrel-app:3.3.4", "image: example/other:latest"
-        )
+    malformed_deployment, replacement_count = re.subn(
+        r"image: tunnelsats/ts-umbrel-app:[^\s]+",
+        "image: example/other:latest",
+        deployment.read_text(),
+        count=1,
     )
+    assert replacement_count == 1
+    deployment.write_text(malformed_deployment)
     before = snapshot_files(version_workspace)
 
     with pytest.raises(ValueError, match="found 0"):

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.4
+    image: tunnelsats/ts-umbrel-app:3.3.5
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.4"
+version: "3.3.5"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.
@@ -16,7 +16,7 @@ description: >-
 
 
   Ideal for users on dynamic home IPs, behind CGNAT, or those seeking an extra layer of privacy for their Lightning peering.
-releaseNotes: "Hardened dataplane policy routing and fallback blackhole rules for target node network isolation. Integrated automated version sync guardrails."
+releaseNotes: "Authenticate the local management plane; enforce fail-closed IPv4/IPv6 routing for Docker and k3s; prevent Lightning real-IP announcements; and update CI actions."
 developer: TunnelSats Team
 website: https://tunnelsats.com
 dependencies: []

--- a/web/index.html
+++ b/web/index.html
@@ -932,7 +932,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.4</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.5</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- bump TunnelSats from v3.3.4 to v3.3.5 across all five canonical version locations
- publish consolidated release notes in the Umbrel manifest and CHANGELOG
- make the version-bumper preflight fixture independent of the current release tag

## Changes since v3.3.4

- authenticate the local management plane with HTTP Basic auth and CSRF protection (#131)
- remove stale Lightning real-IP announcements (#130)
- fail closed on IPv6 egress (#129)
- enforce and verify the protected Docker default route (#128)
- keep dataplane startup and reconciliation fail-closed (#120)
- route outbound Lightning traffic through WireGuard in k3s (#119)
- enforce Lightning pod co-location in k3s (#118)
- update actions/setup-node and actions/setup-python to v7 (#103, #104)

Full comparison: https://github.com/Tunnelsats/ts-umbrel-app/compare/v3.3.4...master

## Validation

- .venv-tests/bin/pytest -q server/tests/ (247 passed)
- .venv-tests/bin/pytest -q server/tests/test_bump_version.py server/tests/test_version_sync.py (24 passed)
- npm test -- --runInBand (62 passed)
- git diff --check