### PR TITLE
fix(monorepo): set APP_HOST to tunnelsats and omit empty PROXY_AUTH_WHITELIST (fixes #143)

### DIFF
--- a/server/tests/test_management_manifest.py
+++ b/server/tests/test_management_manifest.py
@@ -34,10 +34,10 @@ def test_umbrel_compose_uses_authenticated_host_network_app_proxy():
     environment = environment_map(proxy)
 
     assert proxy["network_mode"] == "host"
-    assert environment["APP_HOST"] == "127.0.0.1"
+    assert environment["APP_HOST"] == "tunnelsats"
     assert int(environment["APP_PORT"]) == 9740
     assert environment["PROXY_AUTH_ADD"] == "true"
-    assert environment["PROXY_AUTH_WHITELIST"] == ""
+    assert "PROXY_AUTH_WHITELIST" not in environment
 
 
 def test_umbrel_backend_is_loopback_only_with_browser_security_enabled():

--- a/tunnelsats/docker-compose.yml
+++ b/tunnelsats/docker-compose.yml
@@ -7,10 +7,9 @@ services:
     # loopback-only Flask backend without exposing that backend to the LAN.
     network_mode: "host"
     environment:
-      APP_HOST: 127.0.0.1
+      APP_HOST: tunnelsats
       APP_PORT: "9740"
       PROXY_AUTH_ADD: "true"
-      PROXY_AUTH_WHITELIST: ""
 
   tunnelsats:
     # Use the specific version tag for production


### PR DESCRIPTION
Resolves official Umbrel App Store linter errors flagged on PR #4919.