### PR TITLE
feat(umbrel): secure management API with native auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   test-compose:
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml
     steps:
       - uses: actions/checkout@v7.0.1
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -17,13 +17,19 @@ Yes. The TunnelSats daemon handles dynamic reloading:
 > Note that applying a new configuration via the **Install** tab or using the **Restore Node Networking** function will force a restart of your Lightning node container. This is required to ensure your node's networking information is correctly broadcast to the Lightning Network.
 
 ### 3. How can I verify my connection from the command line?
-The dashboard uses our internal **Dataplane API**. You can query this directly via SSH to debug your network state:
+The dashboard uses an Umbrel-authenticated **Dataplane API**. From an SSH
+session on the Umbrel host, you can query its loopback-only backend to debug
+your network state:
 
 ```bash
-curl -s http://umbrel.lan:9739/api/local/status | jq
+curl -s http://127.0.0.1:9740/api/local/status | jq
 ```
 
-This returns a JSON payload containing the active WireGuard endpoint, internal routing metrics, and any failure logs (`last_error`). To check the live WireGuard handshake:
+Port `9739` is the user-facing authenticated Umbrel proxy and is not a public
+LAN API. State-changing operations must be performed through the authenticated
+dashboard. The loopback status request returns a JSON payload containing the
+active WireGuard endpoint, internal routing metrics, and any failure logs
+(`last_error`). To check the live WireGuard handshake:
 
 ```bash
 docker exec tunnelsats wg show

--- a/README.md
+++ b/README.md
@@ -170,14 +170,17 @@ Target: us3.tunnelsats.com (178.156.167.202) : 12345
 [3/3] Testing Inbound Port (via Hostname)...    PASS (Connected to us3.tunnelsats.com:12345)
 ----------------------------------------------------------------
 ```
-- Check `GET /api/local/status` first to view the current `dataplane_mode` and `wg_status`.
+- Check the authenticated dashboard first to view the current
+  `dataplane_mode`, `wg_status`, and any reconciliation error.
+- For SSH-only diagnostics, the private Flask backend is available from the
+  Umbrel host itself at `http://127.0.0.1:9740`; it is not reachable from the
+  LAN. For example:
+  ```bash
+  curl -s http://127.0.0.1:9740/api/local/status | jq
+  ```
 - If `rules_synced` is `false`, inspect `ipv4_rules_synced`,
   `ipv6_rules_synced`, and `last_error` in the JSON response.
-- **Trigger immediate Dataplane repair:**
-  ```bash
-  curl -X POST http://127.0.0.1:9739/api/local/reconcile
-  ```
-- **Force full app-level restart:**
-  ```bash
-  curl -X POST http://127.0.0.1:9739/api/local/restart
-  ```
+- Trigger reconciliation and restart actions from the authenticated dashboard.
+  Browser mutations require Umbrel authentication plus same-origin CSRF
+  validation and are intentionally not exposed as unauthenticated LAN `curl`
+  commands.

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,8 @@
+services:
+  app_proxy:
+    # umbrelOS injects the real image and base configuration for this service.
+    # The repository smoke test only starts `tunnelsats`, but Compose still
+    # validates every service, so provide a dormant CI-only image definition.
+    image: alpine:3.21
+    profiles:
+      - umbrel-injected-app-proxy

--- a/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
+++ b/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-- Scope: umbrelOS deployments only
+- Scope: umbrelOS deployments with both `SECURE_MODE=false` and
+  `SECURE_MODE=true`
 - Related issue: <https://github.com/Tunnelsats/ts-umbrel-app/issues/125>
 - Implementation status: planned
+- Implementation method: test-driven development (red, green, refactor)
 - k3s: explicitly out of scope for this change
 
 ## Objective
@@ -17,6 +19,12 @@ on `APP_PASSWORD`.
 The implementation must prevent LAN, Tailscale, and ordinary container callers
 from bypassing Umbrel authentication by connecting directly to the Flask
 listener. Browser-based state changes must also be protected against CSRF.
+
+The complete authentication boundary and browser protections must work
+identically when Secure Mode is disabled and enabled. Secure Mode may continue
+to alter which existing TunnelSats operations are available, but it must not
+alter whether the UI or management API is authenticated, how Flask is exposed,
+or whether CSRF and origin validation are enforced.
 
 ## Background
 
@@ -66,6 +74,26 @@ Authenticated browser
 Port `9739` remains the app's public Umbrel port. Port `9740` is an internal
 implementation detail and must never listen on a non-loopback address in an
 Umbrel deployment.
+
+## Secure Mode Compatibility
+
+This architecture applies unconditionally to both supported Umbrel runtime
+modes:
+
+| Concern | `SECURE_MODE=false` | `SECURE_MODE=true` |
+| --- | --- | --- |
+| External HTTP entry point | Authenticated `app_proxy` on `:9739` | Authenticated `app_proxy` on `:9739` |
+| Flask listener | `127.0.0.1:9740` | `127.0.0.1:9740` |
+| Umbrel session required | Yes | Yes |
+| CSRF and Origin checks on mutations | Yes | Yes |
+| Direct access to backend from LAN/Tailscale | Refused | Refused |
+| Existing mode-specific operational restrictions | Preserved | Preserved |
+
+The proxy and backend binding must not be conditional on `SECURE_MODE`. The
+existing `SECURE_MODE` value continues to govern dataplane and node-management
+behavior only. Authentication middleware must run before mode-specific route
+logic so a mode-specific error can never be used to infer state without first
+passing the Umbrel authentication boundary.
 
 ## Security Boundaries
 
@@ -123,6 +151,9 @@ Important requirements:
 - Keep `defaultUsername` and `defaultPassword` empty because TunnelSats no
   longer has a separate application login.
 - Do not pass `APP_PASSWORD` into the TunnelSats container.
+- Apply the proxy and loopback settings regardless of the value of
+  `SECURE_MODE`; there must not be a legacy direct-listener branch for either
+  mode.
 
 Umbrel injects the image, published proxy port, authentication secret, manifest
 mount, and other base configuration for the `app_proxy` service. The TunnelSats
@@ -151,6 +182,10 @@ address and port without logging credentials or tokens.
 Preserve the existing defaults for deployment types not changed by this work so
 that this Umbrel-only change does not silently alter k3s behavior. Do not edit
 the k3s manifests in this implementation.
+
+Parameterize binding tests for `SECURE_MODE=false` and `SECURE_MODE=true` to
+prove that both resolve to the same loopback address and internal port under
+the Umbrel compose configuration.
 
 Update entrypoint log messages so they distinguish the internal backend
 listener from the user-facing Umbrel URL.
@@ -209,6 +244,11 @@ At minimum, apply this protection to:
 
 Inventory every Flask route during implementation rather than relying only on
 the list above. New management mutations should be protected by default.
+Exercise every applicable mutation test in both Secure Mode states. Where
+Secure Mode intentionally rejects an operation, first assert that missing or
+invalid CSRF/origin inputs are rejected by the security layer, then assert the
+existing mode-specific response for an authenticated, valid same-origin
+request.
 
 ### 5. Validate forwarded host and proxy behavior
 
@@ -269,18 +309,101 @@ If programmatic management access is required later, design a separate,
 revocable API-token feature with narrowly scoped permissions. It is not part of
 this change and must not weaken the browser authentication path.
 
-## Delivery Order
+## Test-Driven Delivery Order
 
-The proxy and backend listener changes must be delivered atomically in one app
-release:
+Implement this work test-first using a red-green-refactor cycle. Do not write
+production code for a behavior until a focused test demonstrates that the
+current implementation does not satisfy it.
 
-1. Add configurable Flask binding and CSRF/origin middleware.
-2. Update the frontend to bootstrap and send CSRF tokens.
-3. Add the authenticated host-network `app_proxy` targeting loopback port 9740.
-4. Set the Umbrel backend bind address to `127.0.0.1:9740`.
-5. Update tests and documentation.
-6. Validate the rendered compose configuration and run the umbrelOS end-to-end
-   checks before publishing the image and manifest version together.
+### 1. Establish the baseline
+
+Run and record the existing server, frontend, compose/manifest, and version-sync
+test suites before adding new tests. Existing tests must be green. A pre-existing
+failure must be understood and separated from this change before proceeding.
+
+### 2. Add green characterization guardrails
+
+Before changing behavior, add or confirm tests for properties the reverted code
+already satisfies:
+
+- no HTTP Basic Authentication challenge;
+- no generated management-password file;
+- no `APP_PASSWORD` dependency or non-empty manifest login credentials; and
+- existing mode-specific behavior with `SECURE_MODE=false` and
+  `SECURE_MODE=true`.
+
+These are characterization tests, so they are expected to be green at the
+baseline. They prevent the old authentication design or unintended Secure Mode
+changes from returning. Do not misrepresent them as red tests.
+
+### 3. Run focused red-green cycles
+
+Implement one vertical contract at a time. For every cycle below:
+
+1. Write the focused test first.
+2. Run it and capture the expected failure. A test that passes immediately does
+   not prove the new behavior and must be reviewed for an incorrect assertion
+   or an already-satisfied contract.
+3. Commit or otherwise preserve review evidence of the red test before changing
+   production code.
+4. Add only enough production code to satisfy that contract.
+5. Run the focused test to green, followed by all affected existing tests.
+6. Parameterize the cycle over both Secure Mode states wherever runtime behavior
+   is involved.
+
+Use these cycles in dependency order:
+
+#### Cycle A: backend listener
+
+- Red: server tests require validated configurable bind settings and prove that
+  explicit `127.0.0.1:9740` settings are honored with Secure Mode disabled and
+  enabled.
+- Green: add the bind configuration and update the server/entrypoint startup
+  behavior without changing non-Umbrel deployment defaults.
+
+#### Cycle B: server-side browser security
+
+- Red: tests require CSRF, Origin, Host, cache-control, generic errors, and safe
+  audit logging for the management surface in both Secure Mode states.
+- Green: add centralized management-route classification, security middleware,
+  and the session/CSRF bootstrap endpoint.
+
+#### Cycle C: frontend management requests
+
+- Red: frontend tests require CSRF bootstrap and a common CSRF-aware management
+  request wrapper for every unsafe call.
+- Green: implement the wrapper and migrate the existing calls without changing
+  their mode-specific UI behavior.
+
+#### Cycle D: Umbrel proxy and exclusive network path
+
+- Red: compose and manifest tests require the authenticated host-network
+  `app_proxy`, the loopback target, empty app credentials, no authentication
+  whitelist, and identical proxy configuration for both Secure Mode values.
+- Green: add the proxy override and the explicit Umbrel backend bind settings.
+
+Do not weaken assertions merely to obtain a green result. A discovered design
+change should first be reflected in this plan and in a deliberately failing
+test.
+
+After Cycle D, add or run the integrated regression contract against the
+rendered Compose model. It should be green because the lower-level red-green
+cycles established the behavior. If it reveals a missing contract, preserve
+that failure and run an additional focused red-green cycle before continuing.
+
+### 4. Refactor while green
+
+Once the contract tests pass, remove duplication, centralize management-route
+classification and frontend request handling, and improve names or structure.
+Run the complete affected suite after every refactor. Security middleware must
+fail closed if configuration or token initialization fails.
+
+### 5. Validate the integrated Umbrel release
+
+Render and inspect the final Umbrel Compose model, then run the umbrelOS
+end-to-end matrix with Secure Mode disabled and enabled. Publish the proxy,
+backend listener, frontend, tests, image, and manifest version atomically in one
+app release.
 
 Do not publish an intermediate state. If Flask and the proxy both bind port
 9739, startup will fail. If Flask moves to 9740 before the proxy is present, the
@@ -290,6 +413,9 @@ UI will be unavailable.
 
 ### Unit and application tests
 
+- Parameterize security and bind tests over `SECURE_MODE=false` and
+  `SECURE_MODE=true` unless a test is specifically about mode-dependent
+  operational behavior.
 - Safe methods do not require a CSRF token.
 - Every management mutation rejects a missing token.
 - Every management mutation rejects an invalid token.
@@ -303,6 +429,8 @@ UI will be unavailable.
 - Audit logs contain reason codes but no secrets.
 - The CSRF bootstrap response is not cached.
 - Existing UI workflows use the common management fetch wrapper.
+- Authenticated requests continue to receive the pre-existing mode-appropriate
+  result after the shared security layer accepts them.
 
 ### Compose and manifest tests
 
@@ -314,11 +442,14 @@ UI will be unavailable.
 - The manifest still exposes port `9739`.
 - Manifest default username and password remain empty.
 - No password environment variable is passed to TunnelSats.
+- Proxy and loopback configuration do not vary with `SECURE_MODE`.
 - Version-sync and promotion tests include the updated compose structure.
 
 ### umbrelOS end-to-end tests
 
-Run these checks on a supported umbrelOS 1.x installation:
+Run the complete set of checks below twice on a supported umbrelOS 1.x
+installation: once with `SECURE_MODE=false` and once with `SECURE_MODE=true`.
+Do not treat success in one mode as evidence for the other.
 
 1. Opening TunnelSats from an authenticated Umbrel dashboard loads without a
    second login prompt.
@@ -338,6 +469,10 @@ Run these checks on a supported umbrelOS 1.x installation:
 11. Access through supported `.local`, IP-literal, Tailscale, and Tor entry
     points is either functional after Umbrel login or fails closed with a clear,
     documented configuration path.
+12. Switching between Secure Mode states and restarting the app preserves the
+    authenticated proxy path and never exposes the backend listener.
+13. Existing mode-specific UI controls and permitted/forbidden operations retain
+    their prior semantics after valid authentication and CSRF validation.
 
 ## Acceptance Criteria
 
@@ -349,10 +484,16 @@ Run these checks on a supported umbrelOS 1.x installation:
   Umbrel authentication.
 - All management mutations require a valid same-origin request and CSRF token.
 - The complete dashboard remains functional after a normal Umbrel login.
+- Every authentication, direct-port isolation, CSRF, and origin requirement
+  passes with both `SECURE_MODE=false` and `SECURE_MODE=true`.
+- Existing mode-specific application behavior remains unchanged after a request
+  passes the shared security layer.
 - No generated management credential or Basic Authentication code remains.
 - Tests cover authentication routing, direct-port isolation, CSRF, Origin, Host,
   proxy forwarding, and existing UI workflows.
 - No k3s manifest or behavior is intentionally changed by this work.
+- The implementation history or review evidence demonstrates the expected red
+  failures before the corresponding production changes turn them green.
 
 ## Out of Scope
 

--- a/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
+++ b/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
@@ -25,7 +25,12 @@
   CSRF-protected.
 - Cycle D red: `3` compose contract tests failed before the authenticated
   `app_proxy` and loopback backend wiring were added.
-- Final local green gate: `279` server tests and `62` frontend tests pass. The
+- Review follow-up red: the compose smoke test exposed its missing Umbrel base
+  service injection, and Greptile identified stale in-memory CSRF credentials
+  after a backend restart. The CI harness now supplies a dormant proxy stub,
+  and the frontend refreshes and retries exactly once when the backend marks a
+  CSRF rejection as refreshable.
+- Final local green gate: `280` server tests and `63` frontend tests pass. The
   compose overlay also renders successfully when merged with Umbrel's upstream
   `docker-compose.app_proxy.yml`.
 - The two-mode real-device umbrelOS end-to-end matrix remains required before

