### PR TITLE
fix(api): serve UI without auth gate and fix empty password fallback (fixes #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@
 ## [3.3.5]
 
 - Authenticate the local management plane; enforce fail-closed IPv4/IPv6 routing for Docker and k3s; prevent Lightning real-IP announcements; and update CI actions.
+
+## [3.3.6]
+
+- Fix management UI lockout on direct browser access and empty APP_PASSWORD fallback

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.3.5
+          image: tunnelsats/ts-umbrel-app:3.3.6
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/server/app.py
+++ b/server/app.py
@@ -31,7 +31,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.3.5"
+APP_VERSION = "v3.3.6"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:
@@ -525,7 +525,7 @@ def _read_or_create_management_password():
 
     configured = app.config.get("MANAGEMENT_PASSWORD")
     if configured is None:
-        configured = os.environ.get("MANAGEMENT_PASSWORD") or os.environ.get("APP_PASSWORD")
+        configured = (os.environ.get("MANAGEMENT_PASSWORD") or "").strip() or (os.environ.get("APP_PASSWORD") or "").strip() or None
     if configured is not None:
         if _valid_management_password(configured):
             return configured
@@ -605,9 +605,7 @@ def _management_credentials_are_valid():
 
 def _management_request_is_protected():
     return (
-        request.path == "/"
-        or request.path.endswith(".html")
-        or request.path in ("/api/subscription/renew", "/api/subscription/claim")
+        request.path in ("/api/subscription/renew", "/api/subscription/claim")
         or request.path.startswith("/api/local")
     )
 

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -300,25 +300,21 @@ class TestManagementApiSecurity:
 
         assert res.status_code == 200
 
-    def test_dashboard_document_requires_authentication(self, client):
+    def test_dashboard_document_served_without_authentication(self, client):
         with app.test_client() as raw_client:
-            denied = raw_client.get('/', headers={'Host': 'localhost'})
-            allowed = raw_client.get('/', headers={**management_auth_header(), 'Host': 'localhost'})
+            unauthenticated = raw_client.get('/', headers={'Host': 'localhost'})
+            authenticated = raw_client.get('/', headers={**management_auth_header(), 'Host': 'localhost'})
 
-        assert denied.status_code == 401
-        assert allowed.status_code == 200
-        assert f'{app_module.MANAGEMENT_CSRF_COOKIE}=' in allowed.headers.get('Set-Cookie', '')
+        assert unauthenticated.status_code == 200
+        assert b'<html' in unauthenticated.data.lower() or b'<!doctype' in unauthenticated.data.lower()
+        assert authenticated.status_code == 200
 
-    def test_alternate_html_path_cannot_bypass_authentication(self, client):
+    def test_alternate_html_path_is_not_auth_gated(self, client):
         with app.test_client() as raw_client:
-            denied = raw_client.get('/web/index.html', headers={'Host': 'localhost'})
-            authenticated = raw_client.get(
-                '/web/index.html',
-                headers={**management_auth_header(), 'Host': 'localhost'},
-            )
+            unauthenticated = raw_client.get('/web/index.html', headers={'Host': 'localhost'})
 
-        assert denied.status_code == 401
-        assert authenticated.status_code == 404
+        # HTML paths outside static folder return 404 (not 401)
+        assert unauthenticated.status_code in (200, 404)
 
     def test_session_bootstrap_sets_strict_csrf_cookie(self, client):
         with app.test_client() as raw_client:
@@ -572,6 +568,61 @@ class TestManagementApiSecurity:
         assert password is None
         assert target_path.read_text() == 'unrelated-secret-that-must-not-be-used'
         assert stat.S_IMODE(target_path.stat().st_mode) == 0o644
+
+    def test_empty_env_password_falls_back_to_file_generation(self, monkeypatch, tmp_path):
+        previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)
+        monkeypatch.setenv('MANAGEMENT_PASSWORD', '')
+        monkeypatch.delenv('APP_PASSWORD', raising=False)
+        monkeypatch.setattr(app_module, 'DATA_DIR', str(tmp_path))
+        monkeypatch.setattr(app_module, '_management_password_file_cache', ('', None))
+        try:
+            password = app_module._read_or_create_management_password()
+        finally:
+            if previous_password is not None:
+                app.config['MANAGEMENT_PASSWORD'] = previous_password
+
+        credential_path = tmp_path / app_module.MANAGEMENT_PASSWORD_FILE
+        assert password is not None
+        assert len(password) >= app_module.MANAGEMENT_PASSWORD_MIN_LENGTH
+        assert credential_path.exists()
+        assert credential_path.read_text() == password
+
+    def test_whitespace_only_env_password_falls_back_to_file_generation(self, monkeypatch, tmp_path):
+        previous_password = app.config.pop('MANAGEMENT_PASSWORD', None)
+        monkeypatch.setenv('MANAGEMENT_PASSWORD', '   ')
+        monkeypatch.delenv('APP_PASSWORD', raising=False)
+        monkeypatch.setattr(app_module, 'DATA_DIR', str(tmp_path))
+        monkeypatch.setattr(app_module, '_management_password_file_cache', ('', None))
+        try:
+            password = app_module._read_or_create_management_password()
+        finally:
+            if previous_password is not None:
+                app.config['MANAGEMENT_PASSWORD'] = previous_password
+
+        credential_path = tmp_path / app_module.MANAGEMENT_PASSWORD_FILE
+        assert password is not None
+        assert len(password) >= app_module.MANAGEMENT_PASSWORD_MIN_LENGTH
+        assert credential_path.exists()
+
+    def test_api_endpoints_remain_protected_without_credentials(self, client):
+        protected_paths = [
+            '/api/local/status',
+            '/api/local/session',
+            '/api/subscription/renew',
+            '/api/subscription/claim',
+        ]
+        with app.test_client() as raw_client:
+            for path in protected_paths:
+                res = raw_client.get(path, headers={'Host': 'localhost'})
+                assert res.status_code in (401, 405), f'{path} returned {res.status_code}, expected 401 or 405'
+
+    def test_static_assets_served_without_authentication(self, client):
+        with app.test_client() as raw_client:
+            root = raw_client.get('/', headers={'Host': 'localhost'})
+
+        assert root.status_code == 200
+        content_type = root.headers.get('Content-Type', '')
+        assert 'text/html' in content_type
 
 
 def test_missing_static_asset_remains_404(client):

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.5
+    image: tunnelsats/ts-umbrel-app:3.3.6
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.5"
+version: "3.3.6"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.
@@ -16,7 +16,7 @@ description: >-
 
 
   Ideal for users on dynamic home IPs, behind CGNAT, or those seeking an extra layer of privacy for their Lightning peering.
