### PR TITLE
chore(release): bump version to v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 ## [3.3.8]
 
 - Secure Mode: Backup WireGuard Config view, native file download, modal UX fixes, and gossip verification via read-only lnd.conf audit
+
+## [3.4.0]
+
+- Secure management API with native Umbrel authentication and optimize browser favicon for high-resolution display

--- a/k3s/deployment.yaml
+++ b/k3s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
         - name: tunnelsats
           # Pin to an immutable tag before production use:
-          image: tunnelsats/ts-umbrel-app:3.3.8
+          image: tunnelsats/ts-umbrel-app:3.4.0
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/server/app.py
+++ b/server/app.py
@@ -29,7 +29,7 @@ app = Flask(__name__, static_folder="../web", static_url_path="")
 # Umbrel uses a reverse proxy. Parse X-Forwarded-* headers before IP restrictions.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
-APP_VERSION = "v3.3.8"
+APP_VERSION = "v3.4.0"
 APP_MANIFEST_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "umbrel-app.yml"))
 
 class SecurityHeadersMiddleware:

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   tunnelsats:
     # Use the specific version tag for production
-    image: tunnelsats/ts-umbrel-app:3.3.8
+    image: tunnelsats/ts-umbrel-app:3.4.0
     container_name: tunnelsats
     restart: on-failure
     network_mode: "host"

--- a/tunnelsats/umbrel-app.yml
+++ b/tunnelsats/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tunnelsats
 category: bitcoin
 name: Tunnel⚡Sats
-version: "3.3.8"
+version: "3.4.0"
 tagline: Secure, Lightning-only VPN routing for your LND and CLN node
 description: >-
   Tunnel⚡Sats provides a premium, privacy-preserving networking layer designed exclusively for LND and Core Lightning node runners. By utilizing high-performance WireGuard tunnels, it solves the 'Home IP' exposure conundrum and enables stable, anonymous clearnet connectivity without compromising your entire Umbrel’s traffic.
@@ -16,7 +16,7 @@ description: >-
 
 
   Ideal for users on dynamic home IPs, behind CGNAT, or those seeking an extra layer of privacy for their Lightning peering.
-releaseNotes: "Secure Mode: Backup WireGuard Config view, native file download, modal UX fixes, and gossip verification via read-only lnd.conf audit"
+releaseNotes: "Secure management API with native Umbrel authentication and optimize browser favicon for high-resolution display"
 developer: TunnelSats Team
 website: https://tunnelsats.com
 dependencies: []

--- a/web/index.html
+++ b/web/index.html
@@ -1054,7 +1054,7 @@
                 <div class="flex flex-col">
                     <h1 class="text-xl font-bold text-white tracking-wider">Tunnel<span
                             class="text-tsyellow">Sats</span></h1>
-                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.3.8</span>
+                    <span id="app-version" class="text-[10px] font-mono text-tsgreen/80 mt-0.5 tracking-tighter">v3.4.0</span>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

- Bump TunnelSats version from `v3.3.8` to `v3.4.0` across all 5 canonical file locations (`server/app.py`, `tunnelsats/umbrel-app.yml`, `tunnelsats/docker-compose.yml`, `k3s/deployment.yaml`, `web/index.html`).
- Populate consolidated release notes in `umbrel-app.yml` and `CHANGELOG.md`.

## Changes included in v3.4.0

- **PR #138**: Secure management API with native Umbrel authentication proxy integration, CSRF double-submit protection, session bootstrap, and secure mode handling.
- **PR #140**: Optimize browser favicon viewBox cropping and resolution matching StartOS standard.

## Validation

- `pytest server/tests/` (309 passed)
- `pytest server/tests/test_version_sync.py server/tests/test_bump_version.py` (24 passed)
- `npm test --prefix web` (65 passed)
- `git diff --check`