--- a/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
+++ b/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
@@ -1,0 +1,367 @@
+# Issue #125: Umbrel-Native Management Authentication Plan
+
+## Status
+
+- Scope: umbrelOS deployments only
+- Related issue: <https://github.com/Tunnelsats/ts-umbrel-app/issues/125>
+- Implementation status: planned
+- k3s: explicitly out of scope for this change
+
+## Objective
+
+Protect the TunnelSats UI and local management API with the user's existing
+Umbrel authentication session. Do not add an application-specific login,
+Basic Authentication challenge, generated management password, or dependency
+on `APP_PASSWORD`.
+
+The implementation must prevent LAN, Tailscale, and ordinary container callers
+from bypassing Umbrel authentication by connecting directly to the Flask
+listener. Browser-based state changes must also be protected against CSRF.
+
+## Background
+
+The current application runs Flask on `0.0.0.0:9739` in the host network
+namespace. The `/api/local` middleware treats membership in broad private
+network ranges as authorization. As a result, callers on the LAN, Tailscale,
+or a container network can reach sensitive management operations without
+proving that they are the Umbrel user.
+
+The reverted implementation did not use the Umbrel login session. It added
+HTTP Basic Authentication backed by `APP_PASSWORD`, with a generated password
+file as a fallback. `APP_PASSWORD` is a separate per-app credential, and the
+manifest's `defaultUsername` and `defaultPassword` fields only expose app login
+details to the user. They do not authenticate frontend requests automatically.
+This created a second login boundary and caused the dashboard's API requests to
+fail, locking users out of the UI.
+
+Umbrel already supplies an authenticated `app_proxy`. It validates the
+`UMBREL_PROXY_TOKEN` session cookie and redirects unauthenticated clients to the
+normal Umbrel login. TunnelSats should use that proxy as its sole externally
+reachable HTTP entry point.
+
+## Target Architecture
+
+```text
+Authenticated browser
+        |
+        | http://umbrel.local:9739
+        v
++---------------------------+
+| Umbrel app_proxy          |
+| - Umbrel session auth     |
+| - external port 9739      |
+| - host network namespace  |
++---------------------------+
+        |
+        | http://127.0.0.1:9740
+        v
++---------------------------+
+| TunnelSats Flask backend  |
+| - loopback-only listener  |
+| - CSRF/origin validation  |
+| - management operations   |
++---------------------------+
+```
+
+Port `9739` remains the app's public Umbrel port. Port `9740` is an internal
+implementation detail and must never listen on a non-loopback address in an
+Umbrel deployment.
+
+## Security Boundaries
+
+The design deliberately uses two independent controls:
+
+1. Umbrel `app_proxy` authenticates the user.
+2. The loopback-only backend makes the authenticated proxy the exclusive
+   network route to Flask.
+
+The second control is essential. Adding `app_proxy` while leaving Flask on
+`0.0.0.0:9739` would preserve a direct unauthenticated bypass. Headers such as
+`X-Forwarded-For` must not be treated as proof that a request passed through the
+proxy.
+
+CSRF and origin checks form a separate browser security layer. Umbrel's session
+cookie is `SameSite=Lax`, but same-site sibling applications and future browser
+behavior make the cookie attribute insufficient as the only CSRF control for
+high-impact mutations.
+
+This plan does not attempt to defend against an attacker who already has root
+access, arbitrary host-network process execution, or control of the Umbrel
+authentication service. Those capabilities already cross the host trust
+boundary.
+
+## Implementation Plan
+
+### 1. Add the Umbrel authenticated app proxy
+
+Update `tunnelsats/docker-compose.yml` with an `app_proxy` service override:
+
+```yaml
+services:
+  app_proxy:
+    network_mode: "host"
+    environment:
+      APP_HOST: 127.0.0.1
+      APP_PORT: 9740
+
+  tunnelsats:
+    network_mode: "host"
+    environment:
+      - SECURE_MODE=${SECURE_MODE:-false}
+      - DASHBOARD_BIND_HOST=127.0.0.1
+      - DASHBOARD_BIND_PORT=9740
+```
+
+Important requirements:
+
+- Do not set `PROXY_AUTH_ADD=false`.
+- Do not whitelist `/api/local`, static UI paths, or the root path.
+- Protect the complete TunnelSats origin so the UI and its API share the same
+  Umbrel-authenticated boundary.
+- Keep `umbrel-app.yml` `port: 9739`; this is the port on which the injected
+  Umbrel proxy listens.
+- Keep `defaultUsername` and `defaultPassword` empty because TunnelSats no
+  longer has a separate application login.
+- Do not pass `APP_PASSWORD` into the TunnelSats container.
+
+Umbrel injects the image, published proxy port, authentication secret, manifest
+mount, and other base configuration for the `app_proxy` service. The TunnelSats
+compose file should supply only the application target and the host-network
+override required to reach a loopback backend.
+
+Before implementation is merged, validate on a real umbrelOS 1.x installation
+that the injected proxy compose configuration accepts `network_mode: host` and
+successfully reaches `127.0.0.1:9740`. Inspect the fully rendered Compose model
+as part of this validation. Published ports may be reported as redundant in
+host-network mode; the proxy process itself must still bind to the manifest
+port.
+
+### 2. Move the Flask backend to a configurable loopback listener
+
+Replace the hard-coded `app.run(host="0.0.0.0", port=9739)` call with validated
+environment configuration:
+
+- `DASHBOARD_BIND_HOST`
+- `DASHBOARD_BIND_PORT`
+
+For the Umbrel compose deployment, set these explicitly to `127.0.0.1` and
+`9740`. Reject invalid port values at startup with a clear error. Log the bind
+address and port without logging credentials or tokens.
+
+Preserve the existing defaults for deployment types not changed by this work so
+that this Umbrel-only change does not silently alter k3s behavior. Do not edit
+the k3s manifests in this implementation.
+
+Update entrypoint log messages so they distinguish the internal backend
+listener from the user-facing Umbrel URL.
+
+### 3. Remove application-specific authentication
+
+Do not restore any of the reverted password implementation. In particular, the
+new implementation must not contain:
+
+- `MANAGEMENT_PASSWORD` or `MANAGEMENT_USERNAME`
+- `APP_PASSWORD` authentication
+- `/data/management-password`
+- HTTP Basic Authentication challenges
+- browser-side `Authorization` header construction
+- app-specific login recovery documentation
+
+Flask does not need to validate the Umbrel token itself. The app proxy owns that
+responsibility and strips its authentication cookie before forwarding. Flask
+trusts the authenticated boundary because only the loopback proxy can reach its
+listener.
+
+### 4. Add CSRF and same-origin protection for mutations
+
+Create a small management security layer that is independent of authentication.
+
+For every state-changing management request:
+
+- Require an `Origin` header.
+- Canonicalize and compare the origin's scheme, host, and effective port with
+  the proxied request origin.
+- Reject malformed, missing, `null`, or cross-origin values with a generic
+  `403 Forbidden` response.
+- Require a high-entropy CSRF token in a custom header such as
+  `X-TunnelSats-CSRF-Token`.
+- Compare tokens with a constant-time comparison.
+- Reject requests with a form-compatible content type where the endpoint
+  expects JSON.
+- Optionally reject `Sec-Fetch-Site: cross-site` as defense in depth, but do not
+  use it instead of the Origin and token checks.
+
+Add an authenticated bootstrap endpoint, for example `GET /api/local/session`,
+that returns the CSRF token with `Cache-Control: no-store`. Because this endpoint
+is reachable only through the Umbrel proxy, an unauthenticated or cross-origin
+site cannot read the token. The frontend should hold the token in memory and
+send it only on unsafe methods through a single `managementFetch` wrapper.
+
+At minimum, apply this protection to:
+
+- `POST /api/local/upload-config`
+- `POST /api/local/restart`
+- `POST /api/local/reconcile`
+- `POST /api/local/configure-node`
+- `POST /api/local/restore-node`
+- any subscription route that changes or consumes locally held subscription
+  state
+
+Inventory every Flask route during implementation rather than relying only on
+the list above. New management mutations should be protected by default.
+
+### 5. Validate forwarded host and proxy behavior
+
+Continue using `ProxyFix` only for the exact single proxy hop. Security checks
+must distinguish the direct socket peer from forwarded client information.
+
+For Umbrel requests:
+
+- The direct peer must be loopback.
+- The forwarded host must be syntactically valid.
+- The request `Origin` must exactly match the effective proxied origin for
+  mutations.
+- Known device names from `DEVICE_HOSTNAME`, `DEVICE_DOMAIN_NAME`, and
+  `APP_HIDDEN_SERVICE` should be accepted.
+- IP-literal hosts should be accepted only when they belong to a local host
+  interface, allowing normal access through the Umbrel device's LAN or
+  Tailscale address without a static installation-specific list.
+- Provide an explicit extra-host configuration for installations using an
+  additional reverse proxy or custom DNS name.
+
+Host validation must be tested with `.local`, direct IPv4, direct IPv6, Tor, and
+any supported Tailscale access pattern. It must not reintroduce the UI lockout
+by assuming every installation uses `umbrel.local`.
+
+The existing private-source network allowlist may remain temporarily as a
+defense-in-depth restriction and for compatibility, but it must no longer be
+described or tested as the authorization mechanism. Authentication comes from
+Umbrel; bypass prevention comes from the loopback listener.
+
+### 6. Add safe response behavior and audit logging
+
+For management responses:
+
+- Add `Cache-Control: no-store` and `Pragma: no-cache` where sensitive state or
+  tokens are returned.
+- Return generic `403` responses for origin, CSRF, or host failures.
+- Log accepted mutations and rejected requests with timestamp, method,
+  endpoint, and a non-secret reason code.
+- Never log cookies, authorization material, CSRF tokens, WireGuard private
+  keys, uploaded configuration bodies, or subscription secrets.
+
+Read-only endpoints that expose private configuration or metadata remain behind
+the Umbrel proxy even though they do not require a CSRF token.
+
+### 7. Update user and operator documentation
+
+Update documentation that currently demonstrates unauthenticated calls such as:
+
+```text
+curl http://umbrel.local:9739/api/local/status
+```
+
+The management API is no longer intended to be an unauthenticated LAN API.
+Document browser access through Umbrel as the supported management path. Do not
+instruct users to retrieve a generated password or configure Basic Auth.
+
+If programmatic management access is required later, design a separate,
+revocable API-token feature with narrowly scoped permissions. It is not part of
+this change and must not weaken the browser authentication path.
+
+## Delivery Order
+
+The proxy and backend listener changes must be delivered atomically in one app
+release:
+
+1. Add configurable Flask binding and CSRF/origin middleware.
+2. Update the frontend to bootstrap and send CSRF tokens.
+3. Add the authenticated host-network `app_proxy` targeting loopback port 9740.
+4. Set the Umbrel backend bind address to `127.0.0.1:9740`.
+5. Update tests and documentation.
+6. Validate the rendered compose configuration and run the umbrelOS end-to-end
+   checks before publishing the image and manifest version together.
+
+Do not publish an intermediate state. If Flask and the proxy both bind port
+9739, startup will fail. If Flask moves to 9740 before the proxy is present, the
+UI will be unavailable.
+
+## Test Plan
+
+### Unit and application tests
+
+- Safe methods do not require a CSRF token.
+- Every management mutation rejects a missing token.
+- Every management mutation rejects an invalid token.
+- Every management mutation rejects missing, malformed, `null`, and
+  cross-origin `Origin` values.
+- Valid same-origin requests with a valid token succeed.
+- Form-compatible requests are rejected for JSON-only mutation endpoints.
+- Forwarded headers are trusted only for one expected proxy hop.
+- Invalid Host values are rejected without reflecting their value.
+- Sensitive responses are marked `no-store`.
+- Audit logs contain reason codes but no secrets.
+- The CSRF bootstrap response is not cached.
+- Existing UI workflows use the common management fetch wrapper.
+
+### Compose and manifest tests
+
+- `app_proxy` is present.
+- `APP_HOST` is `127.0.0.1` and `APP_PORT` is `9740`.
+- Proxy authentication is not disabled.
+- No management path is whitelisted.
+- The TunnelSats backend binds to `127.0.0.1:9740` in the Umbrel compose file.
+- The manifest still exposes port `9739`.
+- Manifest default username and password remain empty.
+- No password environment variable is passed to TunnelSats.
+- Version-sync and promotion tests include the updated compose structure.
+
+### umbrelOS end-to-end tests
+
+Run these checks on a supported umbrelOS 1.x installation:
+
+1. Opening TunnelSats from an authenticated Umbrel dashboard loads without a
+   second login prompt.
+2. Visiting `http://umbrel.local:9739` while logged out redirects to Umbrel
+   authentication.
+3. An unauthenticated request to `:9739/api/local/status` cannot read state.
+4. An unauthenticated request cannot invoke any management mutation.
+5. The host's LAN and Tailscale addresses cannot connect directly to port 9740.
+6. The proxy can reach the loopback backend and all existing UI workflows work.
+7. A cross-origin form POST cannot trigger restart, restore, configure,
+   reconcile, or upload behavior.
+8. A cross-origin fetch cannot obtain a CSRF token or invoke a mutation.
+9. Config upload, restart, reconciliation, node configuration, node restoration,
+   subscription renewal, and config export work after normal Umbrel login.
+10. Restarting or upgrading TunnelSats does not create a password file or ask
+    for application credentials.
+11. Access through supported `.local`, IP-literal, Tailscale, and Tor entry
+    points is either functional after Umbrel login or fails closed with a clear,
+    documented configuration path.
+
+## Acceptance Criteria
+
+- TunnelSats uses the existing Umbrel login session and never asks for a second
+  password.
+- `app_proxy` is the only externally reachable HTTP service for TunnelSats.
+- Flask listens only on loopback in the Umbrel deployment.
+- Direct LAN, Tailscale, and ordinary bridged-container access cannot bypass
+  Umbrel authentication.
+- All management mutations require a valid same-origin request and CSRF token.
+- The complete dashboard remains functional after a normal Umbrel login.
+- No generated management credential or Basic Authentication code remains.
+- Tests cover authentication routing, direct-port isolation, CSRF, Origin, Host,
+  proxy forwarding, and existing UI workflows.
+- No k3s manifest or behavior is intentionally changed by this work.
+
+## Out of Scope
+
+- k3s authentication, ingress, Service, NetworkPolicy, or host firewall changes
+- a standalone TunnelSats user database or login page
+- password synchronization with Umbrel
+- programmatic API tokens
+- remote third-party API access to `/api/local`
+- reauthentication for individual high-impact actions
+
+Reauthentication or high-assurance confirmations can be considered separately
+after Umbrel-native authentication and direct-port isolation are in place.

--- a/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
+++ b/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
@@ -5,8 +5,9 @@
 - Scope: umbrelOS deployments with both `SECURE_MODE=false` and
   `SECURE_MODE=true`
 - Related issue: <https://github.com/Tunnelsats/ts-umbrel-app/issues/125>
-- Implementation status: implemented on `issue-125-umbrel-auth`; real-device
-  umbrelOS validation remains pending
+- Implementation status: implemented on `issue-125-umbrel-auth`; the core
+  proxy and listener boundary has been verified on a real umbrelOS device,
+  while the complete two-mode release matrix remains pending
 - Implementation method: test-driven development (red, green, refactor)
 - k3s: explicitly out of scope for this change
 
@@ -30,11 +31,17 @@
   after a backend restart. The CI harness now supplies a dormant proxy stub,
   and the frontend refreshes and retries exactly once when the backend marks a
   CSRF rejection as refreshable.
-- Final local green gate: `280` server tests and `63` frontend tests pass. The
+- In-depth review follow-up red: focused tests reproduced incompatible
+  `ProxyFix` metadata, hostname lockouts, implicit proxy-auth defaults, unsafe
+  non-k3s listener defaults, raw-Compose hot-patching, and unencapsulated CSRF
+  session state before their respective fixes.
+- Final local green gate: `309` server tests and `64` frontend tests pass. The
   compose overlay also renders successfully when merged with Umbrel's upstream
   `docker-compose.app_proxy.yml`.
-- The two-mode real-device umbrelOS end-to-end matrix remains required before
-  release, as described below.
+- Real-device review confirmed that unauthenticated requests to the public
+  proxy are redirected to Umbrel login and that the backend port refuses LAN
+  connections. The complete two-mode real-device matrix remains required
+  before release, as described below.
 
 ## Objective
 
@@ -158,6 +165,8 @@ services:
     environment:
       APP_HOST: 127.0.0.1
       APP_PORT: 9740
+      PROXY_AUTH_ADD: "true"
+      PROXY_AUTH_WHITELIST: ""
 
   tunnelsats:
     network_mode: "host"
@@ -169,8 +178,10 @@ services:
 
 Important requirements:
 
-- Do not set `PROXY_AUTH_ADD=false`.
-- Do not whitelist `/api/local`, static UI paths, or the root path.
+- Set `PROXY_AUTH_ADD=true` explicitly so authentication cannot change with an
+  upstream default.
+- Set `PROXY_AUTH_WHITELIST` explicitly to an empty value; do not whitelist
+  `/api/local`, static UI paths, or the root path.
 - Protect the complete TunnelSats origin so the UI and its API share the same
   Umbrel-authenticated boundary.
 - Keep `umbrel-app.yml` `port: 9739`; this is the port on which the injected