-releaseNotes: "Authenticate the local management plane; enforce fail-closed IPv4/IPv6 routing for Docker and k3s; prevent Lightning real-IP announcements; and update CI actions."
+releaseNotes: "Fix management UI lockout on direct browser access and empty APP_PASSWORD fallback"
 developer: TunnelSats Team
 website: https://tunnelsats.com
 dependencies: []

--- a/web/index.html
+++ b/web/index.html
@@ -932,7 +932,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.5</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.6</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Hotfix for #133: users upgrading to v3.3.5 see raw JSON `{"error":"Unauthorized","success":false}` instead of the web UI when accessing TunnelSats directly in their browser.

## Root Cause

Two bugs introduced in #131 (management auth):

1. **Auth boundary over-reach**: `_management_request_is_protected()` gated `/` and `*.html` behind HTTP Basic Auth. When a browser navigates to `http://umbrel.local:9739/`, the `restrict_local_api()` before-request hook returns JSON 401 **before Flask can serve `index.html`**. The browser renders raw JSON on a blank white page.

2. **Empty `$APP_PASSWORD` fallback failure**: When `MANAGEMENT_PASSWORD=""` (from un-set `${APP_PASSWORD}` in docker-compose), Python evaluates `"" is not None` → `True`, fails the 24-char length check, and returns `None` (503 lockout) instead of falling through to auto-generate `/data/management-password`.

## Changes

### Fix 1: Auth boundary correction (`server/app.py`)
- Removed `/` and `*.html` from `_management_request_is_protected()`
- Static HTML/JS/CSS frontend is now served without credentials
- All `/api/local/*` and subscription endpoints remain fully gated with HTTP Basic Auth + CSRF

### Fix 2: Empty password normalization (`server/app.py`)
- Empty and whitespace-only `MANAGEMENT_PASSWORD` and `APP_PASSWORD` environment variables are now treated as unconfigured
- Falls through to the file-based auto-generation path (`/data/management-password`) instead of returning 503

### Tests (`server/tests/test_app.py`)
- Updated `test_dashboard_document_served_without_authentication` — `/` returns 200 without auth
- Updated `test_alternate_html_path_is_not_auth_gated` — HTML paths return 404 (not 401)
- Added `test_empty_env_password_falls_back_to_file_generation`
- Added `test_whitespace_only_env_password_falls_back_to_file_generation`
- Added `test_api_endpoints_remain_protected_without_credentials`
- Added `test_static_assets_served_without_authentication`

### Version bump
- Bumped to v3.3.6 via `scripts/bump_version.py`
- Made `test_preflight_failure` version-independent with regex

## Validation

- `pytest server/tests/` — **251 passed** ✅
- `pytest server/tests/test_version_sync.py server/tests/test_bump_version.py` — **24 passed** ✅
- `git diff --check` — clean

Closes #133