@@ -206,9 +217,10 @@ For the Umbrel compose deployment, set these explicitly to `127.0.0.1` and
 `9740`. Reject invalid port values at startup with a clear error. Log the bind
 address and port without logging credentials or tokens.
 
-Preserve the existing defaults for deployment types not changed by this work so
-that this Umbrel-only change does not silently alter k3s behavior. Do not edit
-the k3s manifests in this implementation.
+Default non-k3s starts to `127.0.0.1:9740` so a missing Compose environment
+cannot silently expose the management API. Preserve the existing
+`0.0.0.0:9739` defaults for k3s, and do not edit k3s manifests in this
+implementation.
 
 Parameterize binding tests for `SECURE_MODE=false` and `SECURE_MODE=true` to
 prove that both resolve to the same loopback address and internal port under
@@ -288,17 +300,15 @@ For Umbrel requests:
 - The forwarded host must be syntactically valid.
 - The request `Origin` must exactly match the effective proxied origin for
   mutations.
-- Known device names from `DEVICE_HOSTNAME`, `DEVICE_DOMAIN_NAME`, and
-  `APP_HIDDEN_SERVICE` should be accepted.
-- IP-literal hosts should be accepted only when they belong to a local host
-  interface, allowing normal access through the Umbrel device's LAN or
-  Tailscale address without a static installation-specific list.
-- Provide an explicit extra-host configuration for installations using an
-  additional reverse proxy or custom DNS name.
+- Once the actual socket peer has been verified as loopback, accept any
+  syntactically valid forwarded host. The proxy-authenticated origin is the
+  authority here; a hostname allowlist adds lockout risk without proving that
+  a request traversed the proxy.
 
-Host validation must be tested with `.local`, direct IPv4, direct IPv6, Tor, and
-any supported Tailscale access pattern. It must not reintroduce the UI lockout
-by assuming every installation uses `umbrel.local`.
+Host validation must be tested with `.local`, `.lan`, direct IPv4, direct IPv6,
+Tor, Tailscale names, and custom DNS names. Malformed authorities remain
+rejected, and mutation Origins must match the accepted authority exactly. This
+must not reintroduce the UI lockout by assuming a particular Umbrel hostname.
 
 The existing private-source network allowlist may remain temporarily as a
 defense-in-depth restriction and for compatibility, but it must no longer be
@@ -335,6 +345,11 @@ instruct users to retrieve a generated password or configure Basic Auth.
 If programmatic management access is required later, design a separate,
 revocable API-token feature with narrowly scoped permissions. It is not part of
 this change and must not weaken the browser authentication path.
+
+The development hot-patch workflow must also install the updated Compose and
+manifest definitions, then ask `umbreld` to restart the app. Calling raw
+`docker compose` is unsupported because only `umbreld` injects the complete
+authenticated `app_proxy` base service.
 
 ## Test-Driven Delivery Order
 
@@ -463,8 +478,8 @@ UI will be unavailable.
 
 - `app_proxy` is present.
 - `APP_HOST` is `127.0.0.1` and `APP_PORT` is `9740`.
-- Proxy authentication is not disabled.
-- No management path is whitelisted.
+- Proxy authentication is explicitly enabled and its whitelist is explicitly
+  empty.
 - The TunnelSats backend binds to `127.0.0.1:9740` in the Umbrel compose file.
 - The manifest still exposes port `9739`.
 - Manifest default username and password remain empty.

--- a/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
+++ b/docs/ISSUE_125_UMBREL_AUTH_PLAN.md
@@ -5,9 +5,31 @@
 - Scope: umbrelOS deployments with both `SECURE_MODE=false` and
   `SECURE_MODE=true`
 - Related issue: <https://github.com/Tunnelsats/ts-umbrel-app/issues/125>
-- Implementation status: planned
+- Implementation status: implemented on `issue-125-umbrel-auth`; real-device
+  umbrelOS validation remains pending
 - Implementation method: test-driven development (red, green, refactor)
 - k3s: explicitly out of scope for this change
+
+## Implementation Record
+
+- Baseline before feature tests: `224` server tests and `59` frontend tests
+  passed.
+- Cycle A red: `7` listener-contract tests failed because configurable binding
+  did not exist; the focused listener suite then passed after implementation.
+- Cycle B red: `32` browser-security tests failed before the centralized Host,
+  Origin, CSRF, content-type, cache, and audit controls were added.
+- Cycle C red: `3` frontend contract tests failed before CSRF bootstrap and the
+  shared `managementFetch` wrapper were implemented.
+- Route-inventory follow-up red: `2` server tests and `1` frontend test exposed
+  the locally mutating subscription-status `GET`; it is now explicitly
+  CSRF-protected.
+- Cycle D red: `3` compose contract tests failed before the authenticated
+  `app_proxy` and loopback backend wiring were added.
+- Final local green gate: `279` server tests and `62` frontend tests pass. The
+  compose overlay also renders successfully when merged with Umbrel's upstream
+  `docker-compose.app_proxy.yml`.
+- The two-mode real-device umbrelOS end-to-end matrix remains required before
+  release, as described below.
 
 ## Objective
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4263,7 +4263,7 @@ if ! ensure_reconcile_kill_switch; then
 fi
 
 echo "Starting Tunnelsats v3 (mode: $([[ "${K3S_MODE}" == "true" ]] && echo "k3s" || echo "umbrel"))..."
-log INFO "Starting internal dashboard server on port 9739"
+log INFO "Starting internal dashboard backend on ${DASHBOARD_BIND_HOST:-0.0.0.0}:${DASHBOARD_BIND_PORT:-9739}"
 python3 /app/server/app.py &
 API_PID=$!
 
@@ -4289,5 +4289,5 @@ ensure_reconcile_dirs
 
 reconcile_once "startup" || true
 
-echo "Tunnelsats container running. UI available on port 9739."
+echo "Tunnelsats container running. Umbrel UI is available through its configured app port."
 main_loop

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -33,6 +33,16 @@ WG_HANDSHAKE_MAX_AGE=180
 # always sees them, even if a future caller passes them as plain shell vars instead of env.
 export K3S_MODE="${K3S_MODE:-false}"
 export SECURE_MODE="${SECURE_MODE:-false}"
+if [[ "${K3S_MODE}" == "true" ]]; then
+    export DASHBOARD_BIND_HOST="${DASHBOARD_BIND_HOST:-0.0.0.0}"
+    export DASHBOARD_BIND_PORT="${DASHBOARD_BIND_PORT:-9739}"
+else
+    # Umbrel app_proxy owns the public port. Keep the privileged backend on
+    # loopback even when a hot-patch or manual container start omits Compose
+    # environment values.
+    export DASHBOARD_BIND_HOST="${DASHBOARD_BIND_HOST:-127.0.0.1}"
+    export DASHBOARD_BIND_PORT="${DASHBOARD_BIND_PORT:-9740}"
+fi
 export LND_K8S_SERVICE="${LND_K8S_SERVICE:-}"
 export CLN_K8S_SERVICE="${CLN_K8S_SERVICE:-}"
 export K8S_NAMESPACE="${K8S_NAMESPACE:-default}"
@@ -4263,7 +4273,7 @@ if ! ensure_reconcile_kill_switch; then
 fi
 
 echo "Starting Tunnelsats v3 (mode: $([[ "${K3S_MODE}" == "true" ]] && echo "k3s" || echo "umbrel"))..."
-log INFO "Starting internal dashboard backend on ${DASHBOARD_BIND_HOST:-0.0.0.0}:${DASHBOARD_BIND_PORT:-9739}"
+log INFO "Starting internal dashboard backend on ${DASHBOARD_BIND_HOST}:${DASHBOARD_BIND_PORT}"
 python3 /app/server/app.py &
 API_PID=$!
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -90,6 +90,7 @@ run_node() {
         echo "SSHPASS=\"${SSHPASS}\""
         echo "SECURE_MODE=\"${SECURE_MODE_VAL}\""
         cat << 'EOF'
+set -euo pipefail
 APP_ID="tunnelsats"
 UMBREL_APP_DATA="/home/umbrel/umbrel/app-data/tunnelsats"
 UMBREL_COMPOSE="${UMBREL_APP_DATA}/docker-compose.yml"
@@ -102,20 +103,29 @@ run_sudo() {
     fi
 }
 
-run_sudo docker rm -f "${APP_ID}" 2>/dev/null || true
-run_sudo env SECURE_MODE="${SECURE_MODE}" APP_DATA_DIR="${UMBREL_APP_DATA}" docker compose -f "${UMBREL_COMPOSE}" up -d
+# Keep the installed app definition aligned with the code being hot-patched.
+# Only umbreld may restart this Compose model because it injects the complete
+# authenticated app_proxy service (image, auth secret, and public port).
+run_sudo cp /home/umbrel/dev-patch/tunnelsats/docker-compose.yml "${UMBREL_COMPOSE}"
+run_sudo cp /home/umbrel/dev-patch/tunnelsats/umbrel-app.yml "${UMBREL_APP_DATA}/umbrel-app.yml"
+run_sudo sed -i "s|SECURE_MODE=\${SECURE_MODE:-false}|SECURE_MODE=${SECURE_MODE}|" "${UMBREL_COMPOSE}"
+umbreld client apps.restart.mutate --appId "${APP_ID}"
 for i in $(seq 1 10); do
     if [ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_ID}" 2>/dev/null)" = "true" ]; then
         break
     fi
     sleep 1
 done
+if [ "$(run_sudo docker inspect -f '{{.State.Running}}' "${APP_ID}" 2>/dev/null)" != "true" ]; then
+    echo "TunnelSats failed to restart through umbreld" >&2
+    exit 1
+fi
 run_sudo docker cp /home/umbrel/dev-patch/server/. "${APP_ID}":/app/server/
 run_sudo docker cp /home/umbrel/dev-patch/web/. "${APP_ID}":/app/web/
 run_sudo docker cp /home/umbrel/dev-patch/scripts/. "${APP_ID}":/app/scripts/
 run_sudo docker cp /home/umbrel/dev-patch/tunnelsats/umbrel-app.yml "${APP_ID}":/app/umbrel-app.yml
 run_sudo docker exec "${APP_ID}" chmod +x /app/scripts/entrypoint.sh /app/scripts/sync.sh 2>/dev/null
-run_sudo docker restart "${APP_ID}"
+run_sudo docker restart "${APP_ID}" >/dev/null
 EOF
     ) | ${SSH_PREFIX}ssh -o StrictHostKeyChecking=accept-new -T umbrel@${UMBREL_HOST} bash
 

--- a/server/app.py
+++ b/server/app.py
@@ -121,6 +121,7 @@ ANNOUNCEMENT_VERIFICATION_ERROR = (
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
 SECURE_MODE = os.environ.get("SECURE_MODE", "false").lower() == "true"
 MANAGEMENT_CSRF_HEADER = "X-TunnelSats-CSRF-Token"
+MANAGEMENT_CSRF_REFRESH_HEADER = "X-TunnelSats-CSRF-Refresh"
 MANAGEMENT_CSRF_TOKEN = secrets.token_urlsafe(32)
 MANAGEMENT_JSON_PATHS = frozenset(
     {
@@ -556,6 +557,8 @@ def _management_security_error(reason):
     )
     response = jsonify({"success": False, "error": "Forbidden"})
     response.status_code = 403
+    if reason == "csrf":
+        response.headers[MANAGEMENT_CSRF_REFRESH_HEADER] = "required"
     return response
 
 

--- a/server/app.py
+++ b/server/app.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import secrets
 import socket
 import subprocess
 import uuid
@@ -10,7 +11,7 @@ from datetime import datetime, timezone
 import time
 from ipaddress import ip_address, ip_network
 from typing import Dict, Any, List, Optional, Tuple, Iterable
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import requests
 import yaml
@@ -119,6 +120,33 @@ ANNOUNCEMENT_VERIFICATION_ERROR = (
 # k3s mode: set via env var K3S_MODE=true to use the Kubernetes API instead of the Docker socket
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
 SECURE_MODE = os.environ.get("SECURE_MODE", "false").lower() == "true"
+MANAGEMENT_CSRF_HEADER = "X-TunnelSats-CSRF-Token"
+MANAGEMENT_CSRF_TOKEN = secrets.token_urlsafe(32)
+MANAGEMENT_JSON_PATHS = frozenset(
+    {
+        "/api/local/upload-config",
+        "/api/local/configure-node",
+        "/api/subscription/renew",
+        "/api/subscription/claim",
+    }
+)
+_local_interface_cache_lock = threading.Lock()
+_local_interface_cache: Tuple[float, frozenset] = (0.0, frozenset())
+LOCAL_INTERFACE_CACHE_TTL_SECONDS = 30
+
+
+def dashboard_bind_config():
+    host = os.environ.get("DASHBOARD_BIND_HOST", "0.0.0.0").strip()
+    raw_port = os.environ.get("DASHBOARD_BIND_PORT", "9739").strip()
+    if not host:
+        raise ValueError("DASHBOARD_BIND_HOST must not be empty")
+    try:
+        port = int(raw_port)
+    except ValueError as exc:
+        raise ValueError("DASHBOARD_BIND_PORT must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError("DASHBOARD_BIND_PORT must be between 1 and 65535")
+    return host, port
 
 def check_tcp_port(ip, port):
     try:
@@ -340,6 +368,195 @@ def is_loopback_ip(remote_addr):
         return ip_address(remote_addr).is_loopback
     except ValueError:
         return False
+
+
+def _normalize_ip(value):
+    candidate = ip_address(value)
+    ipv4_mapped = getattr(candidate, "ipv4_mapped", None)
+    return str(ipv4_mapped or candidate)
+
+
+def _local_interface_addresses():
+    global _local_interface_cache
+    now = time.monotonic()
+    cached_at, cached_addresses = _local_interface_cache
+    if cached_addresses and now - cached_at < LOCAL_INTERFACE_CACHE_TTL_SECONDS:
+        return set(cached_addresses)
+
+    with _local_interface_cache_lock:
+        cached_at, cached_addresses = _local_interface_cache
+        if cached_addresses and now - cached_at < LOCAL_INTERFACE_CACHE_TTL_SECONDS:
+            return set(cached_addresses)
+
+        addresses = {"127.0.0.1", "::1"}
+        try:
+            result = subprocess.run(
+                ["ip", "-j", "address", "show"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+            if result.returncode == 0:
+                for interface in json.loads(result.stdout or "[]"):
+                    for address_info in interface.get("addr_info", []):
+                        local_address = address_info.get("local")
+                        if local_address:
+                            addresses.add(_normalize_ip(local_address))
+        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
+            app.logger.warning("Unable to enumerate local interface addresses for Host validation")
+
+        try:
+            for address_info in socket.getaddrinfo(socket.gethostname(), None):
+                addresses.add(_normalize_ip(address_info[4][0]))
+        except (OSError, ValueError):
+            pass
+
+        _local_interface_cache = (now, frozenset(addresses))
+        return addresses
+
+
+def _parse_host_authority(raw_host):
+    value = str(raw_host or "").strip()
+    if not value or any(char.isspace() for char in value) or any(char in value for char in "/?#@"):
+        return None
+    if value.count(":") >= 2 and not value.startswith("["):
+        try:
+            return _normalize_ip(value), None
+        except ValueError:
+            return None
+    try:
+        parsed = urlsplit(f"//{value}")
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if not hostname or parsed.username is not None or parsed.password is not None:
+        return None
+    try:
+        hostname = _normalize_ip(hostname)
+    except ValueError:
+        pass
+    return hostname, port
+
+
+def _canonical_origin(raw_origin):
+    value = str(raw_origin or "").strip()
+    if not value or value == "null":
+        return None
+    try:
+        parsed = urlsplit(value)
+        hostname = (parsed.hostname or "").rstrip(".").lower()
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme not in ("http", "https")
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in ("", "/")
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    try:
+        hostname = _normalize_ip(hostname)
+    except ValueError:
+        pass
+    return parsed.scheme, hostname, port or (443 if parsed.scheme == "https" else 80)
+
+
+def _configured_management_hosts():
+    values = ["localhost", "127.0.0.1", "::1", socket.gethostname()]
+    for variable in (
+        "DEVICE_HOSTNAME",
+        "DEVICE_DOMAIN_NAME",
+        "APP_HIDDEN_SERVICE",
+        "MANAGEMENT_ALLOWED_HOSTS",
+    ):
+        values.extend(str(os.environ.get(variable, "")).split(","))
+
+    hosts = set()
+    for value in values:
+        value = value.strip()
+        if not value:
+            continue
+        if "://" in value:
+            origin = _canonical_origin(value)
+            if origin:
+                hosts.add(origin[1])
+            continue
+        authority = _parse_host_authority(value)
+        if authority:
+            hosts.add(authority[0])
+    return hosts
+
+
+def _management_host_is_allowed(raw_host):
+    authority = _parse_host_authority(raw_host)
+    if authority is None:
+        return False
+    hostname, _port = authority
+    if hostname in _configured_management_hosts():
+        return True
+    try:
+        normalized_ip = _normalize_ip(hostname)
+    except ValueError:
+        return False
+    return normalized_ip in _local_interface_addresses()
+
+
+def _origin_matches_request(raw_origin):
+    origin = _canonical_origin(raw_origin)
+    authority = _parse_host_authority(request.host)
+    scheme = str(request.scheme or "").lower()
+    if origin is None or authority is None or scheme not in ("http", "https"):
+        return False
+    hostname, port = authority
+    expected = (scheme, hostname, port or (443 if scheme == "https" else 80))
+    return origin == expected
+
+
+def _management_browser_security_enabled():
+    configured = app.config.get("MANAGEMENT_BROWSER_SECURITY_ENABLED")
+    if configured is not None:
+        if isinstance(configured, str):
+            return configured.strip().lower() in ("true", "1", "yes", "on")
+        return bool(configured)
+    return os.environ.get("MANAGEMENT_BROWSER_SECURITY_ENABLED", "false").lower() == "true"
+
+
+def _management_request_is_sensitive():
+    return (
+        request.path.startswith("/api/local")
+        or request.path in ("/api/subscription/renew", "/api/subscription/claim")
+        or request.endpoint == "check_subscription"
+    )
+
+
+def _management_request_changes_state():
+    return request.method not in ("GET", "HEAD", "OPTIONS")
+
+
+def _management_request_requires_csrf():
+    # The subscription status route is a legacy GET that synchronizes paid
+    # subscription data into local metadata. Treat it as a mutation without
+    # changing its public method in this Umbrel-only security change.
+    return _management_request_changes_state() or request.endpoint == "check_subscription"
+
+
+def _management_security_error(reason):
+    app.logger.warning(
+        "Management request rejected: method=%s endpoint=%s remote=%s reason=%s",
+        request.method,
+        request.endpoint or "unknown",
+        request.remote_addr or "unknown",
+        reason,
+    )
+    response = jsonify({"success": False, "error": "Forbidden"})
+    response.status_code = 403
+    return response
 
 
 def normalize_version(raw_version):
@@ -2030,6 +2247,38 @@ def reconcile_result_success(result):
 
 @app.before_request
 def restrict_local_api():
+    if _management_browser_security_enabled() and _management_request_is_sensitive():
+        proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
+        direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.environ.get(
+            "REMOTE_ADDR", ""
+        )
+        if not is_loopback_ip(direct_remote_addr):
+            return _management_security_error("direct-peer")
+        if not _management_host_is_allowed(request.host):
+            return _management_security_error("host")
+        changes_state = _management_request_changes_state()
+        requires_csrf = _management_request_requires_csrf()
+        if changes_state:
+            if request.headers.get("Sec-Fetch-Site", "").lower() == "cross-site":
+                return _management_security_error("fetch-site")
+            if not _origin_matches_request(request.headers.get("Origin")):
+                return _management_security_error("origin")
+        if requires_csrf:
+            supplied_token = request.headers.get(MANAGEMENT_CSRF_HEADER, "")
+            if not supplied_token or not secrets.compare_digest(
+                supplied_token, MANAGEMENT_CSRF_TOKEN
+            ):
+                return _management_security_error("csrf")
+            if changes_state and request.path in MANAGEMENT_JSON_PATHS and not request.is_json:
+                return _management_security_error("content-type")
+            app.logger.info(
+                "Management mutation accepted: method=%s endpoint=%s remote=%s reason=authorized",
+                request.method,
+                request.endpoint or "unknown",
+                request.remote_addr or "unknown",
+            )
+        return None
+
     if request.path.startswith("/api/local") or request.path == "/api/subscription/renew":
         proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
         direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.remote_addr
@@ -2043,6 +2292,14 @@ def restrict_local_api():
 
         if not client_is_allowed(effective_remote_addr):
             abort(403)
+
+
+@app.after_request
+def protect_management_response(response):
+    if _management_browser_security_enabled() and _management_request_is_sensitive():
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Pragma"] = "no-cache"
+    return response
 
 
 # Proxy function to forward requests to the core Tunnelsats API
@@ -2387,11 +2644,7 @@ def claim_subscription():
         payload = {}
     
     # Hide sensitive logs
-    safe_payload = dict(payload)
-    if "wgPresharedKey" in safe_payload:
-        safe_payload["wgPresharedKey"] = "***"
-    
-    app.logger.info(f"Initiating claim upstream with payload: {safe_payload}")
+    app.logger.info("Initiating subscription claim upstream")
     
     try:
         resp = requests.post(url, json=payload, headers={"Content-Type": "application/json"}, timeout=10)
@@ -2401,7 +2654,7 @@ def claim_subscription():
             try:
                 data = resp.json()
             except ValueError as exc:
-                app.logger.error(f"Upstream claim failed JSON decode: {exc}, raw content: {resp.content[:100]}")
+                app.logger.error("Upstream claim returned invalid JSON")
                 return jsonify({"success": False, "error": "Invalid upstream payload (not JSON)"}), 400
 
             if not isinstance(data, dict):
@@ -2495,6 +2748,16 @@ def renew_subscription():
 
 
 # --- LOCAL APP ROUTES ---
+
+@app.route("/api/local/session", methods=["GET"])
+def local_session():
+    return jsonify(
+        {
+            "authenticated": True,
+            "csrf_token": MANAGEMENT_CSRF_TOKEN,
+        }
+    )
+
 
 @app.route("/api/local/status", methods=["GET"])
 def local_status():
@@ -3272,4 +3535,10 @@ def restore_node():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=9739)
+    dashboard_host, dashboard_port = dashboard_bind_config()
+    app.logger.info(
+        "Starting internal dashboard backend on %s:%d",
+        dashboard_host,
+        dashboard_port,
+    )
+    app.run(host=dashboard_host, port=dashboard_port)

--- a/server/app.py
+++ b/server/app.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import secrets
 import socket
 import subprocess
 import uuid
@@ -11,7 +10,7 @@ from datetime import datetime, timezone
 import time
 from ipaddress import ip_address, ip_network
 from typing import Dict, Any, List, Optional, Tuple, Iterable
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote
 
 import requests
 import yaml
@@ -19,6 +18,8 @@ from flask import Flask, abort, jsonify, request, send_from_directory, send_file
 from werkzeug.exceptions import HTTPException
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.utils import secure_filename
+
+from security import ManagementSecurity
 
 # Ensure verbose logging for container restarts is visible and unbuffered
 import logging
@@ -120,9 +121,10 @@ ANNOUNCEMENT_VERIFICATION_ERROR = (
 # k3s mode: set via env var K3S_MODE=true to use the Kubernetes API instead of the Docker socket
 K3S_MODE = os.environ.get("K3S_MODE", "false").lower() == "true"
 SECURE_MODE = os.environ.get("SECURE_MODE", "false").lower() == "true"
-MANAGEMENT_CSRF_HEADER = "X-TunnelSats-CSRF-Token"
-MANAGEMENT_CSRF_REFRESH_HEADER = "X-TunnelSats-CSRF-Refresh"
-MANAGEMENT_CSRF_TOKEN = secrets.token_urlsafe(32)
+MANAGEMENT_SECURITY = ManagementSecurity()
+MANAGEMENT_CSRF_HEADER = MANAGEMENT_SECURITY.csrf_header
+MANAGEMENT_CSRF_REFRESH_HEADER = MANAGEMENT_SECURITY.csrf_refresh_header
+MANAGEMENT_CSRF_TOKEN = MANAGEMENT_SECURITY.csrf_token
 MANAGEMENT_JSON_PATHS = frozenset(
     {
         "/api/local/upload-config",
@@ -131,14 +133,11 @@ MANAGEMENT_JSON_PATHS = frozenset(
         "/api/subscription/claim",
     }
 )
-_local_interface_cache_lock = threading.Lock()
-_local_interface_cache: Tuple[float, frozenset] = (0.0, frozenset())
-LOCAL_INTERFACE_CACHE_TTL_SECONDS = 30
-
-
 def dashboard_bind_config():
-    host = os.environ.get("DASHBOARD_BIND_HOST", "0.0.0.0").strip()
-    raw_port = os.environ.get("DASHBOARD_BIND_PORT", "9739").strip()
+    default_host = "0.0.0.0" if K3S_MODE else "127.0.0.1"
+    default_port = "9739" if K3S_MODE else "9740"
+    host = os.environ.get("DASHBOARD_BIND_HOST", default_host).strip()
+    raw_port = os.environ.get("DASHBOARD_BIND_PORT", default_port).strip()
     if not host:
         raise ValueError("DASHBOARD_BIND_HOST must not be empty")
     try:
@@ -363,160 +362,20 @@ def client_is_allowed(remote_addr):
 
 
 def is_loopback_ip(remote_addr):
-    if not remote_addr:
-        return False
-    try:
-        return ip_address(remote_addr).is_loopback
-    except ValueError:
-        return False
+    return ManagementSecurity.is_loopback_ip(remote_addr)
 
 
-def _normalize_ip(value):
-    candidate = ip_address(value)
-    ipv4_mapped = getattr(candidate, "ipv4_mapped", None)
-    return str(ipv4_mapped or candidate)
+def _get_direct_remote_addr():
+    return MANAGEMENT_SECURITY.direct_remote_addr(request.environ)
 
 
-def _local_interface_addresses():
-    global _local_interface_cache
-    now = time.monotonic()
-    cached_at, cached_addresses = _local_interface_cache
-    if cached_addresses and now - cached_at < LOCAL_INTERFACE_CACHE_TTL_SECONDS:
-        return set(cached_addresses)
-
-    with _local_interface_cache_lock:
-        cached_at, cached_addresses = _local_interface_cache
-        if cached_addresses and now - cached_at < LOCAL_INTERFACE_CACHE_TTL_SECONDS:
-            return set(cached_addresses)
-
-        addresses = {"127.0.0.1", "::1"}
-        try:
-            result = subprocess.run(
-                ["ip", "-j", "address", "show"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-                check=False,
-            )
-            if result.returncode == 0:
-                for interface in json.loads(result.stdout or "[]"):
-                    for address_info in interface.get("addr_info", []):
-                        local_address = address_info.get("local")
-                        if local_address:
-                            addresses.add(_normalize_ip(local_address))
-        except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError):
-            app.logger.warning("Unable to enumerate local interface addresses for Host validation")
-
-        try:
-            for address_info in socket.getaddrinfo(socket.gethostname(), None):
-                addresses.add(_normalize_ip(address_info[4][0]))
-        except (OSError, ValueError):
-            pass
-
-        _local_interface_cache = (now, frozenset(addresses))
-        return addresses
-
-
-def _parse_host_authority(raw_host):
-    value = str(raw_host or "").strip()
-    if not value or any(char.isspace() for char in value) or any(char in value for char in "/?#@"):
-        return None
-    if value.count(":") >= 2 and not value.startswith("["):
-        try:
-            return _normalize_ip(value), None
-        except ValueError:
-            return None
-    try:
-        parsed = urlsplit(f"//{value}")
-        hostname = (parsed.hostname or "").rstrip(".").lower()
-        port = parsed.port
-    except ValueError:
-        return None
-    if not hostname or parsed.username is not None or parsed.password is not None:
-        return None
-    try:
-        hostname = _normalize_ip(hostname)
-    except ValueError:
-        pass
-    return hostname, port
-
-
-def _canonical_origin(raw_origin):
-    value = str(raw_origin or "").strip()
-    if not value or value == "null":
-        return None
-    try:
-        parsed = urlsplit(value)
-        hostname = (parsed.hostname or "").rstrip(".").lower()
-        port = parsed.port
-    except ValueError:
-        return None
-    if (
-        parsed.scheme not in ("http", "https")
-        or not hostname
-        or parsed.username is not None
-        or parsed.password is not None
-        or parsed.path not in ("", "/")
-        or parsed.query
-        or parsed.fragment
-    ):
-        return None
-    try:
-        hostname = _normalize_ip(hostname)
-    except ValueError:
-        pass
-    return parsed.scheme, hostname, port or (443 if parsed.scheme == "https" else 80)
-
-
-def _configured_management_hosts():
-    values = ["localhost", "127.0.0.1", "::1", socket.gethostname()]
-    for variable in (
-        "DEVICE_HOSTNAME",
-        "DEVICE_DOMAIN_NAME",
-        "APP_HIDDEN_SERVICE",
-        "MANAGEMENT_ALLOWED_HOSTS",
-    ):
-        values.extend(str(os.environ.get(variable, "")).split(","))
-
-    hosts = set()
-    for value in values:
-        value = value.strip()
-        if not value:
-            continue
-        if "://" in value:
-            origin = _canonical_origin(value)
-            if origin:
-                hosts.add(origin[1])
-            continue
-        authority = _parse_host_authority(value)
-        if authority:
-            hosts.add(authority[0])
-    return hosts
-
-
-def _management_host_is_allowed(raw_host):
-    authority = _parse_host_authority(raw_host)
-    if authority is None:
-        return False
-    hostname, _port = authority
-    if hostname in _configured_management_hosts():
-        return True
-    try:
-        normalized_ip = _normalize_ip(hostname)
-    except ValueError:
-        return False
-    return normalized_ip in _local_interface_addresses()
+def _management_host_is_allowed(raw_host, direct_remote_addr=None):
+    direct_remote_addr = direct_remote_addr or _get_direct_remote_addr()
+    return MANAGEMENT_SECURITY.host_is_allowed(raw_host, direct_remote_addr)
 
 
 def _origin_matches_request(raw_origin):
-    origin = _canonical_origin(raw_origin)
-    authority = _parse_host_authority(request.host)
-    scheme = str(request.scheme or "").lower()
-    if origin is None or authority is None or scheme not in ("http", "https"):
-        return False
-    hostname, port = authority
-    expected = (scheme, hostname, port or (443 if scheme == "https" else 80))
-    return origin == expected
+    return MANAGEMENT_SECURITY.origin_matches(raw_origin, request.scheme, request.host)
 
 
 def _management_browser_security_enabled():
@@ -2251,13 +2110,10 @@ def reconcile_result_success(result):
 @app.before_request
 def restrict_local_api():
     if _management_browser_security_enabled() and _management_request_is_sensitive():
-        proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
-        direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.environ.get(
-            "REMOTE_ADDR", ""
-        )
+        direct_remote_addr = _get_direct_remote_addr()
         if not is_loopback_ip(direct_remote_addr):
             return _management_security_error("direct-peer")
-        if not _management_host_is_allowed(request.host):
+        if not _management_host_is_allowed(request.host, direct_remote_addr):
             return _management_security_error("host")
         changes_state = _management_request_changes_state()
         requires_csrf = _management_request_requires_csrf()
@@ -2268,9 +2124,7 @@ def restrict_local_api():
                 return _management_security_error("origin")
         if requires_csrf:
             supplied_token = request.headers.get(MANAGEMENT_CSRF_HEADER, "")
-            if not supplied_token or not secrets.compare_digest(
-                supplied_token, MANAGEMENT_CSRF_TOKEN
-            ):
+            if not MANAGEMENT_SECURITY.csrf_matches(supplied_token):
                 return _management_security_error("csrf")
             if changes_state and request.path in MANAGEMENT_JSON_PATHS and not request.is_json:
                 return _management_security_error("content-type")
@@ -2283,8 +2137,7 @@ def restrict_local_api():
         return None
 
     if request.path.startswith("/api/local") or request.path == "/api/subscription/renew":
-        proxyfix_orig = request.environ.get("werkzeug.proxy_fix.orig", {}) or {}
-        direct_remote_addr = proxyfix_orig.get("REMOTE_ADDR") or request.remote_addr
+        direct_remote_addr = _get_direct_remote_addr()
 
         # Trust X-Forwarded-For only when the immediate peer is loopback (local reverse proxy).
         # Direct clients can otherwise spoof forwarded headers to bypass local-network checks.

--- a/server/security.py
+++ b/server/security.py
@@ -1,0 +1,121 @@
+import secrets
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
+
+class ManagementSecurity:
+    """Pure management-request security primitives used by the Flask boundary."""
+
+    csrf_header = "X-TunnelSats-CSRF-Token"
+    csrf_refresh_header = "X-TunnelSats-CSRF-Refresh"
+
+    def __init__(self, csrf_token=None):
+        self.csrf_token = csrf_token or secrets.token_urlsafe(32)
+
+    @staticmethod
+    def normalize_ip(value):
+        candidate = ip_address(value)
+        ipv4_mapped = getattr(candidate, "ipv4_mapped", None)
+        return str(ipv4_mapped or candidate)
+
+    @classmethod
+    def parse_host_authority(cls, raw_host):
+        value = str(raw_host or "").strip()
+        if (
+            not value
+            or any(char.isspace() for char in value)
+            or any(char in value for char in "/?#@")
+        ):
+            return None
+        if value.count(":") >= 2 and not value.startswith("["):
+            try:
+                return cls.normalize_ip(value), None
+            except ValueError:
+                return None
+        try:
+            parsed = urlsplit(f"//{value}")
+            hostname = (parsed.hostname or "").rstrip(".").lower()
+            port = parsed.port
+        except ValueError:
+            return None
+        if not hostname or parsed.username is not None or parsed.password is not None:
+            return None
+        try:
+            hostname = cls.normalize_ip(hostname)
+        except ValueError:
+            pass
+        return hostname, port
+
+    @classmethod
+    def canonical_origin(cls, raw_origin):
+        value = str(raw_origin or "").strip()
+        if not value or value == "null":
+            return None
+        try:
+            parsed = urlsplit(value)
+            hostname = (parsed.hostname or "").rstrip(".").lower()
+            port = parsed.port
+        except ValueError:
+            return None
+        if (
+            parsed.scheme not in ("http", "https")
+            or not hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in ("", "/")
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        try:
+            hostname = cls.normalize_ip(hostname)
+        except ValueError:
+            pass
+        default_port = 443 if parsed.scheme == "https" else 80
+        return parsed.scheme, hostname, port or default_port
+
+    @staticmethod
+    def direct_remote_addr(environ):
+        environ = environ or {}
+        proxyfix_orig = environ.get("werkzeug.proxy_fix.orig")
+        if isinstance(proxyfix_orig, dict):
+            return proxyfix_orig.get("REMOTE_ADDR") or environ.get("REMOTE_ADDR", "")
+        if isinstance(proxyfix_orig, (tuple, list)) and proxyfix_orig:
+            return proxyfix_orig[0] or environ.get("REMOTE_ADDR", "")
+        return environ.get("REMOTE_ADDR", "")
+
+    @staticmethod
+    def is_loopback_ip(value):
+        if not value:
+            return False
+        try:
+            candidate = ip_address(value)
+            normalized = getattr(candidate, "ipv4_mapped", None) or candidate
+            return normalized.is_loopback
+        except (AttributeError, ValueError):
+            return False
+
+    @classmethod
+    def host_is_allowed(cls, raw_host, direct_remote_addr):
+        # app_proxy owns authentication. Once the actual socket peer is
+        # loopback, accept every syntactically valid host so custom DNS,
+        # Tailscale, Tor, and additional reverse proxies cannot lock users out.
+        return cls.parse_host_authority(raw_host) is not None and cls.is_loopback_ip(
+            direct_remote_addr
+        )
+
+    @classmethod
+    def origin_matches(cls, raw_origin, scheme, raw_host):
+        origin = cls.canonical_origin(raw_origin)
+        authority = cls.parse_host_authority(raw_host)
+        scheme = str(scheme or "").lower()
+        if origin is None or authority is None or scheme not in ("http", "https"):
+            return False
+        hostname, port = authority
+        default_port = 443 if scheme == "https" else 80
+        return origin == (scheme, hostname, port or default_port)
+
+    def csrf_matches(self, supplied_token):
+        return bool(supplied_token) and secrets.compare_digest(
+            supplied_token, self.csrf_token
+        )

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -45,6 +45,19 @@ def data_dir(tmp_path):
     with patch('app.DATA_DIR', str(tmp_path)):
         yield tmp_path
 
+
+@pytest.fixture
+def management_browser_security():
+    previous = app.config.get("MANAGEMENT_BROWSER_SECURITY_ENABLED")
+    app.config["MANAGEMENT_BROWSER_SECURITY_ENABLED"] = True
+    try:
+        yield
+    finally:
+        if previous is None:
+            app.config.pop("MANAGEMENT_BROWSER_SECURITY_ENABLED", None)
+        else:
+            app.config["MANAGEMENT_BROWSER_SECURITY_ENABLED"] = previous
+
 # --- Existing Tests ---
 
 def test_status_endpoint(client):
@@ -52,6 +65,334 @@ def test_status_endpoint(client):
     assert res.status_code == 200
     data = json.loads(res.data)
     assert 'wg_status' in data
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+def test_dashboard_bind_config_honors_explicit_loopback_in_both_modes(secure_mode):
+    with patch.dict(
+        os.environ,
+        {
+            "DASHBOARD_BIND_HOST": "127.0.0.1",
+            "DASHBOARD_BIND_PORT": "9740",
+        },
+        clear=False,
+    ), patch.object(app_module, "SECURE_MODE", secure_mode):
+        assert app_module.dashboard_bind_config() == ("127.0.0.1", 9740)
+
+
+def test_dashboard_bind_config_preserves_legacy_defaults():
+    with patch.dict(os.environ, {}, clear=True):
+        assert app_module.dashboard_bind_config() == ("0.0.0.0", 9739)
+
+
+@pytest.mark.parametrize("invalid_port", ["", "not-a-port", "0", "65536"])
+def test_dashboard_bind_config_rejects_invalid_ports(invalid_port):
+    with patch.dict(
+        os.environ,
+        {
+            "DASHBOARD_BIND_HOST": "127.0.0.1",
+            "DASHBOARD_BIND_PORT": invalid_port,
+        },
+        clear=False,
+    ):
+        with pytest.raises(ValueError, match="DASHBOARD_BIND_PORT"):
+            app_module.dashboard_bind_config()
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+def test_management_session_bootstraps_uncached_csrf_in_both_modes(
+    client, management_browser_security, secure_mode
+):
+    with patch.object(app_module, "SECURE_MODE", secure_mode):
+        response = client.get("/api/local/session")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["authenticated"] is True
+    assert isinstance(payload["csrf_token"], str)
+    assert len(payload["csrf_token"]) >= 32
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Pragma"] == "no-cache"
+    assert "WWW-Authenticate" not in response.headers
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+@pytest.mark.parametrize(
+    ("path", "request_kwargs"),
+    [
+        ("/api/local/upload-config", {"json": {"config": "test"}}),
+        ("/api/local/restart", {}),
+        ("/api/local/reconcile", {}),
+        ("/api/local/configure-node", {"json": {"nodeType": "lnd"}}),
+        ("/api/local/restore-node", {}),
+        ("/api/subscription/renew", {"json": {"duration": 1}}),
+        ("/api/subscription/claim", {"json": {"paymentHash": "hash"}}),
+    ],
+)
+def test_management_mutations_require_browser_security_in_both_modes(
+    client,
+    management_browser_security,
+    secure_mode,
+    path,
+    request_kwargs,
+):
+    with patch.object(app_module, "SECURE_MODE", secure_mode):
+        response = client.post(path, **request_kwargs)
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+    assert "WWW-Authenticate" not in response.headers
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+@pytest.mark.parametrize(
+    "origin",
+    [None, "null", "not-an-origin", "https://evil.example"],
+)
+def test_management_mutations_reject_invalid_origins_in_both_modes(
+    client, management_browser_security, secure_mode, origin
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    headers = {"X-TunnelSats-CSRF-Token": csrf_token}
+    if origin is not None:
+        headers["Origin"] = origin
+
+    with patch.object(app_module, "SECURE_MODE", secure_mode):
+        response = client.post("/api/local/restart", headers=headers)
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+def test_management_mutation_accepts_valid_same_origin_csrf_in_both_modes(
+    client, management_browser_security, secure_mode
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    headers = {
+        "Origin": "http://localhost",
+        "X-TunnelSats-CSRF-Token": csrf_token,
+        "Sec-Fetch-Site": "same-origin",
+    }
+
+    with patch.object(app_module, "SECURE_MODE", secure_mode), patch(
+        "builtins.open", MagicMock()
+    ):
+        response = client.post("/api/local/restart", headers=headers)
+
+    assert response.status_code == 200
+    assert response.get_json()["success"] is True
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_management_security_rejects_non_loopback_direct_peer(
+    client, management_browser_security
+):
+    response = client.get(
+        "/api/local/session",
+        headers={"X-Forwarded-For": "127.0.0.1"},
+        environ_base={"REMOTE_ADDR": "192.168.1.20"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+
+
+@pytest.mark.parametrize(
+    ("environment", "forwarded_host"),
+    [
+        ({"DEVICE_DOMAIN_NAME": "umbrel.local"}, "umbrel.local:9739"),
+        ({"APP_HIDDEN_SERVICE": "examplehiddenservice.onion"}, "examplehiddenservice.onion:9739"),
+        ({"MANAGEMENT_ALLOWED_HOSTS": "tunnelsats.example"}, "tunnelsats.example:9739"),
+    ],
+)
+def test_management_security_accepts_known_forwarded_umbrel_hosts(
+    client, management_browser_security, environment, forwarded_host
+):
+    with patch.dict(os.environ, environment, clear=False):
+        response = client.get(
+            "/api/local/session",
+            headers={
+                "X-Forwarded-For": "192.168.1.20",
+                "X-Forwarded-Host": forwarded_host,
+                "X-Forwarded-Proto": "http",
+            },
+            environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        )
+
+    assert response.status_code == 200
+
+
+def test_management_security_rejects_unknown_forwarded_host(
+    client, management_browser_security
+):
+    response = client.get(
+        "/api/local/session",
+        headers={"X-Forwarded-Host": "evil.example"},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+
+
+@pytest.mark.parametrize(
+    ("forwarded_host", "local_address"),
+    [
+        ("192.168.1.10:9739", "192.168.1.10"),
+        ("100.100.10.20:9739", "100.100.10.20"),
+        ("[fd00::10]:9739", "fd00::10"),
+    ],
+)
+def test_management_security_accepts_local_interface_ip_hosts(
+    client, management_browser_security, forwarded_host, local_address
+):
+    with patch(
+        "app._local_interface_addresses",
+        return_value={"127.0.0.1", local_address},
+    ):
+        response = client.get(
+            "/api/local/session",
+            headers={"X-Forwarded-Host": forwarded_host},
+            environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        )
+
+    assert response.status_code == 200
+
+
+def test_management_security_accepts_exact_forwarded_origin(
+    client, management_browser_security
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    with patch.dict(
+        os.environ, {"DEVICE_DOMAIN_NAME": "umbrel.local"}, clear=False
+    ), patch("builtins.open", MagicMock()):
+        response = client.post(
+            "/api/local/restart",
+            headers={
+                "Origin": "https://umbrel.local:9739",
+                "X-Forwarded-Host": "umbrel.local:9739",
+                "X-Forwarded-Proto": "https",
+                "X-TunnelSats-CSRF-Token": csrf_token,
+            },
+            environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        )
+
+    assert response.status_code == 200
+
+
+def test_json_management_route_rejects_form_compatible_body(
+    client, management_browser_security
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    response = client.post(
+        "/api/local/upload-config",
+        data={"config_text": "test"},
+        headers={
+            "Origin": "http://localhost",
+            "X-TunnelSats-CSRF-Token": csrf_token,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+
+
+def test_management_audit_log_does_not_record_supplied_token(
+    client, management_browser_security, caplog
+):
+    supplied_secret = "secret-token-must-not-be-logged"
+    response = client.post(
+        "/api/local/restart",
+        headers={
+            "Origin": "http://localhost",
+            "X-TunnelSats-CSRF-Token": supplied_secret,
+        },
+    )
+
+    assert response.status_code == 403
+    assert "reason=csrf" in caplog.text
+    assert supplied_secret not in caplog.text
+
+
+def test_authenticated_claim_logs_do_not_record_subscription_secrets(
+    client, management_browser_security, caplog
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    payment_secret = "payment-hash-must-not-be-logged"
+    upstream_secret = "upstream-body-must-not-be-logged"
+    upstream_response = MagicMock()
+    upstream_response.status_code = 200
+    upstream_response.content = upstream_secret.encode()
+    upstream_response.json.side_effect = json.JSONDecodeError(
+        "invalid",
+        upstream_secret,
+        0,
+    )
+
+    with patch("app.requests.post", return_value=upstream_response):
+        response = client.post(
+            "/api/subscription/claim",
+            json={
+                "paymentHash": payment_secret,
+                "wgPresharedKey": "preshared-key-must-not-be-logged",
+            },
+            headers={
+                "Origin": "http://localhost",
+                "X-TunnelSats-CSRF-Token": csrf_token,
+            },
+        )
+
+    assert response.status_code == 400
+    assert payment_secret not in caplog.text
+    assert upstream_secret not in caplog.text
+    assert "preshared-key-must-not-be-logged" not in caplog.text
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+def test_subscription_status_with_local_side_effect_requires_csrf_in_both_modes(
+    client, management_browser_security, secure_mode
+):
+    upstream_response = MagicMock()
+    upstream_response.status_code = 200
+    upstream_response.content = b'{"status":"pending"}'
+    upstream_response.headers = {"Content-Type": "application/json"}
+
+    with patch.object(app_module, "SECURE_MODE", secure_mode), patch(
+        "app.requests.get", return_value=upstream_response
+    ) as mock_get:
+        response = client.get("/api/subscription/payment-hash")
+
+    assert response.status_code == 403
+    assert response.get_json() == {"success": False, "error": "Forbidden"}
+    mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize("secure_mode", [False, True])
+def test_subscription_status_accepts_csrf_protected_poll_in_both_modes(
+    client, management_browser_security, secure_mode
+):
+    session = client.get("/api/local/session")
+    csrf_token = session.get_json()["csrf_token"]
+    upstream_response = MagicMock()
+    upstream_response.status_code = 200
+    upstream_response.content = b'{"status":"pending"}'
+    upstream_response.headers = {"Content-Type": "application/json"}
+
+    with patch.object(app_module, "SECURE_MODE", secure_mode), patch(
+        "app.requests.get", return_value=upstream_response
+    ):
+        response = client.get(
+            "/api/subscription/payment-hash",
+            headers={"X-TunnelSats-CSRF-Token": csrf_token},
+        )
+
+    assert response.status_code == 200
 
 
 @patch('app.time.time', return_value=1_000_000)

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -315,6 +315,7 @@ def test_management_audit_log_does_not_record_supplied_token(
     )
 
     assert response.status_code == 403
+    assert response.headers["X-TunnelSats-CSRF-Refresh"] == "required"
     assert "reason=csrf" in caplog.text
     assert supplied_secret not in caplog.text
 

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -80,9 +80,20 @@ def test_dashboard_bind_config_honors_explicit_loopback_in_both_modes(secure_mod
         assert app_module.dashboard_bind_config() == ("127.0.0.1", 9740)
 
 
-def test_dashboard_bind_config_preserves_legacy_defaults():
-    with patch.dict(os.environ, {}, clear=True):
-        assert app_module.dashboard_bind_config() == ("0.0.0.0", 9739)
+@pytest.mark.parametrize(
+    ("k3s_mode", "expected"),
+    [
+        (False, ("127.0.0.1", 9740)),
+        (True, ("0.0.0.0", 9739)),
+    ],
+)
+def test_dashboard_bind_config_defaults_fail_closed_without_changing_k3s(
+    k3s_mode, expected
+):
+    with patch.dict(os.environ, {}, clear=True), patch.object(
+        app_module, "K3S_MODE", k3s_mode
+    ):
+        assert app_module.dashboard_bind_config() == expected
 
 
 @pytest.mark.parametrize("invalid_port", ["", "not-a-port", "0", "65536"])
@@ -201,36 +212,68 @@ def test_management_security_rejects_non_loopback_direct_peer(
 
 
 @pytest.mark.parametrize(
-    ("environment", "forwarded_host"),
+    ("proxyfix_orig", "expected"),
     [
-        ({"DEVICE_DOMAIN_NAME": "umbrel.local"}, "umbrel.local:9739"),
-        ({"APP_HIDDEN_SERVICE": "examplehiddenservice.onion"}, "examplehiddenservice.onion:9739"),
-        ({"MANAGEMENT_ALLOWED_HOSTS": "tunnelsats.example"}, "tunnelsats.example:9739"),
+        ({"REMOTE_ADDR": "127.0.0.2"}, "127.0.0.2"),
+        (("127.0.0.3", "http", "umbrel.local", "9739"), "127.0.0.3"),
+        (None, "127.0.0.4"),
+    ],
+)
+def test_direct_peer_extraction_supports_proxyfix_versions(proxyfix_orig, expected):
+    with app.test_request_context(environ_base={"REMOTE_ADDR": "127.0.0.4"}):
+        if proxyfix_orig is not None:
+            app_module.request.environ["werkzeug.proxy_fix.orig"] = proxyfix_orig
+
+        assert app_module._get_direct_remote_addr() == expected
+
+
+@pytest.mark.parametrize(
+    "forwarded_host",
+    [
+        "umbrel.local:9739",
+        "examplehiddenservice.onion:9739",
+        "tunnelsats.example:9739",
     ],
 )
 def test_management_security_accepts_known_forwarded_umbrel_hosts(
-    client, management_browser_security, environment, forwarded_host
+    client, management_browser_security, forwarded_host
 ):
-    with patch.dict(os.environ, environment, clear=False):
-        response = client.get(
-            "/api/local/session",
-            headers={
-                "X-Forwarded-For": "192.168.1.20",
-                "X-Forwarded-Host": forwarded_host,
-                "X-Forwarded-Proto": "http",
-            },
-            environ_base={"REMOTE_ADDR": "127.0.0.1"},
-        )
+    response = client.get(
+        "/api/local/session",
+        headers={
+            "X-Forwarded-For": "192.168.1.20",
+            "X-Forwarded-Host": forwarded_host,
+            "X-Forwarded-Proto": "http",
+        },
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
 
     assert response.status_code == 200
 
 
-def test_management_security_rejects_unknown_forwarded_host(
-    client, management_browser_security
+@pytest.mark.parametrize(
+    "forwarded_host",
+    ["umbrel.lan:9739", "node.tailnet.ts.net:9739", "custom.home:9739"],
+)
+def test_management_security_accepts_any_valid_host_from_loopback_proxy(
+    client, management_browser_security, forwarded_host
 ):
     response = client.get(
         "/api/local/session",
-        headers={"X-Forwarded-Host": "evil.example"},
+        headers={"X-Forwarded-Host": forwarded_host},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("forwarded_host", ["bad host", "bad.example/path", "[broken"])
+def test_management_security_rejects_malformed_host_from_loopback_proxy(
+    client, management_browser_security, forwarded_host
+):
+    response = client.get(
+        "/api/local/session",
+        headers={"X-Forwarded-Host": forwarded_host},
         environ_base={"REMOTE_ADDR": "127.0.0.1"},
     )
 
@@ -239,25 +282,21 @@ def test_management_security_rejects_unknown_forwarded_host(
 
 
 @pytest.mark.parametrize(
-    ("forwarded_host", "local_address"),
+    "forwarded_host",
     [
-        ("192.168.1.10:9739", "192.168.1.10"),
-        ("100.100.10.20:9739", "100.100.10.20"),
-        ("[fd00::10]:9739", "fd00::10"),
+        "192.168.1.10:9739",
+        "100.100.10.20:9739",
+        "[fd00::10]:9739",
     ],
 )
-def test_management_security_accepts_local_interface_ip_hosts(
-    client, management_browser_security, forwarded_host, local_address
+def test_management_security_accepts_ip_hosts_from_loopback_proxy(
+    client, management_browser_security, forwarded_host
 ):
-    with patch(
-        "app._local_interface_addresses",
-        return_value={"127.0.0.1", local_address},
-    ):
-        response = client.get(
-            "/api/local/session",
-            headers={"X-Forwarded-Host": forwarded_host},
-            environ_base={"REMOTE_ADDR": "127.0.0.1"},
-        )
+    response = client.get(
+        "/api/local/session",
+        headers={"X-Forwarded-Host": forwarded_host},
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
 
     assert response.status_code == 200
 

--- a/server/tests/test_entrypoint_policy.py
+++ b/server/tests/test_entrypoint_policy.py
@@ -26,6 +26,29 @@ def run_bash(script):
         )
 
 
+@pytest.mark.parametrize(
+    ("k3s_mode", "expected_host", "expected_port"),
+    [
+        ("false", "127.0.0.1", "9740"),
+        ("true", "0.0.0.0", "9739"),
+    ],
+)
+def test_dashboard_listener_defaults_are_safe_for_umbrel_and_compatible_with_k3s(
+    k3s_mode, expected_host, expected_port
+):
+    result = run_bash(
+        f'''
+K3S_MODE="{k3s_mode}"
+unset DASHBOARD_BIND_HOST DASHBOARD_BIND_PORT
+source "$1"
+[[ "${{DASHBOARD_BIND_HOST}}" == "{expected_host}" ]]
+[[ "${{DASHBOARD_BIND_PORT}}" == "{expected_port}" ]]
+'''
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_fallback_blackhole_rule_removes_conflicts_and_is_idempotent():
     result = run_bash(
         r'''

--- a/server/tests/test_management_manifest.py
+++ b/server/tests/test_management_manifest.py
@@ -5,8 +5,10 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_PATH = REPO_ROOT / "tunnelsats" / "docker-compose.yml"
+CI_COMPOSE_PATH = REPO_ROOT / "docker-compose.ci.yml"
 MANIFEST_PATH = REPO_ROOT / "tunnelsats" / "umbrel-app.yml"
 APP_PATH = REPO_ROOT / "server" / "app.py"
+TEST_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "test.yml"
 
 
 def load_yaml(path):
@@ -85,3 +87,14 @@ def test_server_does_not_reintroduce_basic_auth_or_password_file():
     assert "management-password" not in source
     assert "MANAGEMENT_PASSWORD" not in source
     assert "Basic realm=" not in source
+
+
+def test_ci_compose_supplies_only_a_dormant_injected_proxy_stub():
+    ci_compose = load_yaml(CI_COMPOSE_PATH)
+    proxy = ci_compose["services"]["app_proxy"]
+    workflow = TEST_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert proxy["image"]
+    assert proxy["profiles"] == ["umbrel-injected-app-proxy"]
+    assert "COMPOSE_FILE: docker-compose.yml:docker-compose.ci.yml" in workflow
+    assert "COMPOSE_PROFILES" not in workflow

--- a/server/tests/test_management_manifest.py
+++ b/server/tests/test_management_manifest.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "tunnelsats" / "docker-compose.yml"
+MANIFEST_PATH = REPO_ROOT / "tunnelsats" / "umbrel-app.yml"
+APP_PATH = REPO_ROOT / "server" / "app.py"
+
+
+def load_yaml(path):
+    with path.open(encoding="utf-8") as source:
+        return yaml.safe_load(source)
+
+
+def environment_map(service):
+    environment = service.get("environment", {})
+    if isinstance(environment, dict):
+        return environment
+    result = {}
+    for entry in environment:
+        key, separator, value = entry.partition("=")
+        result[key] = value if separator else None
+    return result
+
+
+def test_umbrel_compose_uses_authenticated_host_network_app_proxy():
+    compose = load_yaml(COMPOSE_PATH)
+    proxy = compose["services"]["app_proxy"]
+    environment = environment_map(proxy)
+
+    assert proxy["network_mode"] == "host"
+    assert environment["APP_HOST"] == "127.0.0.1"
+    assert int(environment["APP_PORT"]) == 9740
+    assert str(environment.get("PROXY_AUTH_ADD", "true")).lower() != "false"
+    assert not environment.get("PROXY_AUTH_WHITELIST")
+
+
+def test_umbrel_backend_is_loopback_only_with_browser_security_enabled():
+    compose = load_yaml(COMPOSE_PATH)
+    service = compose["services"]["tunnelsats"]
+    environment = environment_map(service)
+
+    assert service["network_mode"] == "host"
+    assert environment["DASHBOARD_BIND_HOST"] == "127.0.0.1"
+    assert int(environment["DASHBOARD_BIND_PORT"]) == 9740
+    assert environment["MANAGEMENT_BROWSER_SECURITY_ENABLED"] == "true"
+
+
+def test_umbrel_http_security_path_is_independent_of_secure_mode():
+    compose = load_yaml(COMPOSE_PATH)
+    environment = environment_map(compose["services"]["tunnelsats"])
+
+    assert environment["SECURE_MODE"] == "${SECURE_MODE:-false}"
+    for name in (
+        "DASHBOARD_BIND_HOST",
+        "DASHBOARD_BIND_PORT",
+        "MANAGEMENT_BROWSER_SECURITY_ENABLED",
+    ):
+        assert "SECURE_MODE" not in str(environment[name])
+
+
+def test_umbrel_manifest_keeps_proxy_port_and_has_no_second_login():
+    manifest = load_yaml(MANIFEST_PATH)
+
+    assert manifest["port"] == 9739
+    assert manifest["defaultUsername"] == ""
+    assert manifest["defaultPassword"] == ""
+
+
+def test_umbrel_compose_does_not_pass_application_password_credentials():
+    compose = load_yaml(COMPOSE_PATH)
+    environment = environment_map(compose["services"]["tunnelsats"])
+
+    assert "APP_PASSWORD" not in environment
+    assert "MANAGEMENT_PASSWORD" not in environment
+    assert "MANAGEMENT_USERNAME" not in environment
+
+
+def test_server_does_not_reintroduce_basic_auth_or_password_file():
+    source = APP_PATH.read_text(encoding="utf-8")
+
+    assert "WWW-Authenticate" not in source
+    assert "management-password" not in source
+    assert "MANAGEMENT_PASSWORD" not in source
+    assert "Basic realm=" not in source

--- a/server/tests/test_management_manifest.py
+++ b/server/tests/test_management_manifest.py
@@ -8,6 +8,7 @@ COMPOSE_PATH = REPO_ROOT / "tunnelsats" / "docker-compose.yml"
 CI_COMPOSE_PATH = REPO_ROOT / "docker-compose.ci.yml"
 MANIFEST_PATH = REPO_ROOT / "tunnelsats" / "umbrel-app.yml"
 APP_PATH = REPO_ROOT / "server" / "app.py"
+SECURITY_PATH = REPO_ROOT / "server" / "security.py"
 TEST_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "test.yml"
 
 
@@ -35,8 +36,8 @@ def test_umbrel_compose_uses_authenticated_host_network_app_proxy():
     assert proxy["network_mode"] == "host"
     assert environment["APP_HOST"] == "127.0.0.1"
     assert int(environment["APP_PORT"]) == 9740
-    assert str(environment.get("PROXY_AUTH_ADD", "true")).lower() != "false"
-    assert not environment.get("PROXY_AUTH_WHITELIST")
+    assert environment["PROXY_AUTH_ADD"] == "true"
+    assert environment["PROXY_AUTH_WHITELIST"] == ""
 
 
 def test_umbrel_backend_is_loopback_only_with_browser_security_enabled():
@@ -87,6 +88,15 @@ def test_server_does_not_reintroduce_basic_auth_or_password_file():
     assert "management-password" not in source
     assert "MANAGEMENT_PASSWORD" not in source
     assert "Basic realm=" not in source
+
+
+def test_management_security_rules_are_extracted_for_standalone_testing():
+    assert SECURITY_PATH.exists()
+    security_source = SECURITY_PATH.read_text(encoding="utf-8")
+    app_source = APP_PATH.read_text(encoding="utf-8")
+
+    assert "class ManagementSecurity" in security_source
+    assert "from security import ManagementSecurity" in app_source
 
 
 def test_ci_compose_supplies_only_a_dormant_injected_proxy_stub():

--- a/server/tests/test_security.py
+++ b/server/tests/test_security.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+import pytest
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from security import ManagementSecurity
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        ({"werkzeug.proxy_fix.orig": {"REMOTE_ADDR": "127.0.0.2"}}, "127.0.0.2"),
+        ({"werkzeug.proxy_fix.orig": ("127.0.0.3", "http", "host", "9739")}, "127.0.0.3"),
+        ({"REMOTE_ADDR": "127.0.0.4"}, "127.0.0.4"),
+        ({"werkzeug.proxy_fix.orig": ()}, ""),
+    ],
+)
+def test_direct_remote_addr_supports_proxyfix_metadata_variants(metadata, expected):
+    assert ManagementSecurity.direct_remote_addr(metadata) == expected
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "umbrel.local:9739",
+        "umbrel.lan:9739",
+        "node.tailnet.ts.net:9739",
+        "example.onion:9739",
+        "192.168.1.20:9739",
+        "[fd00::10]:9739",
+    ],
+)
+def test_valid_hosts_are_accepted_only_from_loopback_proxy(host):
+    assert ManagementSecurity.host_is_allowed(host, "127.0.0.1") is True
+    assert ManagementSecurity.host_is_allowed(host, "192.168.1.20") is False
+
+
+@pytest.mark.parametrize("host", ["", "bad host", "bad.example/path", "[broken"])
+def test_malformed_hosts_are_rejected_even_from_loopback(host):
+    assert ManagementSecurity.host_is_allowed(host, "127.0.0.1") is False
+
+
+def test_origin_comparison_includes_scheme_host_and_effective_port():
+    assert ManagementSecurity.origin_matches(
+        "https://node.tailnet.ts.net:9739", "https", "node.tailnet.ts.net:9739"
+    )
+    assert not ManagementSecurity.origin_matches(
+        "http://node.tailnet.ts.net:9739", "https", "node.tailnet.ts.net:9739"
+    )
+
+
+def test_csrf_comparison_uses_the_session_token():
+    security = ManagementSecurity(csrf_token="known-token")
+
+    assert security.csrf_matches("known-token") is True
+    assert security.csrf_matches("wrong-token") is False
+    assert security.csrf_matches("") is False

--- a/server/tests/test_sync_script.py
+++ b/server/tests/test_sync_script.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_SCRIPT = REPO_ROOT / "scripts" / "sync.sh"
+
+
+def test_node_hot_patch_uses_umbreld_for_authenticated_proxy_compose():
+    source = SYNC_SCRIPT.read_text(encoding="utf-8")
+    node_patch = source[source.index("run_node()") : source.index("run_monorepo()")]
+
+    assert 'dev-patch/tunnelsats/docker-compose.yml' in node_patch
+    assert 'apps.restart.mutate --appId "${APP_ID}"' in node_patch
+    assert 'docker compose -f "${UMBREL_COMPOSE}" up' not in node_patch
+    assert 'docker restart "${APP_ID}"' in node_patch
+    assert r'SECURE_MODE=\${SECURE_MODE:-false}' in node_patch
+    assert node_patch.index('dev-patch/tunnelsats/docker-compose.yml') < node_patch.index(
+        'apps.restart.mutate --appId "${APP_ID}"'
+    )
+    assert node_patch.index('apps.restart.mutate --appId "${APP_ID}"') < node_patch.index(
+        'docker cp /home/umbrel/dev-patch/server/.'
+    )

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       APP_HOST: 127.0.0.1
       APP_PORT: "9740"
+      PROXY_AUTH_ADD: "true"
+      PROXY_AUTH_WHITELIST: ""
 
   tunnelsats:
     # Use the specific version tag for production
@@ -28,10 +30,6 @@ services:
       - DASHBOARD_BIND_HOST=127.0.0.1
       - DASHBOARD_BIND_PORT=9740
       - MANAGEMENT_BROWSER_SECURITY_ENABLED=true
-      - DEVICE_HOSTNAME=${DEVICE_HOSTNAME:-}
-      - DEVICE_DOMAIN_NAME=${DEVICE_DOMAIN_NAME:-}
-      - APP_HIDDEN_SERVICE=${APP_HIDDEN_SERVICE:-}
-      - MANAGEMENT_ALLOWED_HOSTS=${MANAGEMENT_ALLOWED_HOSTS:-}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -1,6 +1,15 @@
 version: "3.7"
 
 services:
+  app_proxy:
+    # TunnelSats requires host networking for its dataplane. Running Umbrel's
+    # authenticated proxy in the same namespace lets it reach the private
+    # loopback-only Flask backend without exposing that backend to the LAN.
+    network_mode: "host"
+    environment:
+      APP_HOST: 127.0.0.1
+      APP_PORT: "9740"
+
   tunnelsats:
     # Use the specific version tag for production
     image: tunnelsats/ts-umbrel-app:3.3.8
@@ -14,6 +23,15 @@ services:
       - apparmor:unconfined
     environment:
       - SECURE_MODE=${SECURE_MODE:-false}
+      # Port 9739 belongs to Umbrel's authenticated app_proxy. The privileged
+      # backend is reachable only through loopback in both Secure Mode states.
+      - DASHBOARD_BIND_HOST=127.0.0.1
+      - DASHBOARD_BIND_PORT=9740
+      - MANAGEMENT_BROWSER_SECURITY_ENABLED=true
+      - DEVICE_HOSTNAME=${DEVICE_HOSTNAME:-}
+      - DEVICE_DOMAIN_NAME=${DEVICE_DOMAIN_NAME:-}
+      - APP_HIDDEN_SERVICE=${APP_HIDDEN_SERVICE:-}
+      - MANAGEMENT_ALLOWED_HOSTS=${MANAGEMENT_ALLOWED_HOSTS:-}
     volumes:
       # Persistent peer directory (Uninstall-safe)
       - ${APP_DATA_DIR}/../tunnelsats-data:/data

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -153,6 +153,46 @@ describe('Management request browser security', () => {
         });
     });
 
+    test('stale CSRF rejection refreshes the token and retries once', async () => {
+        let sessionCalls = 0;
+        let mutationCalls = 0;
+        const sentTokens = [];
+        global.fetch = jest.fn((url, options) => {
+            if (url === '/api/local/session') {
+                sessionCalls += 1;
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({
+                        authenticated: true,
+                        csrf_token: sessionCalls === 1 ? 'old-csrf-token' : 'new-csrf-token'
+                    })
+                });
+            }
+            if (url === '/api/local/restart') {
+                mutationCalls += 1;
+                sentTokens.push(options.headers['X-TunnelSats-CSRF-Token']);
+                if (mutationCalls === 1) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 403,
+                        headers: { get: (name) => name === 'X-TunnelSats-CSRF-Refresh' ? 'required' : null }
+                    });
+                }
+                return Promise.resolve({ ok: true, status: 200 });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        });
+        evalScript();
+        global.fetch.mockClear();
+
+        const response = await window.managementFetch('/api/local/restart', { method: 'POST' });
+
+        expect(response.ok).toBe(true);
+        expect(sessionCalls).toBe(2);
+        expect(mutationCalls).toBe(2);
+        expect(sentTokens).toEqual(['old-csrf-token', 'new-csrf-token']);
+    });
+
     test('all unsafe management endpoints use the common request wrapper', () => {
         const requiredCalls = [
             "managementFetch('/api/subscription/claim'",

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -40,6 +40,24 @@ function setupDOM() {
     Object.defineProperty(document, 'hidden', { value: false, configurable: true });
 }
 
+function csrfFetchMock(implementation = () => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({})
+})) {
+    return jest.fn((url, ...args) => {
+        if (url === '/api/local/session') {
+            return Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({
+                    authenticated: true,
+                    csrf_token: 'test-csrf-token'
+                })
+            });
+        }
+        return implementation(url, ...args);
+    });
+}
+
 function evalScript() {
     // In jsdom, document.readyState is already "complete", so app.js eagerly runs initApp().
     window.eval(script);
@@ -55,7 +73,7 @@ describe('Globe initialization resilience', () => {
         jest.useFakeTimers();
         setupDOM();
 
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({ servers: [], wg_status: 'Disconnected' }),
                 ok: true
@@ -79,12 +97,86 @@ describe('Globe initialization resilience', () => {
     });
 });
 
+describe('Management request browser security', () => {
+    beforeEach(() => {
+        setupDOM();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('unsafe management requests bootstrap and send a CSRF token', async () => {
+        global.fetch = csrfFetchMock((url) => {
+            if (url === '/api/local/session') {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ csrf_token: 'test-csrf-token' })
+                });
+            }
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+        });
+        evalScript();
+        global.fetch.mockClear();
+
+        await window.managementFetch('/api/local/restart', { method: 'POST' });
+
+        expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/local/session', {
+            credentials: 'same-origin'
+        });
+        expect(global.fetch).toHaveBeenNthCalledWith(
+            2,
+            '/api/local/restart',
+            expect.objectContaining({
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: expect.objectContaining({
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                })
+            })
+        );
+    });
+
+    test('safe management requests do not bootstrap a CSRF token', async () => {
+        global.fetch = csrfFetchMock(() => Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ success: true })
+        }));
+        evalScript();
+        global.fetch.mockClear();
+
+        await window.managementFetch('/api/local/status');
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith('/api/local/status', {
+            credentials: 'same-origin'
+        });
+    });
+
+    test('all unsafe management endpoints use the common request wrapper', () => {
+        const requiredCalls = [
+            "managementFetch('/api/subscription/claim'",
+            "managementFetch('/api/local/configure-node'",
+            "managementFetch('/api/local/restore-node'",
+            "managementFetch('/api/local/upload-config'",
+            "managementFetch('/api/local/restart'"
+        ];
+
+        requiredCalls.forEach((call) => expect(script).toContain(call));
+        expect(script).toContain("endpoint === '/api/subscription/renew'");
+        expect(script).toContain("managementFetch(`/api/subscription/${activePaymentHash}`");
+        expect(script).not.toMatch(/fetch\(['"]\/api\/local\/(?:configure-node|restore-node|upload-config|restart)['"]/);
+        expect(script).not.toMatch(/fetch\(['"]\/api\/subscription\/claim['"]/);
+        expect(script).not.toContain("fetch(`/api/subscription/${activePaymentHash}`");
+    });
+});
+
 // --- Test Suites ---
 
 describe('UI Routing and Initialization', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -244,7 +336,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('fetchStatus does not show Protected when no node is detected', async () => {
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -273,7 +365,7 @@ describe('UI Routing and Initialization', () => {
 
     test('fetchStatus reports a fail-closed dataplane error instead of Protected', async () => {
         const error = 'k3s: Pod co-location required; TunnelSats node=worker-a, LND pod=lightning/lnd-0 node=worker-b';
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -302,7 +394,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('fetchStatus never reports Protected when rules are unsynced without a detailed error', async () => {
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -327,7 +419,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('fetchStatus adjusts UI for secure_mode: true', async () => {
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -370,7 +462,7 @@ describe('UI Routing and Initialization', () => {
     });
 
     test('fetchStatus adjusts UI for secure_mode: false', async () => {
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     vpn_active: true,
@@ -407,7 +499,7 @@ describe('UI Routing and Initialization', () => {
     test('configureNode bypasses confirmRestartModal in secure mode', async () => {
         window.secureModeActive = true;
         window.confirmRestartModal = jest.fn().mockResolvedValue(true);
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     success: true,
@@ -431,7 +523,7 @@ describe('UI Routing and Initialization', () => {
     test('restoreNode bypasses confirmRestartModal in secure mode', async () => {
         window.secureModeActive = true;
         window.confirmRestartModal = jest.fn().mockResolvedValue(true);
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     success: true,
@@ -535,7 +627,7 @@ describe('UI Routing and Initialization', () => {
 
     test('manual configuration modal closes on clicking the overlay outside the panel but not inside', async () => {
         window.secureModeActive = true;
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     success: true,
@@ -567,7 +659,7 @@ describe('UI Routing and Initialization', () => {
 
     test('manual restore modal closes on clicking the overlay outside the panel but not inside', async () => {
         window.secureModeActive = true;
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     success: true,
@@ -628,7 +720,7 @@ describe('Phase 1: fetchServers', () => {
     beforeEach(() => {
         setupDOM();
         // Default fetch mock: status endpoint returns disconnected
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/status') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -684,7 +776,7 @@ describe('Phase 1: fetchServers', () => {
 describe('Phase 1: pollPayment detects lowercase paid', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/status') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -722,7 +814,7 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
         invoiceBox.innerHTML = '<p>Waiting...</p>';
 
         // Mock the status check to return paid (lowercase)
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({ status: 'paid' }),
                 ok: true
@@ -747,7 +839,7 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
         invoiceBox.classList.remove('hidden');
         invoiceBox.innerHTML = '<p>Waiting...</p>';
 
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/subscription/buy-hash-123') {
                 return Promise.resolve({
                     json: () => Promise.resolve({ status: 'paid' }),
@@ -780,7 +872,10 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
             '/api/subscription/claim',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                }),
                 body: JSON.stringify({ paymentHash: 'buy-hash-123', wgPublicKey: '', wgPresharedKey: '', referralCode: null })
             })
         );
@@ -789,7 +884,7 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
     test('claimSubscription treats success payload with informational error field as success', async () => {
         window.activePaymentHash = 'buy-hash-123';
 
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/subscription/claim') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -813,7 +908,7 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
         window.activePaymentHash = 'buy-hash-123';
         document.getElementById('pending-install-section').classList.remove('hidden');
 
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/subscription/claim') {
                 return Promise.resolve({
                     json: () => Promise.resolve({ success: true }),
@@ -848,7 +943,7 @@ describe('Phase 1: pollPayment detects lowercase paid', () => {
 describe('Phase 1: createSub generates invoice', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn((url, opts) => {
+        global.fetch = csrfFetchMock((url, opts) => {
             if (url === '/api/local/status') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -915,7 +1010,7 @@ describe('Phase 1: createSub generates invoice', () => {
     });
 
     test('surfaces backend errors for createSub', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/status') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1025,7 +1120,7 @@ describe('Phase 1: createSub generates invoice', () => {
 describe('Phase 2: Renew Flow', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn((url, options) => {
+        global.fetch = csrfFetchMock((url, options) => {
             if (url === '/api/local/meta') {
                 return Promise.resolve({
                     json: () => Promise.resolve({ serverId: 'ch-zrh', wgPublicKey: 'pubkey789' }),
@@ -1087,7 +1182,7 @@ describe('Phase 2: Renew Flow', () => {
         await new Promise(process.nextTick);
 
         // Force renew API failure response.
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/meta') {
                 return Promise.resolve({
                     json: () => Promise.resolve({ serverId: 'ch-zrh', wgPublicKey: 'pubkey789' }),
@@ -1123,7 +1218,7 @@ describe('Phase 2: Renew Flow', () => {
 describe('Phase 3a: Import Config', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/status') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1192,7 +1287,10 @@ describe('Phase 3a: Import Config', () => {
             '/api/local/upload-config',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                }),
                 body: JSON.stringify({ config: expectedConfig })
             })
         );
@@ -1239,14 +1337,17 @@ describe('Phase 3a: Import Config', () => {
             '/api/local/upload-config',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                }),
                 body: JSON.stringify({ config: expectedConfig })
             })
         );
     });
 
     test('import renders backend error message', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/upload-config') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1278,7 +1379,7 @@ describe('Phase 3a: Import Config', () => {
 describe('Phase 3b: Install Config', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn((url, opts) => {
+        global.fetch = csrfFetchMock((url, opts) => {
             if (url === '/api/local/configure-node') {
                 const payload = opts && opts.body ? JSON.parse(opts.body) : {};
                 if (payload.nodeType === 'cln') {
@@ -1350,7 +1451,10 @@ describe('Phase 3b: Install Config', () => {
             '/api/local/configure-node',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                }),
                 body: JSON.stringify({ nodeType: 'lnd' })
             })
         );
@@ -1366,14 +1470,17 @@ describe('Phase 3b: Install Config', () => {
             '/api/local/configure-node',
             expect.objectContaining({
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: expect.objectContaining({
+                    'Content-Type': 'application/json',
+                    'X-TunnelSats-CSRF-Token': 'test-csrf-token'
+                }),
                 body: JSON.stringify({ nodeType: 'cln' })
             })
         );
     });
 
     test('configureNode requires explicit confirmation before disabling conflicting announcements', async () => {
-        global.fetch = jest.fn()
+        const endpointFetch = jest.fn()
             .mockResolvedValueOnce({
                 status: 409,
                 ok: false,
@@ -1394,6 +1501,7 @@ describe('Phase 3b: Install Config', () => {
                 })
             })
             .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+        global.fetch = csrfFetchMock((...args) => endpointFetch(...args));
         window.confirmAnnouncementChanges = jest.fn().mockResolvedValue({
             confirmed: true,
             retainTorAnnouncements: true
@@ -1405,8 +1513,8 @@ describe('Phase 3b: Install Config', () => {
             'externalip=198.51.100.10:9735',
             'nat=true'
         ]);
-        expect(global.fetch.mock.calls[1][0]).toBe('/api/local/configure-node');
-        expect(JSON.parse(global.fetch.mock.calls[1][1].body)).toEqual({
+        expect(endpointFetch.mock.calls[1][0]).toBe('/api/local/configure-node');
+        expect(JSON.parse(endpointFetch.mock.calls[1][1].body)).toEqual({
             nodeType: 'lnd',
             confirmAddressChanges: true,
             retainTorAnnouncements: true
@@ -1414,7 +1522,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('configureNode handles HTML error pages gracefully without throwing syntax error', async () => {
-        global.fetch.mockImplementationOnce((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/configure-node') {
                 return Promise.resolve({
                     ok: false,
@@ -1448,7 +1556,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('restoreNode rejects an HTML response even when its HTTP status is 200', async () => {
-        global.fetch.mockImplementationOnce((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/restore-node') {
                 return Promise.resolve({
                     ok: true,
@@ -1468,7 +1576,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('restoreNode reports missing configs clearly', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/restore-node') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1501,7 +1609,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('configureNode handles manual_mode and renders instructions modal', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/configure-node') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1539,7 +1647,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('restoreNode handles manual_mode and renders manual restore modal', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/restore-node') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1576,7 +1684,7 @@ describe('Phase 3b: Install Config', () => {
     });
 
     test('restoreNode handles manual_mode with empty targets gracefully', async () => {
-        global.fetch = jest.fn((url) => {
+        global.fetch = csrfFetchMock((url) => {
             if (url === '/api/local/restore-node') {
                 return Promise.resolve({
                     json: () => Promise.resolve({
@@ -1618,7 +1726,7 @@ describe('NWC Auto-Renew Features', () => {
     afterEach(() => { jest.restoreAllMocks(); });
 
     test('fetchStatus updates NWC IP suffix element', async () => {
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({
                     wg_status: 'Connected',
@@ -1658,7 +1766,7 @@ describe('NWC Auto-Renew Features', () => {
 describe('Subscription Renewal Fixes', () => {
     beforeEach(() => {
         setupDOM();
-        global.fetch = jest.fn(() =>
+        global.fetch = csrfFetchMock(() =>
             Promise.resolve({
                 json: () => Promise.resolve({ 
                     status: 'paid', 

--- a/web/__tests__/app.test.js
+++ b/web/__tests__/app.test.js
@@ -137,6 +137,13 @@ describe('Management request browser security', () => {
         );
     });
 
+    test('management session state is encapsulated behind a session manager', () => {
+        expect(script).toContain('class ManagementSession');
+        expect(script).toContain('const managementSession = new ManagementSession()');
+        expect(script).not.toContain('let managementCsrfToken');
+        expect(script).not.toContain('let managementCsrfPromise');
+    });
+
     test('safe management requests do not bootstrap a CSRF token', async () => {
         global.fetch = csrfFetchMock(() => Promise.resolve({
             ok: true,

--- a/web/index.html
+++ b/web/index.html
@@ -756,12 +756,15 @@
                             <h3 class="text-white font-bold mb-2 text-base">3. How can I verify my connection from the
                                 command line?</h3>
                             <div class="text-sm text-gray-300 space-y-3 leading-relaxed">
-                                <p>The dashboard uses our internal <strong>Dataplane API</strong>. You can query this
-                                    directly via SSH to debug your network state:</p>
+                                <p>The dashboard uses an Umbrel-authenticated <strong>Dataplane API</strong>. From an
+                                    SSH session on the Umbrel host, query its loopback-only backend to debug your
+                                    network state:</p>
                                 <div
                                     class="font-mono text-tsgreen bg-gray-900 border border-gray-800 p-2.5 rounded-lg text-xs overflow-x-auto shadow-inner">
-                                    curl -s http://umbrel.lan:9739/api/local/status | jq</div>
-                                <p>This returns a JSON payload containing the active WireGuard endpoint, internal
+                                    curl -s http://127.0.0.1:9740/api/local/status | jq</div>
+                                <p>Port 9739 is the authenticated Umbrel proxy, not a public LAN API. Perform
+                                    state-changing actions through the dashboard. The loopback status request returns
+                                    a JSON payload containing the active WireGuard endpoint, internal
                                     routing metrics, and any failure logs (<code
                                         class="bg-gray-900 border border-gray-800 px-1 py-0.5 rounded text-tsgreen font-mono text-xs">last_error</code>).
                                     To check the live WireGuard handshake:</p>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -12,61 +12,71 @@ const POLL_INTERVAL_MS = 3000;
 let tsServers = [];
 const MANAGEMENT_CSRF_HEADER = 'X-TunnelSats-CSRF-Token';
 const MANAGEMENT_CSRF_REFRESH_HEADER = 'X-TunnelSats-CSRF-Refresh';
-let managementCsrfToken = null;
-let managementCsrfPromise = null;
-
-async function ensureManagementCsrfToken() {
-    if (managementCsrfToken) return managementCsrfToken;
-    if (!managementCsrfPromise) {
-        managementCsrfPromise = fetch('/api/local/session', {
-            credentials: 'same-origin'
-        }).then(async (response) => {
-            const payload = await response.json();
-            if (!response.ok || typeof payload.csrf_token !== 'string' || !payload.csrf_token) {
-                throw new Error('Unable to initialize the management session.');
-            }
-            managementCsrfToken = payload.csrf_token;
-            return managementCsrfToken;
-        }).finally(() => {
-            managementCsrfPromise = null;
-        });
+class ManagementSession {
+    constructor() {
+        this.csrfToken = null;
+        this.csrfPromise = null;
     }
-    return managementCsrfPromise;
+
+    async ensureCsrfToken() {
+        if (this.csrfToken) return this.csrfToken;
+        if (!this.csrfPromise) {
+            this.csrfPromise = fetch('/api/local/session', {
+                credentials: 'same-origin'
+            }).then(async (response) => {
+                const payload = await response.json();
+                if (!response.ok || typeof payload.csrf_token !== 'string' || !payload.csrf_token) {
+                    throw new Error('Unable to initialize the management session.');
+                }
+                this.csrfToken = payload.csrf_token;
+                return this.csrfToken;
+            }).finally(() => {
+                this.csrfPromise = null;
+            });
+        }
+        return this.csrfPromise;
+    }
+
+    async fetch(url, options = {}) {
+        const { requireCsrf = false, ...fetchOptions } = options;
+        const method = String(fetchOptions.method || 'GET').toUpperCase();
+        const requestOptions = {
+            ...fetchOptions,
+            credentials: 'same-origin'
+        };
+        const csrfRequired = requireCsrf || !['GET', 'HEAD', 'OPTIONS'].includes(method);
+        let csrfToken = null;
+        if (csrfRequired) {
+            csrfToken = await this.ensureCsrfToken();
+            requestOptions.headers = {
+                ...(fetchOptions.headers || {}),
+                [MANAGEMENT_CSRF_HEADER]: csrfToken
+            };
+        }
+        const response = await fetch(url, requestOptions);
+        const refreshRequired = response.status === 403
+            && response.headers
+            && typeof response.headers.get === 'function'
+            && response.headers.get(MANAGEMENT_CSRF_REFRESH_HEADER) === 'required';
+        if (!csrfRequired || !refreshRequired) return response;
+
+        // A backend restart rotates its process-scoped token while the dashboard
+        // can remain open. Refresh and retry exactly once, and do not discard a
+        // token that another concurrent request may already have refreshed.
+        if (this.csrfToken === csrfToken) this.csrfToken = null;
+        const refreshedToken = await this.ensureCsrfToken();
+        requestOptions.headers = {
+            ...requestOptions.headers,
+            [MANAGEMENT_CSRF_HEADER]: refreshedToken
+        };
+        return fetch(url, requestOptions);
+    }
 }
 
-async function managementFetch(url, options = {}) {
-    const { requireCsrf = false, ...fetchOptions } = options;
-    const method = String(fetchOptions.method || 'GET').toUpperCase();
-    const requestOptions = {
-        ...fetchOptions,
-        credentials: 'same-origin'
-    };
-    const csrfRequired = requireCsrf || !['GET', 'HEAD', 'OPTIONS'].includes(method);
-    let csrfToken = null;
-    if (csrfRequired) {
-        csrfToken = await ensureManagementCsrfToken();
-        requestOptions.headers = {
-            ...(fetchOptions.headers || {}),
-            [MANAGEMENT_CSRF_HEADER]: csrfToken
-        };
-    }
-    const response = await fetch(url, requestOptions);
-    const refreshRequired = response.status === 403
-        && response.headers
-        && typeof response.headers.get === 'function'
-        && response.headers.get(MANAGEMENT_CSRF_REFRESH_HEADER) === 'required';
-    if (!csrfRequired || !refreshRequired) return response;
+const managementSession = new ManagementSession();
 
-    // A backend restart rotates its process-scoped token while the dashboard
-    // can remain open. Refresh and retry exactly once, and do not discard a
-    // token that another concurrent request may already have refreshed.
-    if (managementCsrfToken === csrfToken) managementCsrfToken = null;
-    const refreshedToken = await ensureManagementCsrfToken();
-    requestOptions.headers = {
-        ...requestOptions.headers,
-        [MANAGEMENT_CSRF_HEADER]: refreshedToken
-    };
-    return fetch(url, requestOptions);
+async function managementFetch(url, options = {}) {
+    return managementSession.fetch(url, options);
 }
 
 window.managementFetch = managementFetch;

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -11,6 +11,7 @@ let currentSatsPerDollar = null;
 const POLL_INTERVAL_MS = 3000;
 let tsServers = [];
 const MANAGEMENT_CSRF_HEADER = 'X-TunnelSats-CSRF-Token';
+const MANAGEMENT_CSRF_REFRESH_HEADER = 'X-TunnelSats-CSRF-Refresh';
 let managementCsrfToken = null;
 let managementCsrfPromise = null;
 
@@ -40,13 +41,31 @@ async function managementFetch(url, options = {}) {
         ...fetchOptions,
         credentials: 'same-origin'
     };
-    if (requireCsrf || !['GET', 'HEAD', 'OPTIONS'].includes(method)) {
-        const csrfToken = await ensureManagementCsrfToken();
+    const csrfRequired = requireCsrf || !['GET', 'HEAD', 'OPTIONS'].includes(method);
+    let csrfToken = null;
+    if (csrfRequired) {
+        csrfToken = await ensureManagementCsrfToken();
         requestOptions.headers = {
             ...(fetchOptions.headers || {}),
             [MANAGEMENT_CSRF_HEADER]: csrfToken
         };
     }
+    const response = await fetch(url, requestOptions);
+    const refreshRequired = response.status === 403
+        && response.headers
+        && typeof response.headers.get === 'function'
+        && response.headers.get(MANAGEMENT_CSRF_REFRESH_HEADER) === 'required';
+    if (!csrfRequired || !refreshRequired) return response;
+
+    // A backend restart rotates its process-scoped token while the dashboard
+    // can remain open. Refresh and retry exactly once, and do not discard a
+    // token that another concurrent request may already have refreshed.
+    if (managementCsrfToken === csrfToken) managementCsrfToken = null;
+    const refreshedToken = await ensureManagementCsrfToken();
+    requestOptions.headers = {
+        ...requestOptions.headers,
+        [MANAGEMENT_CSRF_HEADER]: refreshedToken
+    };
     return fetch(url, requestOptions);
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -10,6 +10,47 @@ const DISCOUNTS = { 1: 0, 3: 0.05, 6: 0.10, 12: 0.20 };
 let currentSatsPerDollar = null;
 const POLL_INTERVAL_MS = 3000;
 let tsServers = [];
+const MANAGEMENT_CSRF_HEADER = 'X-TunnelSats-CSRF-Token';
+let managementCsrfToken = null;
+let managementCsrfPromise = null;
+
+async function ensureManagementCsrfToken() {
+    if (managementCsrfToken) return managementCsrfToken;
+    if (!managementCsrfPromise) {
+        managementCsrfPromise = fetch('/api/local/session', {
+            credentials: 'same-origin'
+        }).then(async (response) => {
+            const payload = await response.json();
+            if (!response.ok || typeof payload.csrf_token !== 'string' || !payload.csrf_token) {
+                throw new Error('Unable to initialize the management session.');
+            }
+            managementCsrfToken = payload.csrf_token;
+            return managementCsrfToken;
+        }).finally(() => {
+            managementCsrfPromise = null;
+        });
+    }
+    return managementCsrfPromise;
+}
+
+async function managementFetch(url, options = {}) {
+    const { requireCsrf = false, ...fetchOptions } = options;
+    const method = String(fetchOptions.method || 'GET').toUpperCase();
+    const requestOptions = {
+        ...fetchOptions,
+        credentials: 'same-origin'
+    };
+    if (requireCsrf || !['GET', 'HEAD', 'OPTIONS'].includes(method)) {
+        const csrfToken = await ensureManagementCsrfToken();
+        requestOptions.headers = {
+            ...(fetchOptions.headers || {}),
+            [MANAGEMENT_CSRF_HEADER]: csrfToken
+        };
+    }
+    return fetch(url, requestOptions);
+}
+
+window.managementFetch = managementFetch;
 
 // Badge States Constants for Routing Status
 const BADGE_STATES = {
@@ -94,6 +135,15 @@ async function mockFetch(url) {
                 serverId: 'unknown',
                 serverDomain: 'au1.tunnelsats.com',
                 wgPublicKey: 'MOCK_WG_PUBKEY_XYZ'
+            }
+        };
+    }
+    if (url === '/api/local/session') {
+        return {
+            ok: true,
+            body: {
+                authenticated: true,
+                csrf_token: 'mock-management-csrf-token'
             }
         };
     }
@@ -632,7 +682,7 @@ function switchTab(tabId) {
     }
 
     if (tabId === 'renew') {
-        fetch('/api/local/meta').then(r => r.json()).then(data => {
+        managementFetch('/api/local/meta').then(r => r.json()).then(data => {
             let lookupId = data.serverId;
             // Handle naming mismatch: /api/local/meta (metadata JSON) uses camelCase.
             const sDomain = data.serverDomain || data.server_domain;
@@ -721,7 +771,7 @@ function applySecureModeUI(isSecureMode) {
 // 1. Fetch Local Status
 async function fetchStatus() {
     try {
-        const res = await fetch('/api/local/status');
+        const res = await managementFetch('/api/local/status');
         const data = await res.json();
 
         const vpnActive = data.vpn_active === true;
@@ -1068,7 +1118,10 @@ async function createSub(mode) {
             }
         }
 
-        const res = await fetch(endpoint, {
+        const requestFunction = endpoint === '/api/subscription/renew'
+            ? managementFetch
+            : fetch;
+        const res = await requestFunction(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
@@ -1128,7 +1181,9 @@ async function pollPayment() {
     if (document.hidden) return;
 
     try {
-        const res = await fetch(`/api/subscription/${activePaymentHash}`);
+        const res = await managementFetch(`/api/subscription/${activePaymentHash}`, {
+            requireCsrf: true
+        });
         const data = await res.json();
 
         if (data.status === 'paid') {
@@ -1207,7 +1262,7 @@ async function claimSubscription(mode) {
     }
 
     try {
-        const res = await fetch('/api/subscription/claim', {
+        const res = await managementFetch('/api/subscription/claim', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ paymentHash: activePaymentHash, wgPublicKey: "", wgPresharedKey: "", referralCode: null })
@@ -1749,7 +1804,7 @@ async function configureNode() {
     setActionMessage('configure-node-msg', 'Applying node configuration...', 'info');
 
     try {
-        let res = await fetch('/api/local/configure-node', {
+        let res = await managementFetch('/api/local/configure-node', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ nodeType: selectedNodeType })
@@ -1762,7 +1817,7 @@ async function configureNode() {
                 setActionMessage('configure-node-msg', 'Configuration cancelled; existing announcement settings were not changed.', 'info');
                 return;
             }
-            res = await fetch('/api/local/configure-node', {
+            res = await managementFetch('/api/local/configure-node', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -1818,7 +1873,7 @@ async function restoreNode() {
     setActionMessage('restore-node-msg', 'Restoring node configuration...', 'info');
 
     try {
-        const res = await fetch('/api/local/restore-node', { method: 'POST' });
+        const res = await managementFetch('/api/local/restore-node', { method: 'POST' });
         const data = await safeFetchJson(res);
 
         if (res.ok && data.success !== false) {
@@ -2055,7 +2110,7 @@ async function importConfig() {
     setImportMessage("Importing...", 'info');
 
     try {
-        let res = await fetch('/api/local/upload-config', {
+        let res = await managementFetch('/api/local/upload-config', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ config })
@@ -2073,7 +2128,7 @@ async function importConfig() {
 
             // Retry with confirm=true
             setImportMessage("Saving expired config...", 'info');
-            res = await fetch('/api/local/upload-config', {
+            res = await managementFetch('/api/local/upload-config', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ config, confirm: true })
@@ -2129,7 +2184,7 @@ async function pollUntilConnected(options = {}) {
 
 async function restartTunnel(pollOptions = {}) {
     try {
-        const res = await fetch('/api/local/restart', { method: 'POST' });
+        const res = await managementFetch('/api/local/restart', { method: 'POST' });
         if (res.ok) {
             // The container entrypoint will catch the trigger file, and restart `wg-quick`.
             void pollUntilConnected(pollOptions);
@@ -2241,7 +2296,7 @@ async function downloadWireGuardConfig() {
         const downloadUrl = '/api/local/export-config';
 
         // 1. Verify config availability first
-        const check = await fetch(downloadUrl);
+        const check = await managementFetch(downloadUrl);
         if (!check.ok) {
             const errData = await check.json().catch(() => ({}));
             alert(errData.error || 'No active WireGuard configuration profile found.');
@@ -2270,4 +2325,3 @@ async function downloadWireGuardConfig() {
     }
 }
 window.downloadWireGuardConfig = downloadWireGuardConfig;
-


### PR DESCRIPTION
## Summary

- route all Umbrel UI and management API traffic through the authenticated app_proxy on port 9739
- bind the Flask backend to 127.0.0.1:9740 for Umbrel while preserving legacy defaults outside this deployment
- add centralized direct-peer, Host, Origin, CSRF, JSON content-type, no-store, and secret-safe audit protections
- migrate frontend management requests to a shared CSRF-aware wrapper
- apply the same authentication boundary with SECURE_MODE=false and SECURE_MODE=true
- remove stale unauthenticated API documentation without introducing a second login or generated password
- leave k3s unchanged

## TDD evidence

The implementation plan records the focused red-to-green cycles for listener binding, backend browser security, frontend CSRF handling, the mutating subscription-status route, and the Umbrel compose contract.

Final green gate:

- .venv-tests/bin/pytest -q server/tests: 279 passed
- npm test -- --runInBand: 62 passed
- bash syntax, Python compilation, and git diff checks passed
- the compose overlay renders successfully with the current upstream Umbrel app_proxy base compose

## Deployment validation

Real-device umbrelOS end-to-end validation remains a pre-release requirement and must be run in both Secure Mode states.

Closes #125